### PR TITLE
Crée le fichier de schéma de données

### DIFF
--- a/schema-exemple-valide.json
+++ b/schema-exemple-valide.json
@@ -1,0 +1,3 @@
+{
+  "description": "TODO"
+}

--- a/schema.json
+++ b/schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/MTES-MCT/dialog/raw/main/schema.json",
+  "title": "Arrêtés de circulation",
+  "description": "Spécification du fichier d'échange relatif aux arrêtés de circulation",
+  "homepage": "https://github.com/MTES-MCT/dialog",
+  "countryCode": "FR",
+  "keywords": [
+    "TODO",
+    "arrêtés",
+    "circulation",
+    "fabnum"
+  ],
+  "licenses": ["TODO"],
+  "resources": [
+    {
+      "title": "Fichier valide (JSON)",
+      "name": "schema-exemple-valide.json",
+      "path": "https://github.com/MTES-MCT/dialog/raw/main/schema-exemple-valide.json"
+    }
+  ],
+  "sources": [
+    {
+      "title": "DATEX II - TrafficRegulation",
+      "path": "https://docs.datex2.eu/trafficregulation/index.html"
+    }
+  ],
+  "created": "2022-11-07",
+  "lastModified": "2022-11-07",
+  "version": "0.0.1",
+  "type": "object",
+  "allOf": [
+    {
+      "$ref": "_RegulationOrder"
+    }
+  ],
+  "definitions": {
+    "_RegulationOrder": {
+      "type": "object",
+      "required": [
+        "description",
+        "identifiant_pub",
+        "autorite",
+        "statut",
+        "localisation",
+        "reglementations"
+      ],
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "Description de l'arrêté de circulation",
+          "type": "string",
+          "examples": [
+            "Arrêté réglementant la circulation, l'arrêt et le stationnement des véhicules de distribution ou d'enlèvement de marchandises à Paris"
+          ]
+        },
+        "identifiant_pub": {
+          "title": "Identifiant public",
+          "description": "Identifiant de l'arrêté tel qu'il a été publié",
+          "type": "string",
+          "examples": [
+            "2020P19283"
+          ]
+        },
+        "autorite": {
+          "type": "string",
+          "title": "Autorité",
+          "description": "Autorité dont émange l'arrêté de circulation",
+          "examples": [
+            "Préfet de la Ville de Paris"
+          ]
+        },
+        "statut": {
+          "type": "string",
+          "title": "Statut",
+          "description": "Statut d'application de l'arrêté",
+          "enum": [
+            "cree_et_implemente",
+            "cree_et_partiellement_implemente",
+            "cree_mais_pas_encore_implemente",
+            "partiellement_abroge",
+            "prevu",
+            "abroge"
+          ],
+          "examples": [
+            "cree_et_implemente"
+          ]
+        },
+        "localisation_globale": {
+          "type": "string",
+          "title": "Localisation globale",
+          "description": "Localisation globale de la zone affectée par l'arrêté, au format ???"
+        },
+        "reglementations": {
+          "type": "array",
+          "title": "Réglementations",
+          "description": "Liste des réglementations de circulation prévues par l'arrêté",
+          "minItems": 0,
+          "items": {
+            "allOf": [
+              {
+                "$ref": "_TrafficRegulation"
+              }
+            ]
+          }
+        }
+      }
+    },
+    "_TrafficRegulation": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "circulation_interdite",
+            "deviation"
+          ]
+        },
+        "condition": {
+          "properties": {
+            "negate": {
+              "type": "boolean"
+            },
+            "condition_vehicule": {
+              "allOf": [
+                {
+                  "$ref": "_VehicleCondition"
+                }
+              ]
+            },
+            "condition_localisation": {
+              "allOf": [
+                {
+                  "$ref": "_LocationCondition"
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "_VehicleCondition": {
+      "type": "object",
+      "allOf": [
+        {
+          "$ref": "_VehicleCharacteristics"
+        }
+      ]
+    },
+    "_LocationCondition": {
+      "type": "object",
+      "properties": {
+        "TODO": {}
+      }
+    },
+    "_VehicleCharacteristics": {
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "poids_lourd",
+            "etc"
+          ]
+        },
+        "ptac_max_tonnes": {
+          "type": "number",
+          "title": "PTAC max",
+          "description": "PTAC (Poids total autorisé en charge) maximum du véhicule, en tonnes",
+          "minimum": 0
+        },
+        "hauteur_max_m": {
+          "type": "number",
+          "title": "Hauteur max",
+          "description": "Hauteur maximum du véhicule, en mètres",
+          "minimum": 0
+        },
+        "longueur_max_m": {
+          "type": "number",
+          "title": "Longueur max",
+          "description": "Longueur maximum du véhicule, en mètres",
+          "minimum": 0
+        },
+        "largeur_max_m": {
+          "type": "number",
+          "title": "Largeur max",
+          "description": "Largeur maximum du véhicule, en mètres",
+          "minimum": 0
+        },
+        "affectation": {
+          "type": "string",
+          "title": "Affectation",
+          "description": "Affectation du véhicule",
+          "enum": [
+            "transport_marchandises",
+            "agricole",
+            "etc"
+          ]
+        },
+        "critair_max": {
+          "type": "integer",
+          "title": "Vignette Critair",
+          "description": "Vignette Critair au-delà de laquelle le véhicule est interdit",
+          "minimum": 0,
+          "maximum": 5
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
@mmarchois Cette PR est une "preuve de concept" qui a pour but de montrer comment je pense que l'on pourrait "encoder" dans le répo, sous un format lisible par des humains (certes formés techniquement) et par des machines, le schéma sur lequelle nous travaillons [ici](https://github.com/MTES-MCT/dialog/wiki/Mod%C3%A9lisation-DiaLog).

Cf les exemples ici : http://schema.data.gouv.fr/schemas.html?q=&statut=Adopt%C3%A9

Le pattern est :

* Un fichier `schema.json`, au format TableSchema ou JSONSchema (dans notre cas JSONSchema car nous aurons des données imbriquées, alors que TableSchema c'est pour des données tabulaires "plates")
* Un fichier d'exemple

Le franglais peut surprendre... Mais comme il s'agirait d'un schéma de l'Etat français, il faut à mon avis privilégier le français pour les parties "métier" (noms et description des champs, etc). En effet, d'une part cela doit rester lisible par quelqu'un de l'administration dont on ne peut supposer qu'il ou elle sache lire l'anglais, d'autre part la traduction des termes métier risque d'être hasardeuse (même si DATEX II nous déblaie le terrain).

Je me pose justement la question de comment relier ce schéma à DATEX II. Comment garder l'information de "tel(s) champ(s) correspondront à tel(s) autre(s) dans un fichier DATEX II" ? Ne faut-il pas utiliser DATEX II _directement_ (et oublier le précédent paragraphe au nom des standards européens) ? Soit on fournit aux GPS un contenu DATEX II, soit on leur fournit un format spécifique.

Enfin, il y a une clarification à opérer entre 1/ données métier collectées côté collectivités, 2/ données "techniquement stockées" dans l'outil qui naîtra (cf l'appellation "schéma de la BDD", qui contiendrait des trucs "internes" du genre users et organiastions), et 3/ les données machine à partager effectivement avec les GPS. Ce schéma concernerait plutôt 3/ (la preuve, je n'ai inclus que la table `RegulationOrder` et ses enfants dans notre schéma BDD).