### PR TITLE
Add DATEX II XSD files and example payload

### DIFF
--- a/spec/datex2/DATEXII_3_Common.xsd
+++ b/spec/datex2/DATEXII_3_Common.xsd
@@ -1,0 +1,2394 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:com="http://datex2.eu/schema/3/common" version="3.3" targetNamespace="http://datex2.eu/schema/3/common" xmlns:comx="http://datex2.eu/schema/3/commonExtension" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="http://datex2.eu/schema/3/commonExtension" schemaLocation="DATEXII_3_CommonExtension.xsd" />
+  <xs:complexType name="_CalendarWeekWithinMonthEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:CalendarWeekWithinMonthEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_ComparisonOperatorEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:ComparisonOperatorEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_DangerousGoodsRegulationsEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:DangerousGoodsRegulationsEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_DayEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:DayEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_DayWeekMonthExtensionType">
+    <xs:sequence>
+      <xs:element name="dayWeekMonthExtended" type="comx:DayWeekMonthExtended" minOccurs="0" />
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="_EmissionClassificationEuroEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:EmissionClassificationEuroEnum">
+        <xs:attribute name="_extendedValue" type="com:_EmissionClassificationEuroEnumExtensionType" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="_EmissionClassificationEuroEnumExtensionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="euroUnknown" />
+      <xs:enumeration value="euroI" />
+      <xs:enumeration value="euroII" />
+      <xs:enumeration value="euroIII" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="_EmissionsExtensionType">
+    <xs:sequence>
+      <xs:element name="emissionsExtension" type="comx:EmissionsExtension" minOccurs="0" />
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="_ExtensionType">
+    <xs:sequence>
+      <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="_FuelTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:FuelTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_HazardousMaterialsExtensionType">
+    <xs:sequence>
+      <xs:element name="dangerousGoodsExtended" type="comx:DangerousGoodsExtended" minOccurs="0" />
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="_InstanceOfDayEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:InstanceOfDayEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_LoadTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:LoadTypeEnum">
+        <xs:attribute name="_extendedValue" type="com:_LoadTypeEnumExtensionType" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="_LoadTypeEnumExtensionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="dangerousGoods" />
+      <xs:enumeration value="passenger" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="_LowEmissionLevelEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:LowEmissionLevelEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_MonthOfYearEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:MonthOfYearEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_PeriodExtensionType">
+    <xs:sequence>
+      <xs:element name="periodExtended" type="comx:PeriodExtended" minOccurs="0" />
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="_PublicEventTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:PublicEventTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_SpecialDayTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:SpecialDayTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_ValidityStatusEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:ValidityStatusEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_VehicleCharacteristicsExtensionType">
+    <xs:sequence>
+      <xs:element name="vehicleCharacteristicsExtended" type="comx:VehicleCharacteristicsExtended" minOccurs="0" />
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="_VehicleEquipmentEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:VehicleEquipmentEnum">
+        <xs:attribute name="_extendedValue" type="com:_VehicleEquipmentEnumExtensionType" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="_VehicleEquipmentEnumExtensionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="dippedHeadlightsInUse" />
+      <xs:enumeration value="speedLimiterInUse" />
+      <xs:enumeration value="electronicTollEquipment" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="_VehicleTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:VehicleTypeEnum">
+        <xs:attribute name="_extendedValue" type="com:_VehicleTypeEnumExtensionType" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="_VehicleTypeEnumExtensionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="animalDrawnVehicles" />
+      <xs:enumeration value="electricVehicles" />
+      <xs:enumeration value="passengerCarWithTrailer" />
+      <xs:enumeration value="motorizedVehicles" />
+      <xs:enumeration value="goodsVehicles" />
+      <xs:enumeration value="nonMotorizedVehicles" />
+      <xs:enumeration value="handcarts" />
+      <xs:enumeration value="soloMotorcycle" />
+      <xs:enumeration value="motorizedVehiclesWithoutNumberPlate" />
+      <xs:enumeration value="motorQuadricycles" />
+      <xs:enumeration value="motorisedPersonalTransportDevices" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="_VehicleUsageEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:VehicleUsageEnum">
+        <xs:attribute name="_extendedValue" type="com:_VehicleUsageEnumExtensionType" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="_VehicleUsageEnumExtensionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="removals" />
+      <xs:enumeration value="circus" />
+      <xs:enumeration value="funFair" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="_WeatherRelatedRoadConditionTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:WeatherRelatedRoadConditionTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_WeightTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="com:WeightTypeEnum">
+        <xs:attribute name="_extendedValue" type="com:_WeightTypeEnumExtensionType" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="_WeightTypeEnumExtensionType">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="combinedMaximumPermitted" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AngleInDegrees">
+    <xs:annotation>
+      <xs:documentation>An integer number representing an angle in whole degrees between 0 and 359.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:NonNegativeInteger">
+      <xs:minInclusive value="0" />
+      <xs:maxInclusive value="359" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Boolean">
+    <xs:annotation>
+      <xs:documentation>Boolean has the value space required to support the mathematical concept of binary-valued logic: {true, false}. </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:boolean" />
+  </xs:simpleType>
+  <xs:complexType name="CalendarWeekWithinMonth">
+    <xs:annotation>
+      <xs:documentation>Specification of periods defined by relevant calendar weeks in a month, see ISO8601. Note: Calendar weeks start with Monday. First week is the week containing the first of the month.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="com:DayWeekMonth">
+        <xs:sequence>
+          <xs:element name="applicableCalenderWeekWithinMonth" type="com:_CalendarWeekWithinMonthEnum" minOccurs="1" maxOccurs="6">
+            <xs:annotation>
+              <xs:documentation>Calender week in month. See ISO8601.  "All weeks of the month" is expressed by not using the CalendarWeekOfMonth class. Note: Calendar weeks start with Monday. First week is the week containing the first of the month.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_calendarWeekWithinMonthExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="CalendarWeekWithinMonthEnum">
+    <xs:annotation>
+      <xs:documentation>Calendar week within month (see ISO8601).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="firstWeek">
+        <xs:annotation>
+          <xs:documentation>Calendar week containing the first of the month. Several days of the first week of the month may occur in the previous calendar month. By construction, the last week of a preceding month can also be the first week of a subsequent month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="secondWeek">
+        <xs:annotation>
+          <xs:documentation>Second week of the month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="thirdWeek">
+        <xs:annotation>
+          <xs:documentation>Third week of the month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fourthWeek">
+        <xs:annotation>
+          <xs:documentation>Fourth week of the month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fifthWeek">
+        <xs:annotation>
+          <xs:documentation>Fifth week of the month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sixthWeek">
+        <xs:annotation>
+          <xs:documentation>Sixth week of the month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lastWeek">
+        <xs:annotation>
+          <xs:documentation>Last calendar week within month, regardless of its actual number. The last calendar week is the week beginning with Monday and containing the last of the month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ComparisonOperatorEnum">
+    <xs:annotation>
+      <xs:documentation>Logical comparison operations.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="equalTo">
+        <xs:annotation>
+          <xs:documentation>Logical comparison operator of "equal to".</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="greaterThan">
+        <xs:annotation>
+          <xs:documentation>Logical comparison operator of "greater than".</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="greaterThanOrEqualTo">
+        <xs:annotation>
+          <xs:documentation>Logical comparison operator of "greater than or equal to".</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lessThan">
+        <xs:annotation>
+          <xs:documentation>Logical comparison operator of "less than".</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lessThanOrEqualTo">
+        <xs:annotation>
+          <xs:documentation>Logical comparison operator of "less than or equal to".</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CountryCode">
+    <xs:annotation>
+      <xs:documentation>EN ISO 3166-1 alpha-2 two-letter country code</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:String">
+      <xs:maxLength value="2" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="CubicMetres">
+    <xs:annotation>
+      <xs:documentation>A volumetric measure defined in cubic metres.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:Float" />
+  </xs:simpleType>
+  <xs:simpleType name="DangerousGoodsRegulationsEnum">
+    <xs:annotation>
+      <xs:documentation>Types of dangerous goods regulations.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="adr">
+        <xs:annotation>
+          <xs:documentation>European agreement on the international carriage of dangerous goods on road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="iataIcao">
+        <xs:annotation>
+          <xs:documentation>Regulations covering the international transportation of dangerous goods issued by the International Air Transport Association and the International Civil Aviation Organisation.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="imoImdg">
+        <xs:annotation>
+          <xs:documentation>Regulations regarding the transportation of dangerous goods on ocean-going vessels issued by the International Maritime Organisation.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="railroadDangerousGoodsBook">
+        <xs:annotation>
+          <xs:documentation>International regulations concerning the international carriage of dangerous goods by rail.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="Date">
+    <xs:annotation>
+      <xs:documentation>A combination of year, month and day integer-valued properties plus an optional timezone property. It represents an interval of exactly one day, beginning on the first moment of the day in the timezone, i.e. '00:00:00' up to but not including '24:00:00'.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:date" />
+  </xs:simpleType>
+  <xs:simpleType name="DateTime">
+    <xs:annotation>
+      <xs:documentation>A combination of integer-valued year, month, day, hour, minute properties, a decimal-valued second property and a time zone property from which it is possible to determine the local time, the equivalent UTC time and the time zone offset from UTC.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:dateTime" />
+  </xs:simpleType>
+  <xs:simpleType name="DayEnum">
+    <xs:annotation>
+      <xs:documentation>Days of the week.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="monday">
+        <xs:annotation>
+          <xs:documentation>Monday.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tuesday">
+        <xs:annotation>
+          <xs:documentation>Tuesday.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="wednesday">
+        <xs:annotation>
+          <xs:documentation>Wednesday.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="thursday">
+        <xs:annotation>
+          <xs:documentation>Thursday.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="friday">
+        <xs:annotation>
+          <xs:documentation>Friday.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="saturday">
+        <xs:annotation>
+          <xs:documentation>Saturday.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sunday">
+        <xs:annotation>
+          <xs:documentation>Sunday.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DayWeekMonth">
+    <xs:annotation>
+      <xs:documentation>Specification of periods defined by the intersection of days or instances of them, calendar weeks and months.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="applicableDay" type="com:_DayEnum" minOccurs="0" maxOccurs="7">
+        <xs:annotation>
+          <xs:documentation>Applicable day of the week. "All days of the week" is expressed by non-inclusion of this attribute.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="applicableMonth" type="com:_MonthOfYearEnum" minOccurs="0" maxOccurs="12">
+        <xs:annotation>
+          <xs:documentation>Applicable month of the year.  "All months of the year" is expressed by non-inclusion of this attribute.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_dayWeekMonthExtension" type="com:_DayWeekMonthExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Decimal">
+    <xs:annotation>
+      <xs:documentation>A decimal number whose value space is the set of numbers that can be obtained by multiplying an integer by a non-positive power of ten, i.e., expressible as i × 10^-n where i and n are integers and n &gt;= 0.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:decimal" />
+  </xs:simpleType>
+  <xs:simpleType name="EmissionClassificationEuroEnum">
+    <xs:annotation>
+      <xs:documentation>Classification of emission according to the Euro emission classification (based on serveral amendments on 1970 Directive 70/220/EEC). Note htat vehicleType as well as fuelType are mandatory to provide to make this classification explicit.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="euro5">
+        <xs:annotation>
+          <xs:documentation>Euro 5.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="euro5a">
+        <xs:annotation>
+          <xs:documentation>Euro 5a.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="euro5b">
+        <xs:annotation>
+          <xs:documentation>Euro 5b.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="euro6">
+        <xs:annotation>
+          <xs:documentation>Euro 6.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="euro6a">
+        <xs:annotation>
+          <xs:documentation>Euro 6a.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="euro6b">
+        <xs:annotation>
+          <xs:documentation>Euro 6b.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="euro6c">
+        <xs:annotation>
+          <xs:documentation>Euro 6c.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="euroV">
+        <xs:annotation>
+          <xs:documentation>Euro V.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="euroVI">
+        <xs:annotation>
+          <xs:documentation>Euro VI.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Any other level.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Emissions">
+    <xs:annotation>
+      <xs:documentation>Emission characteristics of vehicles.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="emissionClassificationEuro" type="com:_EmissionClassificationEuroEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The minimum Euro emission classification the vehicle(s) have to comply with according to the 1970 Directive 70/220/EEC and its several amendments. Note that vehicleType and fuelType need to be provided in order to make this classification explicit.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="emissionClassificationOther" type="com:String" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Some other (probably locally defined) value(s) for emission classification.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="emissionLevel" type="com:_LowEmissionLevelEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The low emission level of a vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_emissionsExtension" type="com:_EmissionsExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Float">
+    <xs:annotation>
+      <xs:documentation>A floating point number whose value space consists of the values m × 2^e, where m is an integer whose absolute value is less than 2^24, and e is an integer between -149 and 104, inclusive.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:float" />
+  </xs:simpleType>
+  <xs:simpleType name="FuelTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Type of fuel used by a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="all">
+        <xs:annotation>
+          <xs:documentation>All sort of fuel is accepted.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="battery">
+        <xs:annotation>
+          <xs:documentation>Battery.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="biodiesel">
+        <xs:annotation>
+          <xs:documentation>Biodiesel.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="diesel">
+        <xs:annotation>
+          <xs:documentation>Fuel used for compression-ignition (CI) engines.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="dieselBatteryHybrid">
+        <xs:annotation>
+          <xs:documentation>Diesel and battery hybrid.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ethanol">
+        <xs:annotation>
+          <xs:documentation>Ethanol.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="hydrogen">
+        <xs:annotation>
+          <xs:documentation>Hydrogen.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="liquidGas">
+        <xs:annotation>
+          <xs:documentation>Liquid gas of any type including LPG.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lpg">
+        <xs:annotation>
+          <xs:documentation>Liquid petroleum gas.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="methane">
+        <xs:annotation>
+          <xs:documentation>Methane gas.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="petrol">
+        <xs:annotation>
+          <xs:documentation>Fuel used for positive-ignition (PI) engines.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="petrol95Octane">
+        <xs:annotation>
+          <xs:documentation>Petrol with 95 octane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="petrol98Octane">
+        <xs:annotation>
+          <xs:documentation>Petrol with 98 octane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="petrolBatteryHybrid">
+        <xs:annotation>
+          <xs:documentation>Petrol and battery hybrid.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="petrolLeaded">
+        <xs:annotation>
+          <xs:documentation>Leaded petrol.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="petrolUnleaded">
+        <xs:annotation>
+          <xs:documentation>Unleaded petrol.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unknown">
+        <xs:annotation>
+          <xs:documentation>The sort of fuel is not known.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="GrossWeightCharacteristic">
+    <xs:annotation>
+      <xs:documentation>Gross weight characteristic of a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="comparisonOperator" type="com:_ComparisonOperatorEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The operator to be used in the vehicle characteristic comparison operation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="grossVehicleWeight" type="com:Tonnes" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The gross weight of the vehicle and its load, including any trailers.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="typeOfWeight" type="com:_WeightTypeEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The meaning of the weight value</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_grossWeightCharacteristicExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="HazardousMaterials">
+    <xs:annotation>
+      <xs:documentation>Details of hazardous materials.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="chemicalName" type="com:MultilingualString" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The chemical name of the hazardous substance carried by the vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="dangerousGoodsFlashPoint" type="com:TemperatureCelsius" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The temperature at which the vapour from a hazardous substance will ignite in air.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="dangerousGoodsRegulations" type="com:_DangerousGoodsRegulationsEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The code defining the regulations, international or national, applicable for a means of transport.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="hazardCodeIdentification" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The dangerous goods description code.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="hazardCodeVersionNumber" type="com:NonNegativeInteger" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The version/revision number of date of issuance of the hazardous material code used.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="hazardSubstanceItemPageNumber" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A number giving additional hazard code classification of a goods item within the applicable dangerous goods regulation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="tremCardNumber" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The identification of a transport emergency card giving advice for emergency actions.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="undgNumber" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A unique serial number assigned within the United Nations to substances and articles contained in a list of the dangerous goods most commonly carried.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="volumeOfDangerousGoods" type="com:CubicMetres" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The volume of dangerous goods on the vehicle(s) reported in a traffic/travel situation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="weightOfDangerousGoods" type="com:Tonnes" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The weight of dangerous goods on the vehicle(s) reported in a traffic/travel situation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_hazardousMaterialsExtension" type="com:_HazardousMaterialsExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="HeaviestAxleWeightCharacteristic">
+    <xs:annotation>
+      <xs:documentation>Weight characteristic of the heaviest axle on the vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="comparisonOperator" type="com:_ComparisonOperatorEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The operator to be used in the vehicle characteristic comparison operation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="heaviestAxleWeight" type="com:Tonnes" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The weight of the heaviest axle on the vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_heaviestAxleWeightCharacteristicExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="HeightCharacteristic">
+    <xs:annotation>
+      <xs:documentation>Height characteristic of a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="comparisonOperator" type="com:_ComparisonOperatorEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The operator to be used in the vehicle characteristic comparison operation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="vehicleHeight" type="com:MetresAsFloat" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The height of the highest part, excluding antennae, of an individual vehicle above the road surface, in metres.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_heightCharacteristicExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="InstanceOfDayEnum">
+    <xs:annotation>
+      <xs:documentation>Instances of a day of the week in a month</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="firstInstance">
+        <xs:annotation>
+          <xs:documentation>First instance of specified day of week in month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="secondInstance">
+        <xs:annotation>
+          <xs:documentation>Second instance of specified day of week in month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="thirdInstance">
+        <xs:annotation>
+          <xs:documentation>Third instance of specified day of week in month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fourthInstance">
+        <xs:annotation>
+          <xs:documentation>Fourth instance of specified day of week in month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fifthInstance">
+        <xs:annotation>
+          <xs:documentation>Fifth instance of specified day of week in month.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lastInstance">
+        <xs:annotation>
+          <xs:documentation>Last instance of specified day of week in month (regardless its actual instance number).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="InstanceOfDayWithinMonth">
+    <xs:annotation>
+      <xs:documentation>Specification of periods defined by the instance of a specific weekday within a month (e.g. 3rd Tuesday in May)</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="com:DayWeekMonth">
+        <xs:sequence>
+          <xs:element name="applicableInstanceOfDayWithinMonth" type="com:_InstanceOfDayEnum" minOccurs="1" maxOccurs="5">
+            <xs:annotation>
+              <xs:documentation>The specified integer instance of the specified applicable day within a month.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_instanceOfDayWithinMonthExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="Integer">
+    <xs:annotation>
+      <xs:documentation>An integer number whose value space is the set {-2147483648, -2147483647, -2147483646, ..., -2, -1, 0, 1, 2, ..., 2147483645, 2147483646, 2147483647}.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:integer" />
+  </xs:simpleType>
+  <xs:complexType name="InternationalIdentifier">
+    <xs:annotation>
+      <xs:documentation>An identifier/name whose range is specific to the particular country.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="country" type="com:CountryCode" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>EN ISO 3166-1 two-character country code.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="nationalIdentifier" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Identifier or name unique within the specified country.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_internationalIdentifierExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Language">
+    <xs:annotation>
+      <xs:documentation>A language datatype, identifies a specified language by an ISO 639-1 2-alpha code.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:language" />
+  </xs:simpleType>
+  <xs:complexType name="LengthCharacteristic">
+    <xs:annotation>
+      <xs:documentation>Length characteristic of a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="comparisonOperator" type="com:_ComparisonOperatorEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The operator to be used in the vehicle characteristic comparison operation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="vehicleLength" type="com:MetresAsFloat" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The overall distance between the front and back of an individual vehicle, including the length of any trailers, couplings, embedded features etc.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_lengthCharacteristicExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="LoadTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of load carried by a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="abnormalLoad">
+        <xs:annotation>
+          <xs:documentation>A load that exceeds normal vehicle dimensions in terms of height, length, width, gross vehicle weight or axle weight or any combination of these. Generally termed an "abnormal load".</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ammunition">
+        <xs:annotation>
+          <xs:documentation>Ammunition.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="chemicals">
+        <xs:annotation>
+          <xs:documentation>Chemicals of unspecified type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="combustibleMaterials">
+        <xs:annotation>
+          <xs:documentation>Combustible materials of unspecified type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="corrosiveMaterials">
+        <xs:annotation>
+          <xs:documentation>Corrosive materials of unspecified type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="debris">
+        <xs:annotation>
+          <xs:documentation>Debris of unspecified type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="empty">
+        <xs:annotation>
+          <xs:documentation>No load.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="explosiveMaterials">
+        <xs:annotation>
+          <xs:documentation>Explosive materials of unspecified type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="extraHighLoad">
+        <xs:annotation>
+          <xs:documentation>A load of exceptional height.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="extraLongLoad">
+        <xs:annotation>
+          <xs:documentation>A load of exceptional length.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="extraWideLoad">
+        <xs:annotation>
+          <xs:documentation>A load of exceptional width.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fuel">
+        <xs:annotation>
+          <xs:documentation>Fuel of unspecified type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="glass">
+        <xs:annotation>
+          <xs:documentation>Glass.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="goods">
+        <xs:annotation>
+          <xs:documentation>Any goods of a commercial nature.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="hazardousMaterials">
+        <xs:annotation>
+          <xs:documentation>Materials classed as being of a hazardous nature.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="liquid">
+        <xs:annotation>
+          <xs:documentation>Liquid of an unspecified nature.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="livestock">
+        <xs:annotation>
+          <xs:documentation>Livestock.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="materials">
+        <xs:annotation>
+          <xs:documentation>General materials of unspecified type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="materialsDangerousForPeople">
+        <xs:annotation>
+          <xs:documentation>Materials classed as being of a danger to people or animals.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="materialsDangerousForTheEnvironment">
+        <xs:annotation>
+          <xs:documentation>Materials classed as being potentially dangerous to the environment.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="materialsDangerousForWater">
+        <xs:annotation>
+          <xs:documentation>Materials classed as being dangerous when exposed to water (e.g. materials which may react exothermically with water).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="oil">
+        <xs:annotation>
+          <xs:documentation>Oil.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ordinary">
+        <xs:annotation>
+          <xs:documentation>Materials that present limited environmental or health risk. Non-combustible, non-toxic, non-corrosive.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="perishableProducts">
+        <xs:annotation>
+          <xs:documentation>Products or produce that will significantly degrade in quality or freshness over a short period of time.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="petrol">
+        <xs:annotation>
+          <xs:documentation>Petrol or petroleum.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="pharmaceuticalMaterials">
+        <xs:annotation>
+          <xs:documentation>Pharmaceutical materials.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="radioactiveMaterials">
+        <xs:annotation>
+          <xs:documentation>Materials that emit significant quantities of electro-magnetic radiation that may present a risk to people, animals or the environment.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="refrigeratedGoods">
+        <xs:annotation>
+          <xs:documentation>Refrigerated goods.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="refuse">
+        <xs:annotation>
+          <xs:documentation>Refuse.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="toxicMaterials">
+        <xs:annotation>
+          <xs:documentation>Materials of a toxic nature which may damage the environment or endanger public health.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="vehicles">
+        <xs:annotation>
+          <xs:documentation>Vehicles of any type which are being transported.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other than as defined in this enumeration.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LongString">
+    <xs:annotation>
+      <xs:documentation>A character string with no specified length limit, whose value space is the set of finite-length sequences of characters. Every character has a corresponding Universal Character Set code point (as defined in ISO/IEC 10646), which is an integer.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string" />
+  </xs:simpleType>
+  <xs:simpleType name="LowEmissionLevelEnum">
+    <xs:annotation>
+      <xs:documentation>The emission level of a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="lowLevelEmission">
+        <xs:annotation>
+          <xs:documentation>Vehicles with low level emission.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="freeOfEmission">
+        <xs:annotation>
+          <xs:documentation>Only vehicles that do not produce emissions (e.g. electric driven). Hybrid driven cars are allowed, when they switch to emission free mode within the considered situation.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="MetresAsFloat">
+    <xs:annotation>
+      <xs:documentation>A measure of distance defined in metres in a floating point format.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:Float" />
+  </xs:simpleType>
+  <xs:simpleType name="MetresAsNonNegativeInteger">
+    <xs:annotation>
+      <xs:documentation>A measure of distance defined in metres in a non negative integer format.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:NonNegativeInteger" />
+  </xs:simpleType>
+  <xs:simpleType name="MonthOfYearEnum">
+    <xs:annotation>
+      <xs:documentation>A list of the months of the year.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="january">
+        <xs:annotation>
+          <xs:documentation>The month of January.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="february">
+        <xs:annotation>
+          <xs:documentation>The month of February.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="march">
+        <xs:annotation>
+          <xs:documentation>The month of March.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="april">
+        <xs:annotation>
+          <xs:documentation>The month of April.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="may">
+        <xs:annotation>
+          <xs:documentation>The month of May.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="june">
+        <xs:annotation>
+          <xs:documentation>The month of June.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="july">
+        <xs:annotation>
+          <xs:documentation>The month of July.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="august">
+        <xs:annotation>
+          <xs:documentation>The month of August.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="september">
+        <xs:annotation>
+          <xs:documentation>The month of September.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="october">
+        <xs:annotation>
+          <xs:documentation>The month of October.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="november">
+        <xs:annotation>
+          <xs:documentation>The month of November.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="december">
+        <xs:annotation>
+          <xs:documentation>The month of December.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="MultilingualString">
+    <xs:sequence>
+      <xs:element name="values">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="value" type="com:MultilingualStringValue" maxOccurs="unbounded" />
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="MultilingualStringValue">
+    <xs:simpleContent>
+      <xs:extension base="com:MultilingualStringValueType">
+        <xs:attribute name="lang" type="xs:language" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="MultilingualStringValueType">
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="1024" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="NamedArea" abstract="true">
+    <xs:annotation>
+      <xs:documentation>An abstract hook class to hook in a model for a named area.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="_namedAreaExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="NonNegativeInteger">
+    <xs:annotation>
+      <xs:documentation>An integer number whose value space is the set {0, 1, 2, ..., 2147483645, 2147483646, 2147483647}.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:nonNegativeInteger" />
+  </xs:simpleType>
+  <xs:complexType name="NumberOfAxlesCharacteristic">
+    <xs:annotation>
+      <xs:documentation>Number of axles characteristic of a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="comparisonOperator" type="com:_ComparisonOperatorEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The operator to be used in the vehicle characteristic comparison operation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="numberOfAxles" type="com:NonNegativeInteger" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The total number of axles of an individual vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_numberOfAxlesCharacteristicExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OverallPeriod">
+    <xs:annotation>
+      <xs:documentation>A continuous or discontinuous period of validity defined by overall bounding start and end times and the possible intersection of valid periods (potentially recurring) with the complement of exception periods (also potentially recurring).</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="overallStartTime" type="com:DateTime" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Start of bounding period of validity defined by date and time.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="overallEndTime" type="com:DateTime" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>End of bounding period of validity defined by date and time.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validPeriod" type="com:Period" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>A single time period, a recurring time period or a set of different recurring time periods during which validity is true.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="exceptionPeriod" type="com:Period" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>A single time period, a recurring time period or a set of different recurring time periods during which validity is false.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_overallPeriodExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PayloadPublication" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A payload publication of traffic related information or associated management information created at a specific point in time that can be exchanged via a DATEX II interface.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="publicationTime" type="com:DateTime" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Date/time at which the payload publication was created.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="publicationCreator" type="com:InternationalIdentifier" />
+      <xs:element name="_payloadPublicationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="lang" type="com:Language" use="required">
+      <xs:annotation>
+        <xs:documentation>The default language used throughout the payload publication.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="modelBaseVersion" type="xs:string" use="required" fixed="3" />
+    <xs:attribute name="extensionName" type="xs:string" use="optional" />
+    <xs:attribute name="extensionVersion" type="xs:string" use="optional" />
+    <xs:attribute name="profileName" type="xs:string" use="optional" />
+    <xs:attribute name="profileVersion" type="xs:string" use="optional" />
+  </xs:complexType>
+  <xs:simpleType name="Percentage">
+    <xs:annotation>
+      <xs:documentation>A measure of percentage.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:Float" />
+  </xs:simpleType>
+  <xs:complexType name="Period">
+    <xs:annotation>
+      <xs:documentation>A continuous time period or a set of discontinuous time periods defined by the intersection of a set of criteria all within an overall delimiting interval.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="startOfPeriod" type="com:DateTime" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Start of period.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="endOfPeriod" type="com:DateTime" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>End of a period.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="periodName" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The name of the period.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="recurringTimePeriodOfDay" type="com:TimePeriodOfDay" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>A recurring period of a day.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="recurringDayWeekMonthPeriod" type="com:DayWeekMonth" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>A recurring period defined in terms of days of the week, weeks of the month and months of the year. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="recurringSpecialDay" type="com:SpecialDay" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>A recurring period in terms of special days.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_periodExtension" type="com:_PeriodExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="PublicEventTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of public events.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="agriculturalShow">
+        <xs:annotation>
+          <xs:documentation>Agricultural show or event which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="airShow">
+        <xs:annotation>
+          <xs:documentation>Air show or other aeronautical event which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="artEvent">
+        <xs:annotation>
+          <xs:documentation>Art event</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="athleticsMeeting">
+        <xs:annotation>
+          <xs:documentation>Athletics event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="commercialEvent">
+        <xs:annotation>
+          <xs:documentation>Commercial event which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="culturalEvent">
+        <xs:annotation>
+          <xs:documentation>Cultural event which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ballGame">
+        <xs:annotation>
+          <xs:documentation>Ball game event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="baseballGame">
+        <xs:annotation>
+          <xs:documentation>Baseball game event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="basketballGame">
+        <xs:annotation>
+          <xs:documentation>Basketball game event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="beerFestival">
+        <xs:annotation>
+          <xs:documentation>Beer festival</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="bicycleRace">
+        <xs:annotation>
+          <xs:documentation>Bicycle race that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="boatRace">
+        <xs:annotation>
+          <xs:documentation>Regatta (boat race event of sailing, powerboat or rowing) that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="boatShow">
+        <xs:annotation>
+          <xs:documentation>Boat show which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="boxingTournament">
+        <xs:annotation>
+          <xs:documentation>Boxing event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="bullFight">
+        <xs:annotation>
+          <xs:documentation>Bull fighting event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ceremonialEvent">
+        <xs:annotation>
+          <xs:documentation>Formal or religious act, rite or ceremony that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="concert">
+        <xs:annotation>
+          <xs:documentation>Concert event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="cricketMatch">
+        <xs:annotation>
+          <xs:documentation>Cricket match that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="exhibition">
+        <xs:annotation>
+          <xs:documentation>Major display or trade show which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fair">
+        <xs:annotation>
+          <xs:documentation>Periodic (e.g. annual), often traditional, gathering for entertainment or trade promotion, which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="festival">
+        <xs:annotation>
+          <xs:documentation>Celebratory event or series of events which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="filmFestival">
+        <xs:annotation>
+          <xs:documentation>Film festival</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="filmTVMaking">
+        <xs:annotation>
+          <xs:documentation>Film or TV making event which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fireworkDisplay">
+        <xs:annotation>
+          <xs:documentation>Firework display</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="flowerEvent">
+        <xs:annotation>
+          <xs:documentation>Flower event</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="foodFestival">
+        <xs:annotation>
+          <xs:documentation>Food festival</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="footballMatch">
+        <xs:annotation>
+          <xs:documentation>Football match that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="funfair">
+        <xs:annotation>
+          <xs:documentation>Periodic (e.g. annual), often traditional, gathering for entertainment, which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="gardeningOrFlowerShow">
+        <xs:annotation>
+          <xs:documentation>Gardening and/or flower show or event which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="golfTournament">
+        <xs:annotation>
+          <xs:documentation>Golf tournament event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="hockeyGame">
+        <xs:annotation>
+          <xs:documentation>Hockey game event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="horseRaceMeeting">
+        <xs:annotation>
+          <xs:documentation>Horse race meeting that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="internationalSportsMeeting">
+        <xs:annotation>
+          <xs:documentation>Large sporting event of an international nature that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="majorEvent">
+        <xs:annotation>
+          <xs:documentation>Significant organised event either on or near the roadway which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="marathon">
+        <xs:annotation>
+          <xs:documentation>Marathon, cross-country or road running event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="market">
+        <xs:annotation>
+          <xs:documentation>Periodic (e.g. weekly) gathering for buying and selling, which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="match">
+        <xs:annotation>
+          <xs:documentation>Sports match of unspecified type that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="motorShow">
+        <xs:annotation>
+          <xs:documentation>Motor show which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="motorSportRaceMeeting">
+        <xs:annotation>
+          <xs:documentation>Motor sport race meeting that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="openAirConcert">
+        <xs:annotation>
+          <xs:documentation>Open air concert</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="parade">
+        <xs:annotation>
+          <xs:documentation>Formal display or organised procession which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="procession">
+        <xs:annotation>
+          <xs:documentation>An organised procession which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="raceMeeting">
+        <xs:annotation>
+          <xs:documentation>Race meeting (other than horse or motor sport) that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="rugbyMatch">
+        <xs:annotation>
+          <xs:documentation>Rugby match that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="severalMajorEvents">
+        <xs:annotation>
+          <xs:documentation>A series of significant organised events either on or near the roadway which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="show">
+        <xs:annotation>
+          <xs:documentation>Entertainment event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="showJumping">
+        <xs:annotation>
+          <xs:documentation>Horse showing jumping and tournament event that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="soundAndLightShow">
+        <xs:annotation>
+          <xs:documentation>Sound and light show.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sportsMeeting">
+        <xs:annotation>
+          <xs:documentation>Sports event of unspecified type that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="stateOccasion">
+        <xs:annotation>
+          <xs:documentation>Public ceremony or visit of national or international significance which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="streetFestival">
+        <xs:annotation>
+          <xs:documentation>Street festival</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tennisTournament">
+        <xs:annotation>
+          <xs:documentation>Tennis tournament that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="theatricalEvent">
+        <xs:annotation>
+          <xs:documentation>Theatrical event</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tournament">
+        <xs:annotation>
+          <xs:documentation>Sporting event or series of events of unspecified type lasting more than one day which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tradeFair">
+        <xs:annotation>
+          <xs:documentation>A periodic (e.g. annual), often traditional, gathering for trade promotion, which could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="waterSportsMeeting">
+        <xs:annotation>
+          <xs:documentation>Water sports meeting that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="wineFestival">
+        <xs:annotation>
+          <xs:documentation>Wine festival</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="winterSportsMeeting">
+        <xs:annotation>
+          <xs:documentation>Winter sports meeting or event (e.g. skiing, ski jumping, skating) that could disrupt traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unknown">
+        <xs:annotation>
+          <xs:documentation>Service provider does not know at time of message generation.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other than as defined in this enumeration.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="PublicHoliday">
+    <xs:annotation>
+      <xs:documentation>Specification of a specific public holiday in case specialDayType is set to 'publicHoliday'.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="com:SpecialDay">
+        <xs:sequence>
+          <xs:element name="publicHolidayName" type="com:MultilingualString" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Specification of a specific public holiday by its name.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_publicHolidayExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Reference">
+    <xs:attribute name="id" type="xs:string" use="required" />
+  </xs:complexType>
+  <xs:complexType name="SpecialDay">
+    <xs:annotation>
+      <xs:documentation>Specification of a special type of day, possibly also a public holiday. Can be country or region specific.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="intersectWithApplicableDays" type="com:Boolean" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>When true, the period is the intersection of applicable days and this special day. When false, the period is the union of applicable days and this special day.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="specialDayType" type="com:_SpecialDayTypeEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Specification of a special day, for example schoolDay, publicHoliday, ...</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="publicEvent" type="com:_PublicEventTypeEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Type of public event on this special day.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="namedArea" type="com:NamedArea" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="_specialDayExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="SpecialDayTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Collection of special types of days.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="dayBeforePublicHoliday">
+        <xs:annotation>
+          <xs:documentation>The day preceding a public holiday.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="publicHoliday">
+        <xs:annotation>
+          <xs:documentation>A public holiday in general. You may use the PublicHoliday class to refer on a specific public holiday.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="dayFollowingPublicHoliday">
+        <xs:annotation>
+          <xs:documentation>A day following a public holiday.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="longWeekendDay">
+        <xs:annotation>
+          <xs:documentation>A day between a public holiday and the weekend.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inLieuOfPublicHoliday">
+        <xs:annotation>
+          <xs:documentation>A holiday in lieu of a public holiday that falls on a weekend.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="schoolDay">
+        <xs:annotation>
+          <xs:documentation>A school day.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="schoolHolidays">
+        <xs:annotation>
+          <xs:documentation>A day within the school holidays.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="publicEventDay">
+        <xs:annotation>
+          <xs:documentation>A day of a public event. You may use the publicEvent attribute to specify the corresponding event.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Some other special day.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="String">
+    <xs:annotation>
+      <xs:documentation>A character string whose value space is the set of finite-length sequences of characters. Every character has a corresponding Universal Character Set code point (as defined in ISO/IEC 10646), which is an integer.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:maxLength value="1024" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TemperatureCelsius">
+    <xs:annotation>
+      <xs:documentation>A measure of temperature defined in degrees Celsius.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:Float" />
+  </xs:simpleType>
+  <xs:simpleType name="Time">
+    <xs:annotation>
+      <xs:documentation>An instant of time that recurs every day. The value space of time is the space of time of day values as defined in § 5.3 of [ISO 8601]. Specifically, it is a set of zero-duration daily time instances.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:time" />
+  </xs:simpleType>
+  <xs:complexType name="TimePeriodOfDay">
+    <xs:annotation>
+      <xs:documentation>Specification of a continuous period of time within a 24 hour period.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="startTimeOfPeriod" type="com:Time" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Start of time period.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="endTimeOfPeriod" type="com:Time" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>End of time period.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_timePeriodOfDayExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Tonnes">
+    <xs:annotation>
+      <xs:documentation>A measure of weight defined in metric tonnes.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:Float" />
+  </xs:simpleType>
+  <xs:simpleType name="Url">
+    <xs:annotation>
+      <xs:documentation>A Uniform Resource Locator (URL) address comprising a compact string of characters for a resource available on the Internet.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:anyURI" />
+  </xs:simpleType>
+  <xs:complexType name="Validity">
+    <xs:annotation>
+      <xs:documentation>Specification of validity, either explicitly or by a validity time period specification which may be discontinuous.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="validityStatus" type="com:_ValidityStatusEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Specification of validity, either explicitly overriding the validity time specification or confirming it.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="overrunning" type="com:Boolean" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The activity or action described by the SituationRecord is still in progress, overrunning its planned duration as indicated in a previous version of this record or even in current version.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validityTimeSpecification" type="com:OverallPeriod">
+        <xs:annotation>
+          <xs:documentation>A specification of periods of validity defined by overall bounding start and end times and the possible intersection of valid periods with exception periods (exception periods overriding valid periods).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_validityExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="ValidityStatusEnum">
+    <xs:annotation>
+      <xs:documentation>Values of validity status that can be assigned to a described event, action or item.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="active">
+        <xs:annotation>
+          <xs:documentation>The described event, action or item is currently active regardless of the definition of the validity time specification.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="planned">
+        <xs:annotation>
+          <xs:documentation>The described event, action or item is currently planned regardless of the definition of the validity time specification.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="suspended">
+        <xs:annotation>
+          <xs:documentation>The described event, action or item is currently suspended, that is inactive, regardless of the definition of the validity time specification.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="definedByValidityTimeSpec">
+        <xs:annotation>
+          <xs:documentation>The validity status of the described event, action or item is in accordance with the definition of the validity time specification.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="VehicleCharacteristics">
+    <xs:annotation>
+      <xs:documentation>The characteristics of a vehicle, e.g. lorry of gross weight greater than 30 tonnes.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="fuelType" type="com:_FuelTypeEnum" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>The type of fuel used by the vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="loadType" type="com:_LoadTypeEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The type of load carried by the vehicle, especially in respect of hazardous loads.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="vehicleEquipment" type="com:_VehicleEquipmentEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The type of equipment in use or on board the vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="vehicleType" type="com:_VehicleTypeEnum" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Vehicle type.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="vehicleUsage" type="com:_VehicleUsageEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The type of usage of the vehicle (i.e. for what purpose is the vehicle being used).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="yearOfFirstRegistration" type="com:Year" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Year of first registration of the vehicle</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="grossWeightCharacteristic" type="com:GrossWeightCharacteristic" minOccurs="0" maxOccurs="2" />
+      <xs:element name="heightCharacteristic" type="com:HeightCharacteristic" minOccurs="0" maxOccurs="2" />
+      <xs:element name="lengthCharacteristic" type="com:LengthCharacteristic" minOccurs="0" maxOccurs="2" />
+      <xs:element name="widthCharacteristic" type="com:WidthCharacteristic" minOccurs="0" maxOccurs="2" />
+      <xs:element name="heaviestAxleWeightCharacteristic" type="com:HeaviestAxleWeightCharacteristic" minOccurs="0" maxOccurs="2" />
+      <xs:element name="numberOfAxlesCharacteristic" type="com:NumberOfAxlesCharacteristic" minOccurs="0" maxOccurs="2" />
+      <xs:element name="emissions" type="com:Emissions" minOccurs="0" />
+      <xs:element name="_vehicleCharacteristicsExtension" type="com:_VehicleCharacteristicsExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="VehicleEquipmentEnum">
+    <xs:annotation>
+      <xs:documentation>Types of vehicle equipment in use or on board.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="notUsingSnowChains">
+        <xs:annotation>
+          <xs:documentation>Vehicle not using snow chains.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="notUsingSnowChainsOrTyres">
+        <xs:annotation>
+          <xs:documentation>Vehicle not using either snow tyres or snow chains.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="snowChainsInUse">
+        <xs:annotation>
+          <xs:documentation>Vehicle using snow chains.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="snowTyresInUse">
+        <xs:annotation>
+          <xs:documentation>Vehicle using snow tyres.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="snowChainsOrTyresInUse">
+        <xs:annotation>
+          <xs:documentation>Vehicle using snow tyres or snow chains.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="withoutSnowTyresOrChainsOnBoard">
+        <xs:annotation>
+          <xs:documentation>Vehicle which is not carrying on board snow tyres or chains.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="VehicleTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="agriculturalVehicle">
+        <xs:annotation>
+          <xs:documentation>Vehicle normally used for agricultural purposes, e.g. tractor, combined harvester etc.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="anyVehicle">
+        <xs:annotation>
+          <xs:documentation>Vehicle of any type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="articulatedBus">
+        <xs:annotation>
+          <xs:documentation>Articulated bus</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="articulatedTrolleyBus">
+        <xs:annotation>
+          <xs:documentation>Articulated trolley bus</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="articulatedVehicle">
+        <xs:annotation>
+          <xs:documentation>Articulated vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="bicycle">
+        <xs:annotation>
+          <xs:documentation>Bicycle.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="bus">
+        <xs:annotation>
+          <xs:documentation>Bus.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="car">
+        <xs:annotation>
+          <xs:documentation>Vehicles designed and constructed for the carriage of passengers and comprising no more than eight seats in addition to the driver’s seat, and having a maximum mass (“technically permissible maximum laden mass”) not exceeding 3.5 tons (M1).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="caravan">
+        <xs:annotation>
+          <xs:documentation>Caravan.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="carOrLightVehicle">
+        <xs:annotation>
+          <xs:documentation>Car or light vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="carWithCaravan">
+        <xs:annotation>
+          <xs:documentation>Car towing a caravan.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="carWithTrailer">
+        <xs:annotation>
+          <xs:documentation>Car towing a trailer.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="constructionOrMaintenanceVehicle">
+        <xs:annotation>
+          <xs:documentation>Vehicle normally used for construction or maintenance purposes, e.g. digger, excavator, bulldozer, lorry mounted crane etc.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fourWheelDrive">
+        <xs:annotation>
+          <xs:documentation>Four wheel drive vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="heavyGoodsVehicle">
+        <xs:annotation>
+          <xs:documentation>Vehicles with a total weight above 3,500 kg (vehicle and load).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="heavyGoodsVehicleWithTrailer">
+        <xs:annotation>
+          <xs:documentation>Heavy goods vehicle with trailer</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="heavyDutyTransporter">
+        <xs:annotation>
+          <xs:documentation>A transporter for heavy duty (usually with abnormal dimensions).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="heavyVehicle">
+        <xs:annotation>
+          <xs:documentation>Vehicle whose weight means it should be classed as a heavy vehicle</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="highSidedVehicle">
+        <xs:annotation>
+          <xs:documentation>High sided vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lightCommercialVehicle">
+        <xs:annotation>
+          <xs:documentation>Vehicles for the carriage of goods and having a maximum mass not exceeding 3.5 tonnes (class N1).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="largeCar">
+        <xs:annotation>
+          <xs:documentation>Large car</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="largeGoodsVehicle">
+        <xs:annotation>
+          <xs:documentation>Vehicles for the carriage of goods and having a maximum mass exceeding 3.5 tonnes (belonging to class N2 when not exceeding 12 tonnes, otherwise class N3).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lightCommercialVehicleWithTrailer">
+        <xs:annotation>
+          <xs:documentation>Light goods vehicle with trailer</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="longHeavyLorry">
+        <xs:annotation>
+          <xs:documentation>A heavy lorry that is longer than normal.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lorry">
+        <xs:annotation>
+          <xs:documentation>Lorry of any type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="metro">
+        <xs:annotation>
+          <xs:documentation>Metro</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="minibus">
+        <xs:annotation>
+          <xs:documentation>Vehicles designed and constructed for the carriage of passengers, comprising more than eight seats in addition to the driver’s seat, and having a maximum mass not exceeding 5 tonnes (class M2).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="moped">
+        <xs:annotation>
+          <xs:documentation>Moped (a two wheeled motor vehicle characterized by a small engine typically less than 50cc and by normally having pedals).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="motorcycle">
+        <xs:annotation>
+          <xs:documentation>Motorcycle.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="motorcycleWithSideCar">
+        <xs:annotation>
+          <xs:documentation>Three wheeled vehicle comprising a motorcycle with an attached side car.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="motorhome">
+        <xs:annotation>
+          <xs:documentation>Motorhome</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="motorscooter">
+        <xs:annotation>
+          <xs:documentation>Motorscooter (a two wheeled motor vehicle characterized by a step-through frame and small diameter wheels).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="passengerCar">
+        <xs:annotation>
+          <xs:documentation>Passenger car</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="smallCar">
+        <xs:annotation>
+          <xs:documentation>Small car</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tanker">
+        <xs:annotation>
+          <xs:documentation>Vehicle with large tank for carrying bulk liquids.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="threeWheeledVehicle">
+        <xs:annotation>
+          <xs:documentation>Three wheeled vehicle of unspecified type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="trailer">
+        <xs:annotation>
+          <xs:documentation>Trailer.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tram">
+        <xs:annotation>
+          <xs:documentation>Tram.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="trolleyBus">
+        <xs:annotation>
+          <xs:documentation>Trolley bus</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="twoWheeledVehicle">
+        <xs:annotation>
+          <xs:documentation>Two wheeled vehicle of unspecified type.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="van">
+        <xs:annotation>
+          <xs:documentation>Van.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="vehicleWithCaravan">
+        <xs:annotation>
+          <xs:documentation>Vehicle (of unspecified type) towing a caravan.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="vehicleWithCatalyticConverter">
+        <xs:annotation>
+          <xs:documentation>Vehicle with catalytic converter.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="vehicleWithoutCatalyticConverter">
+        <xs:annotation>
+          <xs:documentation>Vehicle without catalytic converter.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="vehicleWithTrailer">
+        <xs:annotation>
+          <xs:documentation>Vehicle (of unspecified type) towing a trailer.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="withEvenNumberedRegistrationPlates">
+        <xs:annotation>
+          <xs:documentation>Vehicle with even numbered registration plate.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="withOddNumberedRegistrationPlates">
+        <xs:annotation>
+          <xs:documentation>Vehicle with odd numbered registration plate.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unknown">
+        <xs:annotation>
+          <xs:documentation>Unknown.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other than as defined in this enumeration.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="VehicleUsageEnum">
+    <xs:annotation>
+      <xs:documentation>Types of usage of a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="agricultural">
+        <xs:annotation>
+          <xs:documentation>Vehicle used for agricultural purposes.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="carSharing">
+        <xs:annotation>
+          <xs:documentation>Vehicles operated by a car-sharing company.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="cityLogistics">
+        <xs:annotation>
+          <xs:documentation>Vehicles that are used to deliver goods in a city area.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="commercial">
+        <xs:annotation>
+          <xs:documentation>Vehicle which is limited to non-private usage or public transport usage.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="emergencyServices">
+        <xs:annotation>
+          <xs:documentation>Vehicle used by the emergency services.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="military">
+        <xs:annotation>
+          <xs:documentation>Vehicle used by the military.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="nonCommercial">
+        <xs:annotation>
+          <xs:documentation>Vehicle used for non-commercial or private purposes.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="patrol">
+        <xs:annotation>
+          <xs:documentation>Vehicle used as part of a patrol service, e.g. road operator or automobile association patrol vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="recoveryServices">
+        <xs:annotation>
+          <xs:documentation>Vehicle used to provide a recovery service.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadMaintenanceOrConstruction">
+        <xs:annotation>
+          <xs:documentation>Vehicle used for road maintenance or construction work purposes.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadOperator">
+        <xs:annotation>
+          <xs:documentation>Vehicle used by the road operator.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="taxi">
+        <xs:annotation>
+          <xs:documentation>Vehicle used to provide an authorised taxi service.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="VersionedReference">
+    <xs:attribute name="id" type="xs:string" use="required" />
+    <xs:attribute name="version" type="xs:string" use="optional" />
+  </xs:complexType>
+  <xs:simpleType name="WeatherRelatedRoadConditionTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of road surface conditions which are related to the weather.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="blackIce">
+        <xs:annotation>
+          <xs:documentation>Severe skid risk due to black ice (i.e. clear ice, which is impossible or very difficult to see).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="deepSnow">
+        <xs:annotation>
+          <xs:documentation>Deep snow on the roadway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="dry">
+        <xs:annotation>
+          <xs:documentation>There is no humidity over the sensor.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="freezingOfWetRoads">
+        <xs:annotation>
+          <xs:documentation>The wet road surface is subject to freezing.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="freezingPavements">
+        <xs:annotation>
+          <xs:documentation>The pavements for pedestrians are subject to freezing.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="freezingRain">
+        <xs:annotation>
+          <xs:documentation>Severe skid risk due to rain falling on sub-zero temperature road surface and freezing.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="freshSnow">
+        <xs:annotation>
+          <xs:documentation>Fresh snow (with little or no traffic yet) on the roadway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="glaze">
+        <xs:annotation>
+          <xs:documentation>Glaze of the road surface.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ice">
+        <xs:annotation>
+          <xs:documentation>Increased skid risk due to ice (of any kind).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="iceBuildUp">
+        <xs:annotation>
+          <xs:documentation>Ice is building up on the roadway causing a serious skid hazard.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="iceWithWheelBarTracks">
+        <xs:annotation>
+          <xs:documentation>Ice on the road frozen in the form of wheel tracks.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="icyPatches">
+        <xs:annotation>
+          <xs:documentation>Severe skid risk due to icy patches (i.e. intermittent ice on roadway).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="looseSnow">
+        <xs:annotation>
+          <xs:documentation>Powdery snow on the road which is subject to being blown by the wind.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="moist">
+        <xs:annotation>
+          <xs:documentation>From (0,01 mm) water film thickness over the sensor</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="normalWinterConditionsForPedestrians">
+        <xs:annotation>
+          <xs:documentation>Conditions for pedestrians are consistent with those normally expected in winter.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="notDry">
+        <xs:annotation>
+          <xs:documentation>The road surface is not dry.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="packedSnow">
+        <xs:annotation>
+          <xs:documentation>Packed snow (heavily trafficked) on the roadway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="rime">
+        <xs:annotation>
+          <xs:documentation>Fresh snow (with little or no traffic yet) on the roadway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadSurfaceMelting">
+        <xs:annotation>
+          <xs:documentation>The road surface is melting, or has melted due to abnormally high temperatures.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="slippery">
+        <xs:annotation>
+          <xs:documentation>Detection at least of the presence of partly or wholly solidified aqueous solution over the sensor.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="slushOnRoad">
+        <xs:annotation>
+          <xs:documentation>Increased skid risk due to melting snow (slush) on road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="slushStrings">
+        <xs:annotation>
+          <xs:documentation>Melting snow (slush) on the roadway is formed into wheel tracks.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="snow">
+        <xs:annotation>
+          <xs:documentation>Fresh snow (with little or no traffic yet) on the roadway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="snowDrifts">
+        <xs:annotation>
+          <xs:documentation>Snow drifting is in progress or patches of deep snow are present due to earlier drifting.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="snowOnPavement">
+        <xs:annotation>
+          <xs:documentation>Snow is on the pedestrian pavement.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="wetAndIcyRoad">
+        <xs:annotation>
+          <xs:documentation>Increased skid risk due to partly thawed, wet road with packed snow and ice, or rain falling on packed snow and ice.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="snowOnTheRoad">
+        <xs:annotation>
+          <xs:documentation>Snow is lying on the road surface.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="wetIcyPavement">
+        <xs:annotation>
+          <xs:documentation>Partly thawed, wet pedestrian pavement with packed snow and ice, or rain falling on packed snow and ice.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="streamingWater">
+        <xs:annotation>
+          <xs:documentation>From (2 mm) water film thickness over the sensor.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="surfaceWater">
+        <xs:annotation>
+          <xs:documentation>Water is resting on the roadway which provides an increased hazard to vehicles.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="wet">
+        <xs:annotation>
+          <xs:documentation>From (0,2 mm) water film thickness over the sensor</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other than as defined in this enumeration.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="WeightTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Type of weight - describing the meaning of a vehicle weight value</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="actual">
+        <xs:annotation>
+          <xs:documentation>The weight is the actual weight of a specific vehicle</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="maximumPermitted">
+        <xs:annotation>
+          <xs:documentation>The weight is the maximum permitted weight for a vehicle</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="WidthCharacteristic">
+    <xs:annotation>
+      <xs:documentation>Width characteristic of a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="comparisonOperator" type="com:_ComparisonOperatorEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The operator to be used in the vehicle characteristic comparison operation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="vehicleWidth" type="com:MetresAsFloat" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The maximum width of an individual vehicle, including any features embedded or fixed on it, in metres.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_widthCharacteristicExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="Year">
+    <xs:annotation>
+      <xs:documentation>A year.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:NonNegativeInteger" />
+  </xs:simpleType>
+</xs:schema>

--- a/spec/datex2/DATEXII_3_CommonExtension.xsd
+++ b/spec/datex2/DATEXII_3_CommonExtension.xsd
@@ -1,0 +1,412 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:comx="http://datex2.eu/schema/3/commonExtension" version="3.3" targetNamespace="http://datex2.eu/schema/3/commonExtension" xmlns:com="http://datex2.eu/schema/3/common" xmlns:tro="http://datex2.eu/schema/3/trafficRegulation" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="http://datex2.eu/schema/3/trafficRegulation" schemaLocation="DATEXII_3_TrafficRegulation.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/common" schemaLocation="DATEXII_3_Common.xsd" />
+  <xs:complexType name="_ApplicableDaysWithinMonthEnum">
+    <xs:simpleContent>
+      <xs:extension base="comx:ApplicableDaysWithinMonthEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_EuSpecialPurposeVehicleEnum">
+    <xs:simpleContent>
+      <xs:extension base="comx:EuSpecialPurposeVehicleEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_EuVehicleCategoryEnum">
+    <xs:simpleContent>
+      <xs:extension base="comx:EuVehicleCategoryEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_FuzzyTimeEnum">
+    <xs:simpleContent>
+      <xs:extension base="comx:FuzzyTimeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_PowerUnitOfMeasureEnum">
+    <xs:simpleContent>
+      <xs:extension base="comx:PowerUnitOfMeasureEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:simpleType name="ADRClass">
+    <xs:annotation>
+      <xs:documentation>Specification of classes of dangerous goods according to ADR.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:String">
+      <xs:pattern value="[1-9]|[4-6].[1-2]|4.3" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="AgeCharacteristic">
+    <xs:annotation>
+      <xs:documentation>Characteristics depending on vehicle age</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="comparisonOperator" type="com:_ComparisonOperatorEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The operator to be used in the vehicle characteristic comparison operation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="yearOfFirstRegistration" type="com:Year" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Year of first registration of the vehicle</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_ageCharacteristicExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="ApplicableDaysWithinMonthEnum">
+    <xs:annotation>
+      <xs:documentation>Types of days within a month.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="evenDay">
+        <xs:annotation>
+          <xs:documentation>Days of a month with an even date.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="oddDay">
+        <xs:annotation>
+          <xs:documentation>Days of a month with an odd date.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="daysFromOneToFifteen">
+        <xs:annotation>
+          <xs:documentation>Days from the first of the month to the fifteenth.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="daysFromSixteenToThirtyOne">
+        <xs:annotation>
+          <xs:documentation>Days from the sixteenth of the month to the thirty-first.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DangerousGoodsExtended">
+    <xs:annotation>
+      <xs:documentation>Extension of dangerous goods class.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="adrClassValue" type="comx:ADRClass" minOccurs="0" maxOccurs="13">
+        <xs:annotation>
+          <xs:documentation>The class of the dangerous good according to ADR.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="DayWeekMonthExtended">
+    <xs:annotation>
+      <xs:documentation>Extension of class DayWeekMonth.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="applicableDaysWithinMonth" type="comx:_ApplicableDaysWithinMonthEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Applicable days within month.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="EmissionsExtension">
+    <xs:annotation>
+      <xs:documentation>An extension for the Emissions class to provide a comparison operator.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="comparisonOperator" type="com:_ComparisonOperatorEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A comparison operator for the applicable emission classifications in correspondence to the specified value. The comparison applies to the Roman- or Arabic-numbered portion (e.g. euro6 &gt; euro5b), but not crosswise (e.g. euro6 cannot be compared to euroV).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="EnginePowerCharacteristics">
+    <xs:annotation>
+      <xs:documentation>Characteristics of the engine power of a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="comparisonOperator" type="com:_ComparisonOperatorEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The operator to be used in the vehicle characteristic comparison operation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="enginePower" type="com:Float" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The engine power value of the vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="unitOfMeasure" type="comx:_PowerUnitOfMeasureEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The unit in which the engine power is specified.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_enginePowerCharacteristicsExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="EuSpecialPurposeVehicleEnum">
+    <xs:annotation>
+      <xs:documentation>Vehicle purpose according to EU legislation</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="motorCaravan">
+        <xs:annotation>
+          <xs:documentation>motor caravan: special purpose M category vehicle constructed to include living accommodation which contains at least the following equipment: seats and table, sleeping accommodation, cooking facilities and storage facilities.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="armouredVehicle">
+        <xs:annotation>
+          <xs:documentation>armoured vehicle: vehicle intended for the protection of conveyed passengers and/or goods and complying with armour plating anti-bullet requirements.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ambulance">
+        <xs:annotation>
+          <xs:documentation>ambulance: a motor vehicle of category M intended for the transport of sick or injured people and having special equipment for such purpose.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="hearse">
+        <xs:annotation>
+          <xs:documentation>hearse: a motor vehicle of category M intended for the transport of deceased people and having special equipment for such purpose.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="trailerCaravan">
+        <xs:annotation>
+          <xs:documentation>trailer caravan ee ISO Standard 3833-77, term No 3.2.1.3.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="mobileCrane">
+        <xs:annotation>
+          <xs:documentation>Mobile cranes’ means a special purpose vehicle of category N3, not fitted for the carriage of goods, provided with a crane whose lifting moment is equal to or higher than 400 kNm.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="otherSpecialPurposeVehicle">
+        <xs:annotation>
+          <xs:documentation>Other special purpose vehicles’ means vehicles as defined in item 5 above, with the exception of those mentioned in items 5.1 to 5.6. (often regulated nationally)</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="wheelChairAccessibleVehicle">
+        <xs:annotation>
+          <xs:documentation>wheel chair accessible vehicle</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="EuVehicleCategoryEnum">
+    <xs:annotation>
+      <xs:documentation>Vehicle categories according to EU legislation</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="m">
+        <xs:annotation>
+          <xs:documentation>Motor vehicles with at least four wheels designed and constructed for the carriage of passengers.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="m1">
+        <xs:annotation>
+          <xs:documentation>Vehicles designed and constructed for the carriage of passengers and comprising no more than eight seats in addition to the driver’s seat.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="m2">
+        <xs:annotation>
+          <xs:documentation>Vehicles designed and constructed for the carriage of passengers, comprising more than eight seats in addition to the driver’s seat, and having a maximum mass not exceeding 5 tonnes.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="m3">
+        <xs:annotation>
+          <xs:documentation>Vehicles designed and constructed for the carriage of passengers, comprising more than eight seats in addition to the driver’s seat, and having a maximum mass exceeding 5 tonnes.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="n">
+        <xs:annotation>
+          <xs:documentation>Motor vehicles with at least four wheels designed and constructed for the carriage of goods.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="n1">
+        <xs:annotation>
+          <xs:documentation>Vehicles designed and constructed for the carriage of goods and having a maximum mass not exceeding 3,5 tonnes</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="n2">
+        <xs:annotation>
+          <xs:documentation>Vehicles designed and constructed for the carriage of goods and having a maximum mass exceeding 3,5 tonnes but not exceeding 12 tonnes.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="n3">
+        <xs:annotation>
+          <xs:documentation>Vehicles designed and constructed for the carriage of goods and having a maximum mass exceeding 12 tonnes.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="o">
+        <xs:annotation>
+          <xs:documentation>Trailers (including semi-trailers).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="o1">
+        <xs:annotation>
+          <xs:documentation>Trailers with a maximum mass not exceeding 0,75 tonnes</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="o2">
+        <xs:annotation>
+          <xs:documentation>Trailers with a maximum mass exceeding 0,75 tonnes but not exceeding 3,5 tonnes.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="o3">
+        <xs:annotation>
+          <xs:documentation>Trailers with a maximum mass exceeding 3,5 tonnes but not exceeding 10 tonnes.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="o4">
+        <xs:annotation>
+          <xs:documentation>Trailers with a maximum mass exceeding 10 tonnes.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="FuzzyPeriod">
+    <xs:annotation>
+      <xs:documentation>Class for fuzzy periods of a day.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="beginOrDuration" type="comx:_FuzzyTimeEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Begin or duration of fuzzy time period.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="endOrDuration" type="comx:_FuzzyTimeEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>End or duration of fuzzy time period.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_fuzzyPeriodExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="FuzzyTimeEnum">
+    <xs:annotation>
+      <xs:documentation>Enumeration for fuzzy time periods.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="dawn">
+        <xs:annotation>
+          <xs:documentation>Local time of dawn.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sunset">
+        <xs:annotation>
+          <xs:documentation>Local time of sunset.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="GrossTrailerWeightCharacteristics">
+    <xs:annotation>
+      <xs:documentation>Gross weight characteristic of a trailer of a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="comparisonOperator" type="com:_ComparisonOperatorEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The operator to be used in the trailer characteristic comparison operation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="grossTrailerWeight" type="com:Tonnes" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The gross weight of the vehicle and its load, including any trailers.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="typeOfWeight" type="com:_WeightTypeEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The meaning of the weight value.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_grossTrailerWeightCharacteristicsExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PeriodExtended">
+    <xs:annotation>
+      <xs:documentation>Extension class for Period.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="fuzzyPeriod" type="comx:FuzzyPeriod" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="PowerUnitOfMeasureEnum">
+    <xs:annotation>
+      <xs:documentation>Units for measuring power.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="kilowatt">
+        <xs:annotation>
+          <xs:documentation>Power expressed in kilowatt.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="horsepower">
+        <xs:annotation>
+          <xs:documentation>Power expressed in horsepower.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="RegulatedCharacteristics">
+    <xs:annotation>
+      <xs:documentation>characteristics as defined in EU and or national regulations</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="euVehicleCategory" type="comx:_EuVehicleCategoryEnum" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Vehicle category as defined in EU Directive 2007/46/EG</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="euSpecialPurposeVehicle" type="comx:_EuSpecialPurposeVehicleEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>vehicle purpose as defined in EU Directive 2007/46/EG</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="nationalSpecialPurposeVehicle" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>vehicle purpose as defined by national regulation</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_regulatedCharacteristicsExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TrailerCharacteristics">
+    <xs:annotation>
+      <xs:documentation>The characteristics of a trailer e.g. gross weight of trailer.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="grossTrailerWeightCharacteristics" type="comx:GrossTrailerWeightCharacteristics">
+        <xs:annotation>
+          <xs:documentation>Gross trailer weight characteristics.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_trailerCharacteristicsExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="VehicleCharacteristicsExtended">
+    <xs:annotation>
+      <xs:documentation>Extension class for vehicle characteristics</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="ageCharacteristic" type="comx:AgeCharacteristic" minOccurs="0" />
+      <xs:element name="maximumDesignSpeed" type="tro:Speed" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>The speed which the vehicle is incapable, by reason of its construction, of exceeding on the level under its own power when fully laden.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="trailerCharacteristics" type="comx:TrailerCharacteristics" minOccurs="0" />
+      <xs:element name="hazardousMaterials" type="com:HazardousMaterials" minOccurs="0" />
+      <xs:element name="enginePowerCharacteristics" type="comx:EnginePowerCharacteristics" minOccurs="0" maxOccurs="2" />
+      <xs:element name="regulatedCharacteristics" type="comx:RegulatedCharacteristics" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/spec/datex2/DATEXII_3_D2Payload.xsd
+++ b/spec/datex2/DATEXII_3_D2Payload.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<xs:schema
+  elementFormDefault="qualified"
+  attributeFormDefault="unqualified"
+  xmlns:d2="http://datex2.eu/schema/3/d2Payload"
+  version="3.3"
+  targetNamespace="http://datex2.eu/schema/3/d2Payload"
+  xmlns:com="http://datex2.eu/schema/3/common"
+  xmlns:loc="http://datex2.eu/schema/3/locationReferencing"
+  xmlns:fac="http://datex2.eu/schema/3/facilities"
+  xmlns:tro="http://datex2.eu/schema/3/trafficRegulation"
+  xmlns:prk="http://datex2.eu/schema/3/parking"
+  xmlns:comx="http://datex2.eu/schema/3/commonExtension"
+  xmlns:locx="http://datex2.eu/schema/3/locationExtension"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="http://datex2.eu/schema/3/locationExtension" schemaLocation="DATEXII_3_LocationExtension.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/commonExtension" schemaLocation="DATEXII_3_CommonExtension.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/parking" schemaLocation="DATEXII_3_Parking.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/trafficRegulation" schemaLocation="DATEXII_3_TrafficRegulation.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/facilities" schemaLocation="DATEXII_3_Facilities.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/locationReferencing" schemaLocation="DATEXII_3_LocationReferencing.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/common" schemaLocation="DATEXII_3_Common.xsd" />
+  <xs:element name="payload" type="com:PayloadPublication">
+    <xs:unique name="_payloadTrafficRegulationOrderConstraint">
+      <xs:selector xpath=".//tro:trafficRegulationOrder" />
+      <xs:field xpath="@id" />
+      <xs:field xpath="@version" />
+    </xs:unique>
+    <xs:unique name="_payloadTrafficRegulationPublicationConstraint">
+      <xs:selector xpath=".//tro:trafficRegulationPublication" />
+      <xs:field xpath="@id" />
+    </xs:unique>
+  </xs:element>
+</xs:schema>

--- a/spec/datex2/DATEXII_3_Facilities.xsd
+++ b/spec/datex2/DATEXII_3_Facilities.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:fac="http://datex2.eu/schema/3/facilities" version="3.3" targetNamespace="http://datex2.eu/schema/3/facilities" xmlns:com="http://datex2.eu/schema/3/common" xmlns:loc="http://datex2.eu/schema/3/locationReferencing" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="http://datex2.eu/schema/3/locationReferencing" schemaLocation="DATEXII_3_LocationReferencing.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/common" schemaLocation="DATEXII_3_Common.xsd" />
+  <xs:simpleType name="TimeZone">
+    <xs:annotation>
+      <xs:documentation>Identifies a time zone by specifying the difference to UTC in hours and minutes, as defined in ISO 8601.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:String">
+      <xs:pattern value="[-+][0-9][0-9]:[0-9][0-9]|Z" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/spec/datex2/DATEXII_3_LocationExtension.xsd
+++ b/spec/datex2/DATEXII_3_LocationExtension.xsd
@@ -1,0 +1,196 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:locx="http://datex2.eu/schema/3/locationExtension" version="3.3" targetNamespace="http://datex2.eu/schema/3/locationExtension" xmlns:fac="http://datex2.eu/schema/3/facilities" xmlns:com="http://datex2.eu/schema/3/common" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="http://datex2.eu/schema/3/common" schemaLocation="DATEXII_3_Common.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/facilities" schemaLocation="DATEXII_3_Facilities.xsd" />
+  <xs:complexType name="_AddressLineTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="locx:AddressLineTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_HouseNumberSideEnum">
+    <xs:simpleContent>
+      <xs:extension base="locx:HouseNumberSideEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="Address">
+    <xs:annotation>
+      <xs:documentation>A street oriented addressing structure supporting delivery</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="postcode" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Postcode or postal code for the address.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="city" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Postal city name of the address.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="countryCode" type="com:CountryCode" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>EN ISO 3166-1 two-character country code.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="addressLine" type="locx:AddressLine" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="_addressExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AddressLine">
+    <xs:annotation>
+      <xs:documentation>A class defining information concerning one line of a postal address.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="type" type="locx:_AddressLineTypeEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The type for the address line element</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="text" type="com:MultilingualString" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Free-text description for the address line element</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_addressLineExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="order" type="com:NonNegativeInteger" use="required">
+      <xs:annotation>
+        <xs:documentation>The sequence order that the address line element should be displayed in</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:simpleType name="AddressLineTypeEnum">
+    <xs:annotation>
+      <xs:documentation>A list of supported address line types.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="apartment">
+        <xs:annotation>
+          <xs:documentation>Element indicating a discrete element of a building forming the address</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="building">
+        <xs:annotation>
+          <xs:documentation>Element identifying the number or name and type of the edifice or construction relevant for the address [derived from ISO19160-4]</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="poBox">
+        <xs:annotation>
+          <xs:documentation>A postal delivery location identifier, not necessarily a physical location.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unit">
+        <xs:annotation>
+          <xs:documentation>An element representing a section of a building or organisation.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="region">
+        <xs:annotation>
+          <xs:documentation>Element indicating the name of the area within or adjacent to the town in which delivery address is.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="town">
+        <xs:annotation>
+          <xs:documentation>Element indicating the name of the populated place in which a delivery point is located, or near to or via which the delivery point is accessed. [Source: ISO19160-4]</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="districtTerritory">
+        <xs:annotation>
+          <xs:documentation>Element specifying the geographic or administrative area of the country for the address [Source: 19160-4]</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="floor">
+        <xs:annotation>
+          <xs:documentation>Element indicating the floor or level on which a delivery point is located in a multi-storey building [Source:ISO19160-4]</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="street">
+        <xs:annotation>
+          <xs:documentation>Element indicating road or street identifier or name </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="houseNumber">
+        <xs:annotation>
+          <xs:documentation>Element indicating a house number</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="generalTextLine">
+        <xs:annotation>
+          <xs:documentation>A non-predefined text line for general purpose.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="FacilityLocation">
+    <xs:annotation>
+      <xs:documentation>A location for which a time zone and an address can be specified</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="timeZone" type="fac:TimeZone" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The time zone the facility is located in.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="address" type="locx:Address" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>An address specification following ISO 19160-4.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="HouseNumberSideEnum">
+    <xs:annotation>
+      <xs:documentation>Specifies the side of the house number (even, odd).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="odd">
+        <xs:annotation>
+          <xs:documentation>Correspond to the street side with odd house numbers.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="even">
+        <xs:annotation>
+          <xs:documentation>Correspond to the street side with even house numbers.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NamedAreaCode">
+    <xs:annotation>
+      <xs:documentation>Type for a short numeric or alphanumeric code identifying an area.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:String">
+      <xs:maxLength value="8" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="NamedAreaExtended">
+    <xs:annotation>
+      <xs:documentation>A named area with an additional code (that is not an ISO subdivision code)</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="namedAreaCode" type="locx:NamedAreaCode" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Code for the named area, such a postal code or other code assigned for administration.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SupplementaryPositionalDescriptionExtended">
+    <xs:annotation>
+      <xs:documentation>Extension of class SupplementaryPositionalDescription.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="houseNumberSide" type="locx:_HouseNumberSideEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Side of the street corresponding of the type of number address.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>

--- a/spec/datex2/DATEXII_3_LocationReferencing.xsd
+++ b/spec/datex2/DATEXII_3_LocationReferencing.xsd
@@ -1,0 +1,4005 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:loc="http://datex2.eu/schema/3/locationReferencing" version="3.3" targetNamespace="http://datex2.eu/schema/3/locationReferencing" xmlns:locx="http://datex2.eu/schema/3/locationExtension" xmlns:com="http://datex2.eu/schema/3/common" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="http://datex2.eu/schema/3/common" schemaLocation="DATEXII_3_Common.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/locationExtension" schemaLocation="DATEXII_3_LocationExtension.xsd" />
+  <xs:complexType name="_AlertCDirectionEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:AlertCDirectionEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_AltitudeAccuracyEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:AltitudeAccuracyEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_AreaPlacesEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:AreaPlacesEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_CarriagewayEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:CarriagewayEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_DirectionEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:DirectionEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_DirectionPurposeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:DirectionPurposeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_GeographicCharacteristicEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:GeographicCharacteristicEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_HeightGradeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:HeightGradeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_HeightTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:HeightTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_InfrastructureDescriptorEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:InfrastructureDescriptorEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_IntermediatePointOnLinearElement">
+    <xs:sequence>
+      <xs:element name="referent" type="loc:Referent" minOccurs="1" maxOccurs="1" />
+    </xs:sequence>
+    <xs:attribute name="index" type="xs:int" use="required" />
+  </xs:complexType>
+  <xs:complexType name="_LaneEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:LaneEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_LinearDirectionEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:LinearDirectionEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_LinearElementNatureEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:LinearElementNatureEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_LocationContainedInItinerary">
+    <xs:sequence>
+      <xs:element name="location" type="loc:Location" minOccurs="1" maxOccurs="1" />
+    </xs:sequence>
+    <xs:attribute name="index" type="xs:int" use="required" />
+  </xs:complexType>
+  <xs:complexType name="_LocationReferenceExtensionType">
+    <xs:sequence>
+      <xs:element name="facilityLocation" type="locx:FacilityLocation" minOccurs="0" />
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="_NamedAreaExtensionType">
+    <xs:sequence>
+      <xs:element name="namedAreaExtended" type="locx:NamedAreaExtended" minOccurs="0" />
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="_NamedAreaTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:NamedAreaTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_NutsCodeTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:NutsCodeTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_OpenlrFormOfWayEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:OpenlrFormOfWayEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_OpenlrFunctionalRoadClassEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:OpenlrFunctionalRoadClassEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_OpenlrOrientationEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:OpenlrOrientationEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_OpenlrSideOfRoadEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:OpenlrSideOfRoadEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_PositionConfidenceCodedErrorEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:PositionConfidenceCodedErrorEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_PredefinedItineraryVersionedReference">
+    <xs:complexContent>
+      <xs:extension base="com:VersionedReference">
+        <xs:attribute name="targetClass" type="xs:string" use="required" fixed="loc:PredefinedItinerary" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="_PredefinedLocationGroupVersionedReference">
+    <xs:complexContent>
+      <xs:extension base="com:VersionedReference">
+        <xs:attribute name="targetClass" type="xs:string" use="required" fixed="loc:PredefinedLocationGroup" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="_PredefinedLocationVersionedReference">
+    <xs:complexContent>
+      <xs:extension base="com:VersionedReference">
+        <xs:attribute name="targetClass" type="xs:string" use="required" fixed="loc:PredefinedLocation" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="_ReferentTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:ReferentTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_RelativePositionOnCarriagewayEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:RelativePositionOnCarriagewayEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_SubdivisionTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:SubdivisionTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_SupplementaryPositionalDescriptionExtensionType">
+    <xs:sequence>
+      <xs:element name="supplementaryPositionalDescriptionExtended" type="locx:SupplementaryPositionalDescriptionExtended" minOccurs="0" />
+      <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="_TpegLoc01AreaLocationSubtypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:TpegLoc01AreaLocationSubtypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TpegLoc01FramedPointLocationSubtypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:TpegLoc01FramedPointLocationSubtypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TpegLoc01LinearLocationSubtypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:TpegLoc01LinearLocationSubtypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TpegLoc01SimplePointLocationSubtypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:TpegLoc01SimplePointLocationSubtypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TpegLoc03AreaDescriptorSubtypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:TpegLoc03AreaDescriptorSubtypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TpegLoc03IlcPointDescriptorSubtypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:TpegLoc03IlcPointDescriptorSubtypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TpegLoc03JunctionPointDescriptorSubtypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:TpegLoc03JunctionPointDescriptorSubtypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TpegLoc03OtherPointDescriptorSubtypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:TpegLoc03OtherPointDescriptorSubtypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TpegLoc04HeightTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="loc:TpegLoc04HeightTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="AlertCArea">
+    <xs:annotation>
+      <xs:documentation>An area defined by reference to a predefined ALERT-C location table.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="alertCLocationCountryCode" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>ALERT-C country code as defined in IEC 62106.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alertCLocationTableNumber" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Number allocated to an ALERT-C table in a country. Ref. EN ISO 14819-3 for the allocation of a location table number.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alertCLocationTableVersion" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Version number associated with an ALERT-C table reference.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="areaLocation" type="loc:AlertCLocation">
+        <xs:annotation>
+          <xs:documentation>Area location defined by a specific Alert-C location.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_alertCAreaExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AlertCDirection">
+    <xs:annotation>
+      <xs:documentation>The direction of traffic flow along the road to which the information relates.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="alertCDirectionCoded" type="loc:_AlertCDirectionEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Direction of navigation with respect to secondary to primary location (RDS direction)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alertCDirectionNamed" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>ALERT-C name of a direction e.g. Brussels -&gt; Lille.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alertCAffectedDirection" type="loc:_LinearDirectionEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The direction(s) of traffic flow to which the situation, traffic data or information is related.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_alertCDirectionExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="AlertCDirectionEnum">
+    <xs:annotation>
+      <xs:documentation>Direction used to reach the primary location from the secondary location in ALERT-C location table, as defined in CEN ISO 14819-1</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="negative">
+        <xs:annotation>
+          <xs:documentation>The direction of navigation in an ALERT-C table that corresponds to the negative offset usage to go from the secondary location to the primary location within the ALERT-C location table.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="positive">
+        <xs:annotation>
+          <xs:documentation>The direction of navigation in an ALERT-C table that corresponds to the positive offset usage to go from the secondary location to the primary location within the ALERT-C location table.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="AlertCLinear" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A linear section along a road defined between two points on the road by reference to a pre-defined ALERT-C location table.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="alertCLocationCountryCode" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>ALERT-C country code as defined in IEC 62106.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alertCLocationTableNumber" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Number allocated to an ALERT-C table in a country. Ref. EN ISO 14819-3 for the allocation of a location table number.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alertCLocationTableVersion" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Version number associated with an ALERT-C table reference.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_alertCLinearExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AlertCLinearByCode">
+    <xs:annotation>
+      <xs:documentation>A linear section along a road defined by reference to a linear section in a pre-defined ALERT-C location table.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:AlertCLinear">
+        <xs:sequence>
+          <xs:element name="alertCDirection" type="loc:AlertCDirection" />
+          <xs:element name="locationCodeForLinearLocation" type="loc:AlertCLocation">
+            <xs:annotation>
+              <xs:documentation>Linear location defined by a specific Alert-C location.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_alertCLinearByCodeExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="AlertCLocation">
+    <xs:annotation>
+      <xs:documentation>Identification of a specific point, linear or area location in an ALERT-C location table.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="alertCLocationName" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Name of ALERT-C location.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="specificLocation" type="loc:AlertCLocationCode" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Unique code within the ALERT-C location table which identifies the specific point, linear or area location.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_alertCLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="AlertCLocationCode">
+    <xs:annotation>
+      <xs:documentation>A positive integer number (between 1 and 63 487) which uniquely identifies a pre-defined Alert C location defined within an Alert-C table.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:NonNegativeInteger">
+      <xs:minInclusive value="1" />
+      <xs:maxInclusive value="63487" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="AlertCMethod2Linear">
+    <xs:annotation>
+      <xs:documentation>A linear section along a road between two points, primary and secondary, which are pre-defined in an ALERT-C location table. Direction is FROM the secondary point TO the primary point, i.e. the primary point is downstream of the secondary point.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:AlertCLinear">
+        <xs:sequence>
+          <xs:element name="alertCDirection" type="loc:AlertCDirection" />
+          <xs:element name="alertCMethod2PrimaryPointLocation" type="loc:AlertCMethod2PrimaryPointLocation" />
+          <xs:element name="alertCMethod2SecondaryPointLocation" type="loc:AlertCMethod2SecondaryPointLocation" />
+          <xs:element name="_alertCMethod2LinearExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="AlertCMethod2Point">
+    <xs:annotation>
+      <xs:documentation>A single point on the road network defined by reference to a point in a pre-defined ALERT-C location table and which has an associated direction of traffic flow.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:AlertCPoint">
+        <xs:sequence>
+          <xs:element name="alertCDirection" type="loc:AlertCDirection" />
+          <xs:element name="alertCMethod2PrimaryPointLocation" type="loc:AlertCMethod2PrimaryPointLocation" />
+          <xs:element name="_alertCMethod2PointExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="AlertCMethod2PrimaryPointLocation">
+    <xs:annotation>
+      <xs:documentation>The point (called Primary point) which is either a single point or at the downstream end of a linear road section. The point is specified by a reference to a point in a pre-defined ALERT-C location table.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="alertCLocation" type="loc:AlertCLocation" />
+      <xs:element name="_alertCMethod2PrimaryPointLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AlertCMethod2SecondaryPointLocation">
+    <xs:annotation>
+      <xs:documentation>The point (called Secondary point) which is at the upstream end of a linear road section. The point is specified by a reference to a point in a pre-defined ALERT-C location table.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="alertCLocation" type="loc:AlertCLocation" />
+      <xs:element name="_alertCMethod2SecondaryPointLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AlertCMethod4Linear">
+    <xs:annotation>
+      <xs:documentation>A linear section along a road between two points, primary and secondary, which are pre-defined ALERT-C locations plus offset distance. Direction is FROM the secondary point TO the primary point, i.e. the primary point is downstream of the secondary point.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:AlertCLinear">
+        <xs:sequence>
+          <xs:element name="alertCMethod4PrimaryPointLocation" type="loc:AlertCMethod4PrimaryPointLocation" />
+          <xs:element name="alertCMethod4SecondaryPointLocation" type="loc:AlertCMethod4SecondaryPointLocation" />
+          <xs:element name="_alertCMethod4LinearExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="AlertCMethod4Point">
+    <xs:annotation>
+      <xs:documentation>A single point on the road network defined by reference to a point in a pre-defined ALERT-C location table plus an offset distance and which has an associated direction of traffic flow.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:AlertCPoint">
+        <xs:sequence>
+          <xs:element name="alertCDirection" type="loc:AlertCDirection" />
+          <xs:element name="alertCMethod4PrimaryPointLocation" type="loc:AlertCMethod4PrimaryPointLocation" />
+          <xs:element name="_alertCMethod4PointExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="AlertCMethod4PrimaryPointLocation">
+    <xs:annotation>
+      <xs:documentation>The point (called Primary point) which is either a single point or at the downstream end of a linear road section. The point is specified by a reference to a point in a pre-defined ALERT-C location table plus a non-negative offset distance.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="alertCLocation" type="loc:AlertCLocation" />
+      <xs:element name="offsetDistance" type="loc:OffsetDistance" />
+      <xs:element name="_alertCMethod4PrimaryPointLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AlertCMethod4SecondaryPointLocation">
+    <xs:annotation>
+      <xs:documentation>The point (called Secondary point) which is at the upstream end of a linear road section. The point is specified by a reference to a point in a pre-defined Alert-C location table plus a non-negative offset distance.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="_alertCMethod4SecondaryPointLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AlertCPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A single point on the road network defined by reference to a pre-defined ALERT-C location table and which has an associated direction of traffic flow.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="alertCLocationCountryCode" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>ALERT-C country code as defined IEC 62106.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alertCLocationTableNumber" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Number allocated to an ALERT-C table in a country. Ref. EN ISO 14819-3 for the allocation of a location table number.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="alertCLocationTableVersion" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Version number associated with an ALERT-C table reference.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_alertCPointExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="AltitudeAccuracyEnum">
+    <xs:annotation>
+      <xs:documentation>Coded level of vertical accuracy</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="equalToOrLessThan1Centimetre">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 1 centimetre</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan2Centimetres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 2 centimetres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan5Centimetres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 5 centimetres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan10Centimetres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 10 centimetres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan20Centimetres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 20 centimetres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan50Centimetres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 50 centimetres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan1Metre">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 1 metre</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan2Metres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 2 metres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan5Metres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 5 metres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan10Metres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 10 metres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan20Metres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 20 metres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan50Metres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 50 metres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan100Metres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 100 metres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="equalToOrLessThan200Metres">
+        <xs:annotation>
+          <xs:documentation>Indicates if the altitude accuracy is equal to or less than 200 metres</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="AltitudeConfidence">
+    <xs:annotation>
+      <xs:documentation>Evaluation of the altitude confidence assessed according to ETSI ISO 102894-2</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="altitudeAccuracyCodedValue" type="loc:_AltitudeAccuracyEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Absolute accuracy of reported value of a geographical point for a confidence level expressed by a coded scale.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="altitudeAccuracyCodedError" type="loc:_PositionConfidenceCodedErrorEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Error code in case the altitude confidence is out of range or cannot be determined</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_altitudeConfidenceExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AreaDestination">
+    <xs:annotation>
+      <xs:documentation>The specification of the destination of a defined route or itinerary which is an area.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:Destination">
+        <xs:sequence>
+          <xs:element name="areaLocation" type="loc:AreaLocation" />
+          <xs:element name="_areaDestinationExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="AreaLocation">
+    <xs:annotation>
+      <xs:documentation>Location representing a geographic or geometric defined area which may be qualified by height information to provide additional geospatial discrimination (e.g. for snow in an area but only above a certain altitude).</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:Location">
+        <xs:sequence>
+          <xs:element name="areasAtWhichApplicable" type="loc:_AreaPlacesEnum" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Places, in generic terms, at which the corresponding information applies.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="alertCArea" type="loc:AlertCArea" minOccurs="0" maxOccurs="unbounded" />
+          <xs:element name="tpegAreaLocation" type="loc:TpegAreaLocation" minOccurs="0" />
+          <xs:element name="namedArea" type="loc:NamedArea" minOccurs="0" />
+          <xs:element name="gmlMultiPolygon" type="loc:GmlMultiPolygon" minOccurs="0" />
+          <xs:element name="openlrAreaLocationReference" type="loc:OpenlrAreaLocationReference" minOccurs="0" />
+          <xs:element name="_areaLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="AreaPlacesEnum">
+    <xs:annotation>
+      <xs:documentation>Type of area place(s)</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="atBorders">
+        <xs:annotation>
+          <xs:documentation>At national borders</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="atHighAltitudes">
+        <xs:annotation>
+          <xs:documentation>At high altitudes</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inBuiltUpAreas">
+        <xs:annotation>
+          <xs:documentation>In built up areas, i.e. villages, towns and cities</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inForestedAreas">
+        <xs:annotation>
+          <xs:documentation>On sections of the road where it runs through or adjacent to forested areas</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inGalleries">
+        <xs:annotation>
+          <xs:documentation>In galleries</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inLowLyingAreas">
+        <xs:annotation>
+          <xs:documentation>In low-lying areas</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inRuralAreas">
+        <xs:annotation>
+          <xs:documentation>In rural areas, i.e. outside villages, towns and cities</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inShadedAreas">
+        <xs:annotation>
+          <xs:documentation>In shaded areas</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inTheInnerCityAreas">
+        <xs:annotation>
+          <xs:documentation>In the city centre areas</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inTunnels">
+        <xs:annotation>
+          <xs:documentation>In tunnels</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onBridges">
+        <xs:annotation>
+          <xs:documentation>On bridges</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onDownhillSections">
+        <xs:annotation>
+          <xs:documentation>On downhill sections of the road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onElevatedSections">
+        <xs:annotation>
+          <xs:documentation>On elevated sections of the road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onEnteringOrLeavingTunnels">
+        <xs:annotation>
+          <xs:documentation>On entering or leaving tunnels</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onFlyovers">
+        <xs:annotation>
+          <xs:documentation>On flyover sections of the road, i.e. sections of the road which pass over another road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onPasses">
+        <xs:annotation>
+          <xs:documentation>On mountain passes</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onUndergroundSections">
+        <xs:annotation>
+          <xs:documentation>On underground sections of the road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onUnderpasses">
+        <xs:annotation>
+          <xs:documentation>On underpasses, i.e. sections of the road which pass under another road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Carriageway">
+    <xs:annotation>
+      <xs:documentation>Supplementary positional information which details carriageway and lane locations. Several instances may exist where the element being described extends over more than one carriageway.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="carriageway" type="loc:_CarriagewayEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Indicates the section of carriageway to which the location relates.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="originalNumberOfLanes" type="com:Integer" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Normal number of lanes, potentially available for moving traffic, before reduction due to situations. Hard shoulder should not be counted unless it is sometimes used operationally for moving traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="lane" type="loc:Lane" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="_carriagewayExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="CarriagewayEnum">
+    <xs:annotation>
+      <xs:documentation>List of descriptors identifying specific carriageway details.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="connectingCarriageway">
+        <xs:annotation>
+          <xs:documentation>On the connecting carriageway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="cycleTrack">
+        <xs:annotation>
+          <xs:documentation>Independent road or part of a road designated for cycles, signposted as such. A cycle track is separated from other roads or other parts of the same road by structural means.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="entrySlipRoad">
+        <xs:annotation>
+          <xs:documentation>On the entry slip road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="exitSlipRoad">
+        <xs:annotation>
+          <xs:documentation>On the exit slip road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="flyover">
+        <xs:annotation>
+          <xs:documentation>On the flyover, i.e. the section of road passing over another.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="footpath">
+        <xs:annotation>
+          <xs:documentation>On the footpath</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="leftHandFeederRoad">
+        <xs:annotation>
+          <xs:documentation>On the left hand feeder road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="leftHandParallelCarriageway">
+        <xs:annotation>
+          <xs:documentation>On the left hand parallel carriageway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="mainCarriageway">
+        <xs:annotation>
+          <xs:documentation>On the main carriageway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="oppositeCarriageway">
+        <xs:annotation>
+          <xs:documentation>On the opposite carriageway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="parallelCarriageway">
+        <xs:annotation>
+          <xs:documentation>On the adjacent external parallel carriageway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="rightHandFeederRoad">
+        <xs:annotation>
+          <xs:documentation>On the right hand feeder road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="rightHandParallelCarriageway">
+        <xs:annotation>
+          <xs:documentation>On the right hand parallel carriageway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roundabout">
+        <xs:annotation>
+          <xs:documentation>On the roundabout.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="serviceRoad">
+        <xs:annotation>
+          <xs:documentation>On the adjacent service road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="slipRoads">
+        <xs:annotation>
+          <xs:documentation>On the slip roads.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="underpass">
+        <xs:annotation>
+          <xs:documentation>On the underpass, i.e. the section of road passing under another.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unspecifiedCarriageway">
+        <xs:annotation>
+          <xs:documentation>On an unspecified carriageway</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Destination" abstract="true">
+    <xs:annotation>
+      <xs:documentation>The specification of a destination. This may be either a point location or an area location.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="_destinationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="DirectionEnum">
+    <xs:annotation>
+      <xs:documentation>List of directions of travel.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="aligned">
+        <xs:annotation>
+          <xs:documentation>Same direction as the normal direction of flow at this point on the road network.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="allDirections">
+        <xs:annotation>
+          <xs:documentation>All directions (where more than two are applicable) at this point on the road network.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="anticlockwise">
+        <xs:annotation>
+          <xs:documentation>Anti-clockwise.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="bothWays">
+        <xs:annotation>
+          <xs:documentation>Both directions that are applicable at this point on the road network.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="clockwise">
+        <xs:annotation>
+          <xs:documentation>Clockwise.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="innerRing">
+        <xs:annotation>
+          <xs:documentation>Inner ring direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="outerRing">
+        <xs:annotation>
+          <xs:documentation>Outer ring direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="eastBound">
+        <xs:annotation>
+          <xs:documentation>East bound general direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="northBound">
+        <xs:annotation>
+          <xs:documentation>North bound general direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="northEastBound">
+        <xs:annotation>
+          <xs:documentation>North east bound general direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="northWestBound">
+        <xs:annotation>
+          <xs:documentation>North west bound general direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="southBound">
+        <xs:annotation>
+          <xs:documentation>South bound general direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="southEastBound">
+        <xs:annotation>
+          <xs:documentation>South east bound general direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="southWestBound">
+        <xs:annotation>
+          <xs:documentation>South west bound general direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="westBound">
+        <xs:annotation>
+          <xs:documentation>West bound general direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inboundTowardsTown">
+        <xs:annotation>
+          <xs:documentation>Heading towards town centre direction of travel.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="outboundFromTown">
+        <xs:annotation>
+          <xs:documentation>Heading out of or away from the town centre direction of travel.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="opposite">
+        <xs:annotation>
+          <xs:documentation>Opposite direction to the normal direction of flow at this point on the road network.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unknown">
+        <xs:annotation>
+          <xs:documentation>Direction is unknown.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other than as defined in this enumeration.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DirectionPurposeEnum">
+    <xs:annotation>
+      <xs:documentation>Main purpose of a direction of a road</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="inbound">
+        <xs:annotation>
+          <xs:documentation>On the carriageway or lane which is inbound towards the centre of the town or city.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="outbound">
+        <xs:annotation>
+          <xs:documentation>On the carriageway or lane which is outbound from the centre of the town or city.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DistanceAlongLinearElement" abstract="true">
+    <xs:annotation>
+      <xs:documentation>Distance of a point along a linear element either measured from the start node or a defined referent on that linear element, where the start node is relative to the element definition rather than the direction of traffic flow.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="_distanceAlongLinearElementExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="DistanceFromLinearElementReferent">
+    <xs:annotation>
+      <xs:documentation>Distance of a point along a linear element measured from a "from referent" on the linear element, in the sense relative to the linear element definition rather than the direction of traffic flow or optionally towards a "towards referent".</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:DistanceAlongLinearElement">
+        <xs:sequence>
+          <xs:element name="distanceAlong" type="com:MetresAsFloat" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>A measure of distance along a linear element.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="fromReferent" type="loc:Referent">
+            <xs:annotation>
+              <xs:documentation>A known location along the linear element from which the distanceAlong is measured, termed the "fromReferent" in EN ISO 19148. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="towardsReferent" type="loc:Referent" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>A known location along the linear element towards which the distanceAlong is measured, termed the "towardsReferent" in EN ISO 19148.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_distanceFromLinearElementReferentExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="DistanceFromLinearElementStart">
+    <xs:annotation>
+      <xs:documentation>Distance of a point along a linear element measured from the start node of the linear element, where start node is relative to the element definition rather than the direction of traffic flow.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:DistanceAlongLinearElement">
+        <xs:sequence>
+          <xs:element name="distanceAlong" type="com:MetresAsFloat" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>A measure of distance along a linear element.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_distanceFromLinearElementStartExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ExternalReferencing">
+    <xs:annotation>
+      <xs:documentation>A location defined by reference to an external/other referencing system.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="externalLocationCode" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A code in the external referencing system which defines the location.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="externalReferencingSystem" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Identification of the external/other location referencing system.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_externalReferencingExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="GeographicCharacteristicEnum">
+    <xs:annotation>
+      <xs:documentation>Descriptor to help to identify a specific location.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="aroundABendInRoad">
+        <xs:annotation>
+          <xs:documentation>Around a bend in the road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onBorder">
+        <xs:annotation>
+          <xs:documentation>On border crossing.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onPass">
+        <xs:annotation>
+          <xs:documentation>On mountain pass.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="overCrestOfHill">
+        <xs:annotation>
+          <xs:documentation>Over the crest of a hill.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="GmlLinearRing">
+    <xs:annotation>
+      <xs:documentation>Closed line string not self-intersecting (i.e. having as last point the first point)</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:GmlLineString">
+        <xs:sequence>
+          <xs:element name="_gmlLinearRingExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="GmlLineString">
+    <xs:annotation>
+      <xs:documentation>Line string based on GML (EN ISO 19136) definition: a curve defined by a series of two or more coordinate tuples. Unlike GML may be self-intersecting. If srsName attribute is not present, posList is assumed to use "ETRS89-LatLonh" reference system.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="posList" type="loc:GmlPosList" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>List of coordinate Tuples define the geometry of this GmlLineString. There must be at least 2 Tuples of coordinates.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_gmlLineStringExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="srsDimension" type="com:NonNegativeInteger" use="optional">
+      <xs:annotation>
+        <xs:documentation>Provides the size of the tuple of coordinates of each point. This number is 2 or 3. By default when omitted the dimension shall be interpreted as 2.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="srsName" type="com:String" use="optional">
+      <xs:annotation>
+        <xs:documentation>Specifies the Coordinate Reference System (CRS) used to interpret the coordinates in this GmlLineString</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="GmlMultiPolygon">
+    <xs:annotation>
+      <xs:documentation>An area defined by a set of polygons acording to GML (EN ISO 19136).</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="gmlAreaName" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Name of the multi-polygon area</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="gmlPolygon" type="loc:GmlPolygon" maxOccurs="unbounded" />
+      <xs:element name="_gmlMultiPolygonExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="GmlPolygon">
+    <xs:annotation>
+      <xs:documentation>Planar surface defined by 1 exterior boundary and 0 or more interior boundaries</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="exterior" type="loc:GmlLinearRing">
+        <xs:annotation>
+          <xs:documentation>A boundary of a polygonal surface consisting of a ring i.e. in the normal 2D case, a closed polygonal line distinguished as exterior. Such a polygonal line has at least 4 pairs of coordinates</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="interior" type="loc:GmlLinearRing" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>A boundary of internal patches of a polygonal surface consisting of a ring feature</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_gmlPolygonExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="GmlPosList">
+    <xs:annotation>
+      <xs:documentation>List of coordinates, space-separated, within the same coordinate reference system, defining a geometric entity. Modelled on DirectPositionListType in GML (EN ISO 19136), but constrained to represent a 2D or 3D polyline.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:LongString">
+      <xs:pattern value="[-+]?[0-9]*\.?[0-9]+(\s[-+]?[0-9]*\.?[0-9]+){3,}" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="HeightCoordinate">
+    <xs:annotation>
+      <xs:documentation>Third coordinate for points defined geodetically</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="heightValue" type="com:MetresAsFloat" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Value in metres for the height measured vertically at to the planar coordinates the point corresponding.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="heightType" type="loc:_HeightTypeEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Type of measured height.When it is omitted it is supposed to be the ellipsoidal height.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="altitudeConfidence" type="loc:AltitudeConfidence" minOccurs="0" />
+      <xs:element name="verticalPositionAccuracy" type="loc:PositionAccuracy" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Defines the vertical position accuracy according to EN16803-1</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_heightCoordinateExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="HeightGradeEnum">
+    <xs:annotation>
+      <xs:documentation>List of height or vertical gradings of road sections.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="aboveGrade">
+        <xs:annotation>
+          <xs:documentation>Above or over the normal road grade elevation.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="atGrade">
+        <xs:annotation>
+          <xs:documentation>At the normal road grade elevation.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="belowGrade">
+        <xs:annotation>
+          <xs:documentation>Below or under the normal road grade elevation.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="HeightTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Coded value for type of height</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="ellipsoidalHeight">
+        <xs:annotation>
+          <xs:documentation>Value measured vertically above the reference ellipsoid</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="gravityRelatedHeight">
+        <xs:annotation>
+          <xs:documentation>Height type corresponding a value measured along direction of gravity above the reference geoid i.e. equipotential surface of the Earth's gravity field which globally approximates mean sea level.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="relativeHeight">
+        <xs:annotation>
+          <xs:documentation>Height type corresponding to value masured vertically above the ground level at this point.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="InfrastructureDescriptorEnum">
+    <xs:annotation>
+      <xs:documentation>Descriptor identifying infrastructure to help to identify a specific location.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="atMotorwayInterchange">
+        <xs:annotation>
+          <xs:documentation>At a motorway interchange.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="atRestArea">
+        <xs:annotation>
+          <xs:documentation>At rest area off the carriageway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="atServiceArea">
+        <xs:annotation>
+          <xs:documentation>At service area.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="atTollPlaza">
+        <xs:annotation>
+          <xs:documentation>At toll plaza.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="atTunnelEntryOrExit">
+        <xs:annotation>
+          <xs:documentation>At entry or exit of tunnel.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inGallery">
+        <xs:annotation>
+          <xs:documentation>In gallery.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="inTunnel">
+        <xs:annotation>
+          <xs:documentation>In tunnel.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onBridge">
+        <xs:annotation>
+          <xs:documentation>On bridge.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onConnector">
+        <xs:annotation>
+          <xs:documentation>On connecting carriageway between two different roads or road sections.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onElevatedSection">
+        <xs:annotation>
+          <xs:documentation>On elevated section of road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onFlyover">
+        <xs:annotation>
+          <xs:documentation>On flyover, i.e. on section of road over another road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onIceRoad">
+        <xs:annotation>
+          <xs:documentation>On ice road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onLevelCrossing">
+        <xs:annotation>
+          <xs:documentation>On level-crossing.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onLinkRoad">
+        <xs:annotation>
+          <xs:documentation>On road section linking two different roads.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onRoundabout">
+        <xs:annotation>
+          <xs:documentation>On roundabout.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onTheRoadway">
+        <xs:annotation>
+          <xs:documentation>On the roadway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onUndergroundSection">
+        <xs:annotation>
+          <xs:documentation>On underground section of road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onUnderpass">
+        <xs:annotation>
+          <xs:documentation>On underpass, i.e. section of road which passes under another road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="withinJunction">
+        <xs:annotation>
+          <xs:documentation>On the main carriageway within a junction between exit slip road and entry slip road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="IsoNamedArea">
+    <xs:annotation>
+      <xs:documentation>The ISO 3166-2 representation for the named area.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:NamedArea">
+        <xs:sequence>
+          <xs:element name="subdivisionType" type="loc:_SubdivisionTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The ISO 3166-2 subdivison type for the named area.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="subdivisionCode" type="loc:SubdivisionCode" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The second part of an ISO 3166-2 subdivision code for the named area, which may be used along with the country attribute from the parent class to make a full ISO 3166-2 subdivision code.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_isoNamedAreaExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Itinerary" abstract="true">
+    <xs:annotation>
+      <xs:documentation>Multiple (i.e. more than one) physically separate locations arranged as an ordered set that defines an itinerary or route.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:LocationReference">
+        <xs:sequence>
+          <xs:element name="routeDestination" type="loc:Destination" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>Destination of a route or final location in an itinerary.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_itineraryExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ItineraryByIndexedLocations">
+    <xs:annotation>
+      <xs:documentation>Multiple physically separate locations arranged as an ordered set that defines an itinerary or route. The index qualifier indicates the order.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:Itinerary">
+        <xs:sequence>
+          <xs:element name="locationContainedInItinerary" type="loc:_LocationContainedInItinerary" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>A location contained in an itinerary (i.e. an ordered set of locations defining a route or itinerary).</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_itineraryByIndexedLocationsExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="ItineraryByReference">
+    <xs:annotation>
+      <xs:documentation>Multiple (i.e. more than one) physically separate locations which are ordered that constitute an itinerary or route where they are defined by reference to a predefined itinerary.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:Itinerary">
+        <xs:sequence>
+          <xs:element name="predefinedItineraryReference" type="loc:_PredefinedItineraryVersionedReference" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>A reference to a versioned instance of a predefined itinerary as specified in a PredefinedLocationsPublication.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_itineraryByReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Lane">
+    <xs:annotation>
+      <xs:documentation>Indicates a specific lane or group of lanes.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="laneNumber" type="com:Integer" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The number of the lane, where 1 is nearest the hard shoulder/verge and the numbers increase towards the central reservation/road axis.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="laneUsage" type="loc:_LaneEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Indicates the specific lane to which the location relates.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_laneExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="LaneEnum">
+    <xs:annotation>
+      <xs:documentation>List of descriptors identifying specific lanes.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="allLanesCompleteCarriageway">
+        <xs:annotation>
+          <xs:documentation>In all lanes of the carriageway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="busLane">
+        <xs:annotation>
+          <xs:documentation>In the bus lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="busStop">
+        <xs:annotation>
+          <xs:documentation>In the bus stop lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="carPoolLane">
+        <xs:annotation>
+          <xs:documentation>In the carpool lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="centralReservation">
+        <xs:annotation>
+          <xs:documentation>On the central reservation separating the two directional carriageways of the highway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="crawlerLane">
+        <xs:annotation>
+          <xs:documentation>In the crawler lane - a lane that should be used by slower vehicles.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="cycleLane">
+        <xs:annotation>
+          <xs:documentation>Part of a carriageway designated for cycles. A cycle lane is distinguished from the rest of the carriageway by longitudinal road markings.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="emergencyLane">
+        <xs:annotation>
+          <xs:documentation>In the emergency lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="escapeLane">
+        <xs:annotation>
+          <xs:documentation>In the escape lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="expressLane">
+        <xs:annotation>
+          <xs:documentation>In the express lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="hardShoulder">
+        <xs:annotation>
+          <xs:documentation>On the hard shoulder.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="heavyVehicleLane">
+        <xs:annotation>
+          <xs:documentation>In the heavy vehicle lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="layBy">
+        <xs:annotation>
+          <xs:documentation>In a lay-by.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="leftHandTurningLane">
+        <xs:annotation>
+          <xs:documentation>In the left hand turning lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="leftLane">
+        <xs:annotation>
+          <xs:documentation>In the left lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="localTrafficLane">
+        <xs:annotation>
+          <xs:documentation>In the local traffic lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="middleLane">
+        <xs:annotation>
+          <xs:documentation>In the middle lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="overtakingLane">
+        <xs:annotation>
+          <xs:documentation>In the overtaking lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="rightHandTurningLane">
+        <xs:annotation>
+          <xs:documentation>In the right hand turning lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="rightLane">
+        <xs:annotation>
+          <xs:documentation>In the right lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="rushHourLane">
+        <xs:annotation>
+          <xs:documentation>In the lane dedicated for use during the rush (peak) hour.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="setDownArea">
+        <xs:annotation>
+          <xs:documentation>In the area/lane reserved for passenger pick-up or set-down.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="slowVehicleLane">
+        <xs:annotation>
+          <xs:documentation>In a lane dedicated to vehicles that are not permitted to exceed a fixed slow speed.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="throughTrafficLane">
+        <xs:annotation>
+          <xs:documentation>In the through traffic lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tidalFlowLane">
+        <xs:annotation>
+          <xs:documentation>In the lane dedicated for use as a tidal flow lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="turningLane">
+        <xs:annotation>
+          <xs:documentation>In the turning lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="verge">
+        <xs:annotation>
+          <xs:documentation>On the verge.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="LinearDirectionEnum">
+    <xs:annotation>
+      <xs:documentation>Directions of traffic flow relative to the direction in which the linear element is defined.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="both">
+        <xs:annotation>
+          <xs:documentation>Indicates that both directions of traffic flow are affected by the situation or relate to the traffic data.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="opposite">
+        <xs:annotation>
+          <xs:documentation>Indicates that the direction of traffic flow affected by the situation or related to the traffic data is in the opposite sense to the direction in which the linear element is defined.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="aligned">
+        <xs:annotation>
+          <xs:documentation>Indicates that the direction of traffic flow affected by the situation or related to the traffic data is in the same sense as the direction in which the linear element is defined.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unknown">
+        <xs:annotation>
+          <xs:documentation>Indicates that the direction of traffic flow affected by the situation or related to the traffic data is unknown.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="LinearElement">
+    <xs:annotation>
+      <xs:documentation>A linear element along a single linear object, consistent with EN ISO 19148 definitions. </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="roadName" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Name of the road</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="roadNumber" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Identifier/number of the road</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="linearElementReferenceModel" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The identifier of a road network reference model which segments the road network according to specific business rules.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="linearElementReferenceModelVersion" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The version of the identified road network reference model.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="linearElementNature" type="loc:_LinearElementNatureEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>An indication of the nature of the linear element.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_linearElementExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="LinearElementByCode">
+    <xs:annotation>
+      <xs:documentation>A linear element along a single linear object defined by its identifier or code in a road network reference model (specified in LinearElement class) which segments the road network according to specific business rules.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:LinearElement">
+        <xs:sequence>
+          <xs:element name="linearElementIdentifier" type="com:String" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>An identifier or code of a linear element (or link) in the road network reference model that is specified in the LinearElement class. </xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_linearElementByCodeExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LinearElementByLineString">
+    <xs:annotation>
+      <xs:documentation>A linear element defined by a line string (class GmlLineString).</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:LinearElement">
+        <xs:sequence>
+          <xs:element name="gmlLineString" type="loc:GmlLineString" />
+          <xs:element name="_linearElementByLineStringExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LinearElementByPoints">
+    <xs:annotation>
+      <xs:documentation>A linear element along a single linear object defined by its start and end points.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:LinearElement">
+        <xs:sequence>
+          <xs:element name="startPointOfLinearElement" type="loc:Referent">
+            <xs:annotation>
+              <xs:documentation>The referent at a known location on the linear object which defines the start of the linear element.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="intermediatePointOnLinearElement" type="loc:_IntermediatePointOnLinearElement" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>A referent at a known location on the linear object which is neither the start or end of the linear element.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="endPointOfLinearElement" type="loc:Referent">
+            <xs:annotation>
+              <xs:documentation>The referent at a known location on the linear object which defines the end of the linear element.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_linearElementByPointsExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="LinearElementNatureEnum">
+    <xs:annotation>
+      <xs:documentation>List of indicative natures of linear elements.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="road">
+        <xs:annotation>
+          <xs:documentation>The nature of the linear element is a road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadSection">
+        <xs:annotation>
+          <xs:documentation>The nature of the linear element is a section of a road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="slipRoad">
+        <xs:annotation>
+          <xs:documentation>The nature of the linear element is a slip road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other than as defined in this enumeration.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="LinearLocation">
+    <xs:annotation>
+      <xs:documentation>Location representing a linear section with optional directionality defined between two points. </xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:NetworkLocation">
+        <xs:sequence>
+          <xs:element name="openlrLinear" type="loc:OpenlrLinear" minOccurs="0" />
+          <xs:element name="gmlLineString" type="loc:GmlLineString" minOccurs="0" />
+          <xs:element name="secondarySupplementaryDescription" type="loc:SupplementaryPositionalDescription" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Supplementary description that applies to the secondary end of the linear location. Use when properties change along the Linear. For a one-way linear the secondary end should be the destination end.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_linearLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LinearWithinLinearElement">
+    <xs:annotation>
+      <xs:documentation>A linear section along a linear element where the linear element is either a part of or the whole of a linear object (i.e. a road), consistent with ISO 19148 definitions. </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="administrativeAreaOfLinearSection" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Identification of the road administration area which contains the specified linear section.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="directionOnLinearSection" type="loc:_DirectionEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The direction of traffic flow on the linear section in terms of general destination direction.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="directionRelativeOnLinearSection" type="loc:_LinearDirectionEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The direction of traffic flow on the linear section relative to the direction in which the linear element is defined.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="heightGradeOfLinearSection" type="loc:_HeightGradeEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Identification of whether the linear section that is part of the linear element is at, above or below the normal elevation of a linear element of that type (e.g. road or road section) at that location, typically used to indicate "grade" separation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="linearElement" type="loc:LinearElement" />
+      <xs:element name="fromPoint" type="loc:DistanceAlongLinearElement">
+        <xs:annotation>
+          <xs:documentation>A point on the linear element that defines the start node of the linear section.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="toPoint" type="loc:DistanceAlongLinearElement">
+        <xs:annotation>
+          <xs:documentation>A point on the linear element that defines the end node of the linear section.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_linearWithinLinearElementExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Location" abstract="true">
+    <xs:annotation>
+      <xs:documentation>The specification of a location either on a network (as a point or a linear location) or as an area. This may be provided in one or more referencing systems.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:LocationReference">
+        <xs:sequence>
+          <xs:element name="externalReferencing" type="loc:ExternalReferencing" minOccurs="0" maxOccurs="unbounded" />
+          <xs:element name="coordinatesForDisplay" type="loc:PointCoordinates" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Coordinates that may be used by clients for visual display on user interfaces.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_locationExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LocationByReference">
+    <xs:annotation>
+      <xs:documentation>A location defined by reference to a predefined location.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:Location">
+        <xs:sequence>
+          <xs:element name="predefinedLocationReference" type="loc:_PredefinedLocationVersionedReference" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>A reference to a versioned predefined location.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_locationByReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LocationGroup" abstract="true">
+    <xs:annotation>
+      <xs:documentation>Multiple (i.e. more than one) physically separate locations which have no specific order.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:LocationReference">
+        <xs:sequence>
+          <xs:element name="_locationGroupExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LocationGroupByList">
+    <xs:annotation>
+      <xs:documentation>A group of (i.e. more than one) physically separate locations which have no specific order and where each location is explicitly listed.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:LocationGroup">
+        <xs:sequence>
+          <xs:element name="locationContainedInGroup" type="loc:Location" minOccurs="2" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>A location contained in a non-ordered group of locations.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_locationGroupByListExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LocationGroupByReference">
+    <xs:annotation>
+      <xs:documentation>A group of (i.e. more than one) physically separate locations which have no specific order that are defined by reference to a predefined non ordered location group.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:LocationGroup">
+        <xs:sequence>
+          <xs:element name="predefinedLocationGroupReference" type="loc:_PredefinedLocationGroupVersionedReference" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>A reference to a versioned instance of a predefined location group as specified in a PredefinedLocationsPublication.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_locationGroupByReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="LocationReference" abstract="true">
+    <xs:annotation>
+      <xs:documentation>Represents one or more physically separate locations. Multiple locations may be related, as in an itinerary or route, or may be unrelated. One LocationReference should not use multiple Location objects to represent the same physical location.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="_locationReferenceExtension" type="loc:_LocationReferenceExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="NamedArea">
+    <xs:annotation>
+      <xs:documentation>An area defined by a name and/or in terms of known boundaries, such as country or county boundaries or allocated control area of particular authority. The attributes do not form a union; instead, the smallest intersection forms the resulting area.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="com:NamedArea">
+        <xs:sequence>
+          <xs:element name="areaName" type="com:MultilingualString" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The name of the area.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="namedAreaType" type="loc:_NamedAreaTypeEnum" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The type of the area.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="country" type="com:CountryCode" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>EN ISO 3166-1 two-character country code.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_namedAreaExtension" type="loc:_NamedAreaExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="NamedAreaTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of areas.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="applicationRegion">
+        <xs:annotation>
+          <xs:documentation>Application region</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="continent">
+        <xs:annotation>
+          <xs:documentation>Continent</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="country">
+        <xs:annotation>
+          <xs:documentation>Country</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="countryGroup">
+        <xs:annotation>
+          <xs:documentation>Group of countries.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="carParkArea">
+        <xs:annotation>
+          <xs:documentation>Car park area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="carpoolArea">
+        <xs:annotation>
+          <xs:documentation>Carpool area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fuzzyArea">
+        <xs:annotation>
+          <xs:documentation>Fuzzy area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="industrialArea">
+        <xs:annotation>
+          <xs:documentation>Industrial area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lake">
+        <xs:annotation>
+          <xs:documentation>Lake</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="meteorologicalArea">
+        <xs:annotation>
+          <xs:documentation>Meteorological area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="metropolitanArea">
+        <xs:annotation>
+          <xs:documentation>Metropolitan area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="municipality">
+        <xs:annotation>
+          <xs:documentation>Municipality</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="parkAndRideSite">
+        <xs:annotation>
+          <xs:documentation>A park and ride site</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ruralCounty">
+        <xs:annotation>
+          <xs:documentation>Rural county</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sea">
+        <xs:annotation>
+          <xs:documentation>Sea</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="touristArea">
+        <xs:annotation>
+          <xs:documentation>Tourist area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="trafficArea">
+        <xs:annotation>
+          <xs:documentation>Traffic area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="urbanCounty">
+        <xs:annotation>
+          <xs:documentation>Urban county</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="order1AdministrativeArea">
+        <xs:annotation>
+          <xs:documentation>Order 1 administrative area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="order2AdministrativeArea">
+        <xs:annotation>
+          <xs:documentation>Order 2 administrative area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="order3AdministrativeArea">
+        <xs:annotation>
+          <xs:documentation>Order 3 administrative area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="order4AdministrativeArea">
+        <xs:annotation>
+          <xs:documentation>Order 4 administrative area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="order5AdministrativeArea">
+        <xs:annotation>
+          <xs:documentation>Order 5 administrative area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="policeForceControlArea">
+        <xs:annotation>
+          <xs:documentation>Police force control area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadOperatorControlArea">
+        <xs:annotation>
+          <xs:documentation>Road operator control area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="waterArea">
+        <xs:annotation>
+          <xs:documentation>Water area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="NetworkLocation" abstract="true">
+    <xs:annotation>
+      <xs:documentation>The specification of a location on a network (as a point or a linear location).</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:Location">
+        <xs:sequence>
+          <xs:element name="supplementaryPositionalDescription" type="loc:SupplementaryPositionalDescription" minOccurs="0" />
+          <xs:element name="destination" type="loc:Destination" minOccurs="0" />
+          <xs:element name="_networkLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="NutsCode">
+    <xs:annotation>
+      <xs:documentation>A NUTS code (Nomenclature of territorial units for statistics).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:String">
+      <xs:maxLength value="5" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="NutsCodeTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of NUTS codes (Nomenclature of territorial units for statistics) including LAU codes (Local Administrative Units).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="nuts1Code">
+        <xs:annotation>
+          <xs:documentation>NUTS 1 code</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="nuts2Code">
+        <xs:annotation>
+          <xs:documentation>NUTS 2 code</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="nuts3Code">
+        <xs:annotation>
+          <xs:documentation>NUTS 3 code</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lau1Code">
+        <xs:annotation>
+          <xs:documentation>LAU 1 code</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lau2Code">
+        <xs:annotation>
+          <xs:documentation>LAU 2 code</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="NutsNamedArea">
+    <xs:annotation>
+      <xs:documentation>The NUTS-Code representation for the named area (Nomenclature of territorial units for statistics) or its LAU code representation (Local Administrative Unit).</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:NamedArea">
+        <xs:sequence>
+          <xs:element name="nutsCodeType" type="loc:_NutsCodeTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The NUTS code type for the named area.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="nutsCode" type="loc:NutsCode" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The NUTS code for the named area.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_nutsNamedAreaExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OffsetDistance">
+    <xs:annotation>
+      <xs:documentation>The non-negative offset distance from the ALERT-C referenced point to the actual point.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="offsetDistance" type="com:MetresAsNonNegativeInteger" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The non-negative offset distance from the ALERT-C referenced point to the actual point. The ALERT-C locations in the primary and secondary locations must always encompass the linear section being specified, thus offset distance is towards the other point.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_offsetDistanceExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OpenlrAreaLocationReference" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A two-dimensional part of the surface of the earth which is bounded by a closed curve. An area location may cover parts of the road network but does not necessarily need to. It is represented according to the OpenLR standard for Area Locations</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="_openlrAreaLocationReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OpenlrBasePointLocation" abstract="true">
+    <xs:annotation>
+      <xs:documentation>Holds common data that are used both in OpenlrPointAccessPoint and OpenlrPointAlongLine.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrPointLocationReference">
+        <xs:sequence>
+          <xs:element name="openlrSideOfRoad" type="loc:_OpenlrSideOfRoadEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Provides the of road where the corresponding point lies.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="openlrOrientation" type="loc:_OpenlrOrientationEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Orientation of the driving direction in relation with the direction of the underlying linear</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="openlrLocationReferencePoint" type="loc:OpenlrLocationReferencePoint">
+            <xs:annotation>
+              <xs:documentation>Allows defining the first point of the OpenLR path</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="openlrLastLocationReferencePoint" type="loc:OpenlrLastLocationReferencePoint">
+            <xs:annotation>
+              <xs:documentation>Allows defining the last point of the OpenLR path</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="openlrOffsets" type="loc:OpenlrOffsets" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Provides optional offsets relative to the path</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_openlrBasePointLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OpenlrBaseReferencePoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>Base class used to hold data about a reference point.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="openlrCoordinates" type="loc:PointCoordinates">
+        <xs:annotation>
+          <xs:documentation>Provides coordinates for the base point of the OpenLR path</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="openlrLineAttributes" type="loc:OpenlrLineAttributes">
+        <xs:annotation>
+          <xs:documentation>Properties of the line towards the topologically adjacent OpenLR location referencing point, on the shortest path to that point.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_openlrBaseReferencePointExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OpenlrCircleLocationReference">
+    <xs:annotation>
+      <xs:documentation>The OpenLR method of area definition by providing a center position and a radius</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrAreaLocationReference">
+        <xs:sequence>
+          <xs:element name="openlrRadius" type="com:MetresAsNonNegativeInteger" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The radius of the corresponding circular area.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="openlrGeoCoordinate" type="loc:OpenlrGeoCoordinate" />
+          <xs:element name="_openlrCircleLocationReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OpenlrClosedLineLocationReference">
+    <xs:annotation>
+      <xs:documentation>The OpenLR method of area definition by providing a closed path (i.e. a circuit) in the road network.
+The boundary always consists of road segments</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrAreaLocationReference">
+        <xs:sequence>
+          <xs:element name="openlrLocationReferencePoint" type="loc:OpenlrLocationReferencePoint" maxOccurs="unbounded" />
+          <xs:element name="openlrLastLine" type="loc:OpenlrLastLocationReferencePoint">
+            <xs:annotation>
+              <xs:documentation>Provides the line attributes for the last line section closing the polygon.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_openlrClosedLineLocationReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="OpenlrFormOfWayEnum">
+    <xs:annotation>
+      <xs:documentation>Enumeration of for of way</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="undefined">
+        <xs:annotation>
+          <xs:documentation>Undefined</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="motorway">
+        <xs:annotation>
+          <xs:documentation>Motorway</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="multipleCarriageway">
+        <xs:annotation>
+          <xs:documentation>Multiple carriageway</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="singleCarriageway">
+        <xs:annotation>
+          <xs:documentation>Single carriageway</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roundabout">
+        <xs:annotation>
+          <xs:documentation>Roundabout</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="slipRoad">
+        <xs:annotation>
+          <xs:documentation>Slip road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="trafficSquare">
+        <xs:annotation>
+          <xs:documentation>Traffic square</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="OpenlrFunctionalRoadClassEnum">
+    <xs:annotation>
+      <xs:documentation>Enumeration of functional road class</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="frc0">
+        <xs:annotation>
+          <xs:documentation>Main road, highest importance</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="frc1">
+        <xs:annotation>
+          <xs:documentation>First class road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="frc2">
+        <xs:annotation>
+          <xs:documentation>Second class road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="frc3">
+        <xs:annotation>
+          <xs:documentation>Third class road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="frc4">
+        <xs:annotation>
+          <xs:documentation>Fourth class road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="frc5">
+        <xs:annotation>
+          <xs:documentation>Fifth class road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="frc6">
+        <xs:annotation>
+          <xs:documentation>Sixth class road</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="frc7">
+        <xs:annotation>
+          <xs:documentation>Other class road, lowest importance</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="OpenlrGeoCoordinate">
+    <xs:annotation>
+      <xs:documentation>A geo-coordinate pair is a position in a map defined by its longitude and latitude coordinate values.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrPointLocationReference">
+        <xs:sequence>
+          <xs:element name="openlrCoordinates" type="loc:PointCoordinates">
+            <xs:annotation>
+              <xs:documentation>Corresponding coordinates of an OpenLR point defined by its only coordinates.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_openlrGeoCoordinateExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OpenlrGridLocationReference">
+    <xs:annotation>
+      <xs:documentation>Area defined using an OpenLR™ method consisting in defining it by a tessellation of rectangles</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrAreaLocationReference">
+        <xs:sequence>
+          <xs:element name="openlrNumColumns" type="com:NonNegativeInteger" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The number that the base rectangle should be multiplied in the east direction</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="openlrNumRows" type="com:NonNegativeInteger" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The number that the base rectangle should be multiplied in the north direction</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="openlrRectangle" type="loc:OpenlrRectangle" />
+          <xs:element name="_openlrGridLocationReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OpenlrLastLocationReferencePoint">
+    <xs:annotation>
+      <xs:documentation>The sequence of location reference points is terminated by a last location reference point.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrBaseReferencePoint">
+        <xs:sequence>
+          <xs:element name="_openlrLastLocationReferencePointExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OpenlrLinear">
+    <xs:annotation>
+      <xs:documentation>OpenLR line location reference</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="firstDirection" type="loc:OpenlrLineLocationReference">
+        <xs:annotation>
+          <xs:documentation>First OpenLR reference in first/main direction.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="oppositeDirection" type="loc:OpenlrLineLocationReference" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>If both direction, this is the reference in the opposite direction against firstDirection.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_openlrLinearExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OpenlrLineAttributes">
+    <xs:annotation>
+      <xs:documentation>Line attributes are part of a location reference point and consists of functional road class (FRC),form of way (FOW) and bearing (BEAR) data.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="openlrFunctionalRoadClass" type="loc:_OpenlrFunctionalRoadClassEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Certain aspects of the physical form that a Road Element takes. It is based on a number of certain physical and traffic properties. (EN ISO 14825 § 7.2.85)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="openlrFormOfWay" type="loc:_OpenlrFormOfWayEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A classification based on the importance of the role that the Road Element (or Ferry Connection) performs in the connectivity of the total road network. (EN ISO 14825 § 7.2.88)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="openlrBearing" type="com:AngleInDegrees" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>defines the bearing field as an integer value between 0 and 359</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_openlrLineAttributesExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OpenlrLineLocationReference">
+    <xs:annotation>
+      <xs:documentation>A line location reference is defined by an ordered sequence of location reference points and a terminating last location reference point.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="openlrLocationReferencePoint" type="loc:OpenlrLocationReferencePoint" maxOccurs="unbounded" />
+      <xs:element name="openlrLastLocationReferencePoint" type="loc:OpenlrLastLocationReferencePoint" />
+      <xs:element name="openlrOffsets" type="loc:OpenlrOffsets" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Allows for adding offsets to the line location path defined by nodes when the starting (respectively ending) point does not coincide with a node.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_openlrLineLocationReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OpenlrLocationReferencePoint">
+    <xs:annotation>
+      <xs:documentation>The basis of a location reference is a sequence of location reference points (LRPs).</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrBaseReferencePoint">
+        <xs:sequence>
+          <xs:element name="openlrPathAttributes" type="loc:OpenlrPathAttributes">
+            <xs:annotation>
+              <xs:documentation>Additional path attributes relative to the next point</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_openlrLocationReferencePointExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OpenlrOffsets">
+    <xs:annotation>
+      <xs:documentation>Offsets are used to locate the start and end of a location more precisely than bounding to the nodes in a network.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="openlrPositiveOffset" type="com:MetresAsNonNegativeInteger" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The positive offset along the line of the location measured along the line reference path between the start point of the location reference and the starting node of the line reference path.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="openlrNegativeOffset" type="com:MetresAsNonNegativeInteger" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The negative offset along the line of the location measured along the line reference path between the end point of the location reference and the ending node of the line reference path.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_openlrOffsetsExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="OpenlrOrientationEnum">
+    <xs:annotation>
+      <xs:documentation>Enumeration of orientation</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="noOrientationOrUnknown">
+        <xs:annotation>
+          <xs:documentation>No orientation or unknown</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="withLineDirection">
+        <xs:annotation>
+          <xs:documentation>With line direction</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="againstLineDirection">
+        <xs:annotation>
+          <xs:documentation>Against line direction</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="both">
+        <xs:annotation>
+          <xs:documentation>Both directions</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="OpenlrPathAttributes">
+    <xs:annotation>
+      <xs:documentation>Properties of the path from the associated location reference point to the next location reference point, which are specified to assist correct identification of the point in an external map data source.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="openlrLowestFrcToNextLRPoint" type="loc:_OpenlrFunctionalRoadClassEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The lowest FRC to the next point indicates the lowest functional road class used in the location reference path to the next LR-point.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="openlrDistanceToNextLRPoint" type="com:NonNegativeInteger" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The DNP attribute measures the distance in meters between two consecutive location reference-points along the location reference path described in the corresponding enumeration</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_openlrPathAttributesExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OpenlrPointAlongLine">
+    <xs:annotation>
+      <xs:documentation>Point along a line</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrBasePointLocation">
+        <xs:sequence>
+          <xs:element name="_openlrPointAlongLineExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OpenlrPointLocationReference" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A point location is a zero-dimensional element in a map that specifies a geometric location.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="_openlrPointLocationReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OpenlrPoiWithAccessPoint">
+    <xs:annotation>
+      <xs:documentation>A point of interest (POI) along a line with access is a point location which is defined by a linear reference path, an offset value (defining the access point) from the starting node of this path and a coordinate pair that defines the POI itself.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrBasePointLocation">
+        <xs:sequence>
+          <xs:element name="openlrCoordinates" type="loc:PointCoordinates">
+            <xs:annotation>
+              <xs:documentation>The coordinate of the actual point of interest</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_openlrPoiWithAccessPointExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OpenlrPolygonCorners">
+    <xs:annotation>
+      <xs:documentation>A geodetic coordinate Tuple that defines the vertices of the underlying geometrical polygon.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="openlrCoordinates" type="loc:PointCoordinates" minOccurs="3" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Corresponding coordinates of vertices that define a polygon.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_openlrPolygonCornersExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OpenlrPolygonLocationReference">
+    <xs:annotation>
+      <xs:documentation>The OpenLR method of area definition by providing points that bound the area</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrAreaLocationReference">
+        <xs:sequence>
+          <xs:element name="openlrPolygonCorners" type="loc:OpenlrPolygonCorners" />
+          <xs:element name="_openlrPolygonLocationReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OpenlrRectangle">
+    <xs:annotation>
+      <xs:documentation>Area delimited by a rectangle defined by the geodetic co-ordinates of the two ends of its diagonal from south-west to north-east (the rectangle having two sides that are parallel to lines of latitude)</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="openlrLowerLeft" type="loc:PointCoordinates">
+        <xs:annotation>
+          <xs:documentation>The lower left corner of the rectangle.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="openlrUpperRight" type="loc:PointCoordinates">
+        <xs:annotation>
+          <xs:documentation>The upper right corner of the rectangle.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_openlrRectangleExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="OpenlrRectangleLocationReference">
+    <xs:annotation>
+      <xs:documentation>The openLR method of area definition by providing a rectangular shape defined by two geo-coordinate pairs</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:OpenlrAreaLocationReference">
+        <xs:sequence>
+          <xs:element name="openlrRectangle" type="loc:OpenlrRectangle" />
+          <xs:element name="_openlrRectangleLocationReferenceExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="OpenlrSideOfRoadEnum">
+    <xs:annotation>
+      <xs:documentation>Enumeration of side of road</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="onRoadOrUnknown">
+        <xs:annotation>
+          <xs:documentation>On road or unknown</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="right">
+        <xs:annotation>
+          <xs:documentation>On the right side of the road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="left">
+        <xs:annotation>
+          <xs:documentation>On the left side of the road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="both">
+        <xs:annotation>
+          <xs:documentation>On both sides of the road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="PercentageDistanceAlongLinearElement">
+    <xs:annotation>
+      <xs:documentation>Distance of a point along a linear element measured from the start node expressed as a percentage of the whole length of the linear element, where start node is relative to the element definition rather than the direction of traffic flow.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:DistanceAlongLinearElement">
+        <xs:sequence>
+          <xs:element name="percentageDistanceAlong" type="com:Percentage" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>A measure of distance along a linear element from the start of the element expressed as a percentage of the total length of the linear object.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_percentageDistanceAlongLinearElementExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="PointAlongLinearElement">
+    <xs:annotation>
+      <xs:documentation>A point on a linear element where the linear element is either a part of or the whole of a linear object (i.e. a road), consistent with EN ISO 19148 definitions. </xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="administrativeAreaOfPoint" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Identification of the road administration area which contains the specified point.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="directionAtPoint" type="loc:_DirectionEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The direction of traffic flow at the specified point in terms of general destination direction.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="directionRelativeAtPoint" type="loc:_LinearDirectionEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The direction of traffic flow at the specified point relative to the direction in which the linear element is defined.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="heightGradeOfPoint" type="loc:_HeightGradeEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Identification of whether the point on the linear element is at, above or below the normal elevation of a linear element of that type (e.g. road or road section) at that location, typically used to indicate "grade" separation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="linearElement" type="loc:LinearElement" />
+      <xs:element name="distanceAlongLinearElement" type="loc:DistanceAlongLinearElement" />
+      <xs:element name="_pointAlongLinearElementExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PointByCoordinates">
+    <xs:annotation>
+      <xs:documentation>A single point defined only by a coordinate set with an optional bearing direction.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="bearing" type="com:AngleInDegrees" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A bearing at the point measured in degrees (0 - 359). Unless otherwise specified the reference direction corresponding to 0 degrees is North.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="pointCoordinates" type="loc:PointCoordinates" />
+      <xs:element name="_pointByCoordinatesExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PointCoordinates">
+    <xs:annotation>
+      <xs:documentation>A pair of planar coordinates defining the geodetic position of a single point using the European Terrestrial Reference System 1989 (ETRS89).</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="latitude" type="com:Float" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Latitude in decimal degrees using the European Terrestrial Reference System 1989 (ETRS89).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="longitude" type="com:Float" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Longitude in decimal degrees using the European Terrestrial Reference System 1989 (ETRS89).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="heightCoordinate" type="loc:HeightCoordinate" minOccurs="0" maxOccurs="3" />
+      <xs:element name="positionConfidenceEllipse" type="loc:PositionConfidenceEllipse" minOccurs="0" />
+      <xs:element name="horizontalPositionAccuracy" type="loc:PositionAccuracy" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Defines the horizontal position accuracy according EN 16803-1</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_pointCoordinatesExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PointDestination">
+    <xs:annotation>
+      <xs:documentation>The specification of the destination of a defined route or itinerary which is a point.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:Destination">
+        <xs:sequence>
+          <xs:element name="pointLocation" type="loc:PointLocation" />
+          <xs:element name="_pointDestinationExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="PointLocation">
+    <xs:annotation>
+      <xs:documentation>Location representing a single geospatial point.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:NetworkLocation">
+        <xs:sequence>
+          <xs:element name="pointByCoordinates" type="loc:PointByCoordinates" minOccurs="0" />
+          <xs:element name="pointAlongLinearElement" type="loc:PointAlongLinearElement" minOccurs="0" maxOccurs="unbounded" />
+          <xs:element name="alertCPoint" type="loc:AlertCPoint" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>The point location expressed using AlertC. Multiple instances of AlertCPoint shall represent the same real-world geographic feature.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="tpegPointLocation" type="loc:TpegPointLocation" minOccurs="0" />
+          <xs:element name="openlrPointLocationReference" type="loc:OpenlrPointLocationReference" minOccurs="0" />
+          <xs:element name="_pointLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="PositionAccuracy">
+    <xs:annotation>
+      <xs:documentation>Horizontal position accuracy parameters defined according to EN 16803-1</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="accuracyPercentile50" type="com:MetresAsFloat" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Accuracy defined by the 50th percentile of the cumulative distribution of position errors.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="accuracyPercentile75" type="com:MetresAsFloat" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Accuracy defined by the 75th percentile of the cumulative distribution of position errors</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="accuracyPercentile95" type="com:MetresAsFloat" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Accuracy defined by the 95th percentile of the cumulative distribution of position errors</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_positionAccuracyExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="PositionConfidenceCodedErrorEnum">
+    <xs:annotation>
+      <xs:documentation>Error code for horizontal or vertical position confidence</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="outOfRange">
+        <xs:annotation>
+          <xs:documentation>Indicates the accuracy is out of range, i.e. greater than 4 093 cm for horizontal position.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unavailable">
+        <xs:annotation>
+          <xs:documentation>Indicates the accuracy information is unavailable.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="PositionConfidenceEllipse">
+    <xs:annotation>
+      <xs:documentation>Confidence ellipse position defined in a shape of ellipse with a predefined confidence level (e.g. 95 %). The centre of the ellipse shape corresponds to the reference position point for which the position accuracy is evaluated.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="semiMajorAxisLength" type="com:MetresAsFloat" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Half of length of the major axis, i.e. distance between the centre point and major axis point of the position accuracy ellipse.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="semiMajorAxisLengthCodedError" type="loc:_PositionConfidenceCodedErrorEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Provides a coded error in case the semi-major axis length is not defined</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="semiMinorAxisLength" type="com:MetresAsFloat" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Half of length of the minor axis, i.e. distance between the centre point and minor axis point of the position accuracy ellipse</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="semiMinorAxisLengthCodedError" type="loc:_PositionConfidenceCodedErrorEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Provides a coded error in case the semi-minor axis length is not defined</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="semiMajorAxisOrientation" type="com:AngleInDegrees" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Orientation direction of the ellipse major axis of the position accuracy ellipse with regards to the geographic north.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="semiMajorAxisOrientationError" type="com:Boolean" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Indicates whether the ellipse orientation is unavailable (True) or not (False)</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_positionConfidenceEllipseExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="Referent">
+    <xs:annotation>
+      <xs:documentation>A referent on a linear object that has a known location such as a node, a reference marker (e.g. a marker-post), an intersection etc.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="referentIdentifier" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The identifier of the referent, unique on the specified linear element (i.e. road or part of).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="referentName" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The name of the referent, e.g. a junction or intersection name.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="referentType" type="loc:_ReferentTypeEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The type of the referent.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="referentDescription" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Description of the referent.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="pointCoordinates" type="loc:PointCoordinates" minOccurs="0" />
+      <xs:element name="_referentExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="ReferentTypeEnum">
+    <xs:annotation>
+      <xs:documentation>A set of types of known points along a linear object such as a road.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="boundary">
+        <xs:annotation>
+          <xs:documentation>A boundary between two jurisdictional or administrative areas. These may be legal boundaries such as between counties or countries, maintenance responsibility boundaries or control boundaries. </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="intersection">
+        <xs:annotation>
+          <xs:documentation>A crossing of two or more roads where the precise point of intersection is defined according to specific business rules.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="referenceMarker">
+        <xs:annotation>
+          <xs:documentation>A marker which is usually but not necessarily physical that is one of a sequence which are spaced out along the linear object (road) to provide a location reference. The spacing of markers is not necessarily even.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="landmark">
+        <xs:annotation>
+          <xs:documentation>A visible identifiable physical landmark either alongside or close to the linear object.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadNode">
+        <xs:annotation>
+          <xs:documentation>A topological node defined on a road network. Such nodes may delineate the segmentation of the road network according to defined business rules or may constitute a purely topological representation of a road network.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="RelativePositionOnCarriagewayEnum">
+    <xs:annotation>
+      <xs:documentation>Identifies a relative position across a carriageway</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="inTheCentre">
+        <xs:annotation>
+          <xs:documentation>In the centre of the roadway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onTheLeft">
+        <xs:annotation>
+          <xs:documentation>On the left of the roadway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="onTheRight">
+        <xs:annotation>
+          <xs:documentation>On the right of the roadway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="RoadInformation">
+    <xs:annotation>
+      <xs:documentation>Information on a road</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="roadDestination" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A destination associated with this road.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="roadName" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The name of the road</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="roadNumber" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The road number designated by the road authority</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_roadInformationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SingleRoadLinearLocation">
+    <xs:annotation>
+      <xs:documentation>Location representing a linear section along a single road with optional directionality defined between two points on the same road. No matter the kind of linear reference it uses, the constraint of using only a single road must be preserved.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:LinearLocation">
+        <xs:sequence>
+          <xs:element name="tpegLinearLocation" type="loc:TpegLinearLocation" minOccurs="0" />
+          <xs:element name="alertCLinear" type="loc:AlertCLinear" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>The linear location expressed using AlertC. Multiple instances of AlertCLinear shall represent the same real-world geographic feature.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="linearWithinLinearElement" type="loc:LinearWithinLinearElement" minOccurs="0" maxOccurs="unbounded" />
+          <xs:element name="_singleRoadLinearLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="SubdivisionCode">
+    <xs:annotation>
+      <xs:documentation>The second part of an ISO 3166-2 country sub-division code (up to 3 characters) which may be used along with a CountryCode to make a full ISO 3166-2 subdivision code.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:String">
+      <xs:maxLength value="3" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="SubdivisionTypeEnum">
+    <xs:annotation>
+      <xs:documentation>ISO 3166-2 subdivison types.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="administrativeAtoll">
+        <xs:annotation>
+          <xs:documentation>Administrative atoll</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="administrativeRegion">
+        <xs:annotation>
+          <xs:documentation>Administrative region</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="administrativeTerritory">
+        <xs:annotation>
+          <xs:documentation>Administrative territory</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="arcticRegion">
+        <xs:annotation>
+          <xs:documentation>Arctic region</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="autonomousCity">
+        <xs:annotation>
+          <xs:documentation>Autonomous city</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="autonomousCityInNorthAfrica">
+        <xs:annotation>
+          <xs:documentation>Autonomous city in North Africa</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="autonomousCommunity">
+        <xs:annotation>
+          <xs:documentation>Autonomous community</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="autonomousDistrict">
+        <xs:annotation>
+          <xs:documentation>Autonomous district</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="autonomousProvince">
+        <xs:annotation>
+          <xs:documentation>Autonomous province</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="autonomousRegion">
+        <xs:annotation>
+          <xs:documentation>Autonomous region</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="canton">
+        <xs:annotation>
+          <xs:documentation>Canton</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="capitalCity">
+        <xs:annotation>
+          <xs:documentation>Capital city</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="city">
+        <xs:annotation>
+          <xs:documentation>City</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="cityMunicipality">
+        <xs:annotation>
+          <xs:documentation>City municipality</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="cityOfCountyRight">
+        <xs:annotation>
+          <xs:documentation>City of county right</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="commune">
+        <xs:annotation>
+          <xs:documentation>Commune</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="councilArea">
+        <xs:annotation>
+          <xs:documentation>Council area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="county">
+        <xs:annotation>
+          <xs:documentation>County</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="country">
+        <xs:annotation>
+          <xs:documentation>Country</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="department">
+        <xs:annotation>
+          <xs:documentation>Department</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="dependency">
+        <xs:annotation>
+          <xs:documentation>Dependency</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="district">
+        <xs:annotation>
+          <xs:documentation>District</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="districtMunicipality">
+        <xs:annotation>
+          <xs:documentation>District municipality</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="districtWithSpecialStatus">
+        <xs:annotation>
+          <xs:documentation>District with special status</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="entity">
+        <xs:annotation>
+          <xs:documentation>Entity</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="geographicalEntity">
+        <xs:annotation>
+          <xs:documentation>Geographical entity</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="governorate">
+        <xs:annotation>
+          <xs:documentation>Governorate</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="laender">
+        <xs:annotation>
+          <xs:documentation>Länder</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="localCouncil">
+        <xs:annotation>
+          <xs:documentation>Local Council</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="londonBorough">
+        <xs:annotation>
+          <xs:documentation>London borough</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="metropolitanArea">
+        <xs:annotation>
+          <xs:documentation>Metropolitan area</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="metropolitanDepartment">
+        <xs:annotation>
+          <xs:documentation>Metropolitan department</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="metropolitanDistrict">
+        <xs:annotation>
+          <xs:documentation>Metropolitan district</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="metropolitanRegion">
+        <xs:annotation>
+          <xs:documentation>Metropolitan region</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="municipality">
+        <xs:annotation>
+          <xs:documentation>Municipality</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="overseasDepartment">
+        <xs:annotation>
+          <xs:documentation>Overseas department</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="overseasRegion">
+        <xs:annotation>
+          <xs:documentation>Overseas region</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="overseasTerritorialCollectivity">
+        <xs:annotation>
+          <xs:documentation>Overseas territorial collectivity</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="parish">
+        <xs:annotation>
+          <xs:documentation>Parish</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="province">
+        <xs:annotation>
+          <xs:documentation>Province</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="quarter">
+        <xs:annotation>
+          <xs:documentation>Quarter</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="region">
+        <xs:annotation>
+          <xs:documentation>Region</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="republic">
+        <xs:annotation>
+          <xs:documentation>Republic</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="republicanCity">
+        <xs:annotation>
+          <xs:documentation>Republic city</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="selfGovernedPart">
+        <xs:annotation>
+          <xs:documentation>Self-governed part</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="specialMunicipality">
+        <xs:annotation>
+          <xs:documentation>Special Municipality</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="state">
+        <xs:annotation>
+          <xs:documentation>State</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="territorialUnit">
+        <xs:annotation>
+          <xs:documentation>Territorial unit</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="territory">
+        <xs:annotation>
+          <xs:documentation>Territory</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="twoTierCounty">
+        <xs:annotation>
+          <xs:documentation>Two tier country</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unitaryAuthority">
+        <xs:annotation>
+          <xs:documentation>Unitary Authority</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ward">
+        <xs:annotation>
+          <xs:documentation>Ward</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="SupplementaryPositionalDescription">
+    <xs:annotation>
+      <xs:documentation>A collection of supplementary positional information which improves the precision of the location.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="directionPurpose" type="loc:_DirectionPurposeEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Identifies the main purpose of the road at the location</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="geographicDescriptor" type="loc:_GeographicCharacteristicEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Descriptor which identifies a geographic characteristic to help identify the specific location</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="infrastructureDescriptor" type="loc:_InfrastructureDescriptorEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Descriptor which identifies infrastructure to help identify the specific location.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="lengthAffected" type="com:MetresAsFloat" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>This indicates the length (measured in metres) of carriageway (and lanes) affected by the associated traffic element.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="locationDescription" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Supplementary human-readable description of the location</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="positionOnCarriageway" type="loc:_RelativePositionOnCarriagewayEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Relative position across carriageway</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="sequentialRampNumber" type="com:NonNegativeInteger" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The sequential number of an exit/entrance ramp from a given location in a given direction (normally used to indicate a specific exit/entrance in a complex junction/intersection).</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="carriageway" type="loc:Carriageway" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="namedArea" type="loc:NamedArea" minOccurs="0" />
+      <xs:element name="roadInformation" type="loc:RoadInformation" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Information on a set of one or more roads. The location could correspond to a part of the road identified, the whole stretch of road identified, or a combination of multiple road sections.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_supplementaryPositionalDescriptionExtension" type="loc:_SupplementaryPositionalDescriptionExtensionType" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="locationPrecision" type="com:MetresAsNonNegativeInteger" use="optional">
+      <xs:annotation>
+        <xs:documentation>Indicates that the location is given with a precision which is better than the stated value in metres.</xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
+  </xs:complexType>
+  <xs:complexType name="TpegAreaDescriptor">
+    <xs:annotation>
+      <xs:documentation>A descriptor for describing an area location.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegDescriptor">
+        <xs:sequence>
+          <xs:element name="tpegAreaDescriptorType" type="loc:_TpegLoc03AreaDescriptorSubtypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The nature of the descriptor used to define the location under consideration (derived from the TPEG Loc table 03).</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_tpegAreaDescriptorExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TpegAreaLocation" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A geographic or geometric area defined by a TPEG-Loc structure which may include height information for additional geospatial discrimination.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="tpegAreaLocationType" type="loc:_TpegLoc01AreaLocationSubtypeEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The type of TPEG location.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="tpegHeight" type="loc:TpegHeight" minOccurs="0" />
+      <xs:element name="_tpegAreaLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TpegDescriptor" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A collection of information providing descriptive references to locations using the TPEG-Loc location referencing approach.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="descriptor" type="com:MultilingualString" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A text string which describes or elaborates the location.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_tpegDescriptorExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TpegFramedPoint">
+    <xs:annotation>
+      <xs:documentation>A point on the road network which is framed between two other points on the same road.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegPointLocation">
+        <xs:sequence>
+          <xs:element name="tpegFramedPointLocationType" type="loc:_TpegLoc01FramedPointLocationSubtypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The type of TPEG location.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="framedPoint" type="loc:TpegNonJunctionPoint">
+            <xs:annotation>
+              <xs:documentation>A single non-junction point on the road network which is framed between two other specified points on the road network.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="to" type="loc:TpegPoint">
+            <xs:annotation>
+              <xs:documentation>The location at the downstream end of the section of road which frames the TPEGFramedPoint.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="from" type="loc:TpegPoint">
+            <xs:annotation>
+              <xs:documentation>The location at the upstream end of the section of road which frames the TPEGFramedPoint.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_tpegFramedPointExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TpegGeometricArea">
+    <xs:annotation>
+      <xs:documentation>A geometric area defined by a centre point and a radius.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegAreaLocation">
+        <xs:sequence>
+          <xs:element name="radius" type="com:MetresAsNonNegativeInteger" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The radius of the corresponding circular area</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="centrePoint" type="loc:PointCoordinates">
+            <xs:annotation>
+              <xs:documentation>Centre point of a circular geometric area.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="name" type="loc:TpegAreaDescriptor" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Name of area.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_tpegGeometricAreaExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TpegHeight">
+    <xs:annotation>
+      <xs:documentation>Height information which provides additional discrimination for the applicable area.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="height" type="com:MetresAsFloat" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A measurement of height in metres</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="heightType" type="loc:_TpegLoc04HeightTypeEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A descriptive identification of relative height using TPEG-Loc location referencing.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_tpegHeightExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TpegIlcPointDescriptor">
+    <xs:annotation>
+      <xs:documentation>A descriptor for describing a junction by defining the intersecting roads.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegPointDescriptor">
+        <xs:sequence>
+          <xs:element name="tpegIlcPointDescriptorType" type="loc:_TpegLoc03IlcPointDescriptorSubtypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The nature of the descriptor used to define the location under consideration (derived from the TPEG Loc table 03).</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_tpegIlcPointDescriptorExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TpegJunction">
+    <xs:annotation>
+      <xs:documentation>A point on the road network which is a road junction point.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegPoint">
+        <xs:sequence>
+          <xs:element name="pointCoordinates" type="loc:PointCoordinates" />
+          <xs:element name="name" type="loc:TpegJunctionPointDescriptor" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>A name which identifies a junction point on the road network</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="ilc" type="loc:TpegIlcPointDescriptor" maxOccurs="3">
+            <xs:annotation>
+              <xs:documentation>A descriptor for describing a junction by identifying the intersecting roads at a road junction.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="otherName" type="loc:TpegOtherPointDescriptor" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>A descriptive name which helps to identify the junction point.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_tpegJunctionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TpegJunctionPointDescriptor">
+    <xs:annotation>
+      <xs:documentation>A descriptor for describing a point at a junction on a road network.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegPointDescriptor">
+        <xs:sequence>
+          <xs:element name="tpegJunctionPointDescriptorType" type="loc:_TpegLoc03JunctionPointDescriptorSubtypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The nature of the descriptor used to define the location under consideration (derived from the TPEG Loc table 03).</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_tpegJunctionPointDescriptorExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TpegLinearLocation">
+    <xs:annotation>
+      <xs:documentation>A linear section along a single road defined between two points on the same road by a TPEG-Loc structure.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="tpegDirection" type="loc:_DirectionEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The direction of traffic flow.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="tpegLinearLocationType" type="loc:_TpegLoc01LinearLocationSubtypeEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The type of TPEG location.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="to" type="loc:TpegPoint">
+        <xs:annotation>
+          <xs:documentation>The location at the down stream end of the linear section of road.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="from" type="loc:TpegPoint">
+        <xs:annotation>
+          <xs:documentation>The location at the up stream end of the linear section of road.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_tpegLinearLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="TpegLoc01AreaLocationSubtypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of area.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="largeArea">
+        <xs:annotation>
+          <xs:documentation>A geographic or geometric large area.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other than as defined in this enumeration.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TpegLoc01FramedPointLocationSubtypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of points on the road network framed by two other points on the same road.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="framedPoint">
+        <xs:annotation>
+          <xs:documentation>A point on the road network framed by two other points on the same road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TpegLoc01LinearLocationSubtypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of linear location.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="segment">
+        <xs:annotation>
+          <xs:documentation>A segment (or link) of the road network corresponding to the way in which the road operator has segmented the network.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TpegLoc01SimplePointLocationSubtypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of simple point.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="intersection">
+        <xs:annotation>
+          <xs:documentation>An point on the road network at which one or more roads intersect.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="nonLinkedPoint">
+        <xs:annotation>
+          <xs:documentation>A point on the road network which is not at a junction or intersection.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TpegLoc03AreaDescriptorSubtypeEnum">
+    <xs:annotation>
+      <xs:documentation>Descriptors for describing area locations.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="administrativeAreaName">
+        <xs:annotation>
+          <xs:documentation>Name of an administrative area.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="administrativeReferenceName">
+        <xs:annotation>
+          <xs:documentation>Reference name by which administrative area is known.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="areaName">
+        <xs:annotation>
+          <xs:documentation>Name of an area.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="countyName">
+        <xs:annotation>
+          <xs:documentation>Name of a county (administrative sub-division).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lakeName">
+        <xs:annotation>
+          <xs:documentation>Name of a lake.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="nationName">
+        <xs:annotation>
+          <xs:documentation>Name of a nation (e.g. Wales) which is a sub-division of a ISO recognised country.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="policeForceControlAreaName">
+        <xs:annotation>
+          <xs:documentation>Name of a police force control area.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="regionName">
+        <xs:annotation>
+          <xs:documentation>Name of a geographic region.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="seaName">
+        <xs:annotation>
+          <xs:documentation>Name of a sea.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="townName">
+        <xs:annotation>
+          <xs:documentation>Name of a town.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other than as defined in this enumeration.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TpegLoc03IlcPointDescriptorSubtypeEnum">
+    <xs:annotation>
+      <xs:documentation>Descriptors for describing a junction by identifying the intersecting roads at a road junction.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="tpegIlcName1">
+        <xs:annotation>
+          <xs:documentation>The name of the road on which the junction point is located.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tpegIlcName2">
+        <xs:annotation>
+          <xs:documentation>The name of the first intersecting road at the junction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tpegIlcName3">
+        <xs:annotation>
+          <xs:documentation>The name of the second intersecting road (if one exists) at the junction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TpegLoc03JunctionPointDescriptorSubtypeEnum">
+    <xs:annotation>
+      <xs:documentation>Descriptors for describing a point at a road junction.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="junctionName">
+        <xs:annotation>
+          <xs:documentation>Name of a road network junction where two or more roads join.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TpegLoc03OtherPointDescriptorSubtypeEnum">
+    <xs:annotation>
+      <xs:documentation>Descriptors other than junction names and road descriptors which can help to identify the location of points on the road network.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="administrativeAreaName">
+        <xs:annotation>
+          <xs:documentation>Name of an administrative area.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="administrativeReferenceName">
+        <xs:annotation>
+          <xs:documentation>Reference name by which an administrative area is known.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="airportName">
+        <xs:annotation>
+          <xs:documentation>Name of an airport.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="areaName">
+        <xs:annotation>
+          <xs:documentation>Name of an area.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="buildingName">
+        <xs:annotation>
+          <xs:documentation>Name of a building.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="busStopIdentifier">
+        <xs:annotation>
+          <xs:documentation>Identifier of a bus stop on the road network.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="busStopName">
+        <xs:annotation>
+          <xs:documentation>Name of a bus stop on the road network.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="canalName">
+        <xs:annotation>
+          <xs:documentation>Name of a canal.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="countyName">
+        <xs:annotation>
+          <xs:documentation>Name of a county (administrative sub-division).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ferryPortName">
+        <xs:annotation>
+          <xs:documentation>Name of a ferry port.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="intersectionName">
+        <xs:annotation>
+          <xs:documentation>Name of a road network intersection.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lakeName">
+        <xs:annotation>
+          <xs:documentation>Name of a lake.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="linkName">
+        <xs:annotation>
+          <xs:documentation>Name of a road link.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="localLinkName">
+        <xs:annotation>
+          <xs:documentation>Local name of a road link.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="metroStationName">
+        <xs:annotation>
+          <xs:documentation>Name of a metro/underground station.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="nationName">
+        <xs:annotation>
+          <xs:documentation>Name of a nation (e.g. Wales) which is a sub-division of a ISO recognised country.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="nonLinkedPointName">
+        <xs:annotation>
+          <xs:documentation>Name of a point on the road network which is not at a junction or intersection. </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="parkingFacilityName">
+        <xs:annotation>
+          <xs:documentation>Name of a parking facility.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="pointName">
+        <xs:annotation>
+          <xs:documentation>Name of a specific point.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="pointOfInterestName">
+        <xs:annotation>
+          <xs:documentation>Name of a general point of interest.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="railwayStation">
+        <xs:annotation>
+          <xs:documentation>Name of a railway station.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="regionName">
+        <xs:annotation>
+          <xs:documentation>Name of a geographic region.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="riverName">
+        <xs:annotation>
+          <xs:documentation>Name of a river.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="seaName">
+        <xs:annotation>
+          <xs:documentation>Name of a sea.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="serviceAreaName">
+        <xs:annotation>
+          <xs:documentation>Name of a service area on a road network.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tidalRiverName">
+        <xs:annotation>
+          <xs:documentation>Name of a river which is of a tidal nature.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="townName">
+        <xs:annotation>
+          <xs:documentation>Name of a town.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other than as defined in this enumeration.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="TpegLoc04HeightTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of height.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="above">
+        <xs:annotation>
+          <xs:documentation>Height above specified location.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="aboveSeaLevel">
+        <xs:annotation>
+          <xs:documentation>Height above mean sea high water level.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="aboveStreetLevel">
+        <xs:annotation>
+          <xs:documentation>Height above street level.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="at">
+        <xs:annotation>
+          <xs:documentation>At height of specified location.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="atSeaLevel">
+        <xs:annotation>
+          <xs:documentation>At mean sea high water level.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="atStreetLevel">
+        <xs:annotation>
+          <xs:documentation>At street level.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="below">
+        <xs:annotation>
+          <xs:documentation>Height below specified location.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="belowSeaLevel">
+        <xs:annotation>
+          <xs:documentation>Height below mean sea high water level.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="belowStreetLevel">
+        <xs:annotation>
+          <xs:documentation>Height below street level.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="undefined">
+        <xs:annotation>
+          <xs:documentation>Undefined height reference.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unknown">
+        <xs:annotation>
+          <xs:documentation>Unknown height reference.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other than as defined in this enumeration.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TpegNamedOnlyArea">
+    <xs:annotation>
+      <xs:documentation>An area defined by a well-known name.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegAreaLocation">
+        <xs:sequence>
+          <xs:element name="name" type="loc:TpegAreaDescriptor" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>Name of area.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_tpegNamedOnlyAreaExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TpegNonJunctionPoint">
+    <xs:annotation>
+      <xs:documentation>A point on the road network which is not a road junction point.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegPoint">
+        <xs:sequence>
+          <xs:element name="pointCoordinates" type="loc:PointCoordinates" />
+          <xs:element name="name" type="loc:TpegOtherPointDescriptor" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>A descriptive name which helps to identify the non-junction point. At least one descriptor must identify the road on which the point is located, i.e. must be of type 'linkName' or 'localLinkName'.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_tpegNonJunctionPointExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TpegOtherPointDescriptor">
+    <xs:annotation>
+      <xs:documentation>General descriptor for describing a point.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegPointDescriptor">
+        <xs:sequence>
+          <xs:element name="tpegOtherPointDescriptorType" type="loc:_TpegLoc03OtherPointDescriptorSubtypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The nature of the descriptor used to define the location under consideration (derived from the TPEG Loc table 03).</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_tpegOtherPointDescriptorExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TpegPoint" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A point on the road network which is either a junction point or a non junction point.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="_tpegPointExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TpegPointDescriptor" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A descriptor for describing a point location.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegDescriptor">
+        <xs:sequence>
+          <xs:element name="_tpegPointDescriptorExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TpegPointLocation" abstract="true">
+    <xs:annotation>
+      <xs:documentation>A single point on the road network defined by a TPEG-Loc structure and which has an associated direction of traffic flow.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="tpegDirection" type="loc:_DirectionEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The direction of traffic flow.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_tpegPointLocationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TpegSimplePoint">
+    <xs:annotation>
+      <xs:documentation>A point on the road network which is not bounded by any other points on the road network.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:TpegPointLocation">
+        <xs:sequence>
+          <xs:element name="tpegSimplePointLocationType" type="loc:_TpegLoc01SimplePointLocationSubtypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The type of TPEG location.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="point" type="loc:TpegPoint">
+            <xs:annotation>
+              <xs:documentation>A single point defined by a coordinate set and TPEG descriptors.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_tpegSimplePointExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:schema>

--- a/spec/datex2/DATEXII_3_Parking.xsd
+++ b/spec/datex2/DATEXII_3_Parking.xsd
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:prk="http://datex2.eu/schema/3/parking" version="1" targetNamespace="http://datex2.eu/schema/3/parking" xmlns:com="http://datex2.eu/schema/3/common" xmlns:fac="http://datex2.eu/schema/3/facilities" xmlns:loc="http://datex2.eu/schema/3/locationReferencing" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="http://datex2.eu/schema/3/locationReferencing" schemaLocation="DATEXII_3_LocationReferencing.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/facilities" schemaLocation="DATEXII_3_Facilities.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/common" schemaLocation="DATEXII_3_Common.xsd" />
+  <xs:complexType name="_RoadTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="prk:RoadTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="RoadInformationEnhanced">
+    <xs:annotation>
+      <xs:documentation>Additional road information.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="loc:RoadInformation">
+        <xs:sequence>
+          <xs:element name="typeOfRoad" type="prk:_RoadTypeEnum" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Type of the road.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="roadOrigination" type="com:MultilingualString" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>Name of some city, area, compass direction or other identification this road comes from.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_roadInformationEnhancedExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="RoadTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Categorisation of the  road type (motorway,main road,...).</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="motorway">
+        <xs:annotation>
+          <xs:documentation>Motorway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="trunkRoad">
+        <xs:annotation>
+          <xs:documentation>Trunk road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="mainRoad">
+        <xs:annotation>
+          <xs:documentation>Main road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Other.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>

--- a/spec/datex2/DATEXII_3_TrafficRegulation.xsd
+++ b/spec/datex2/DATEXII_3_TrafficRegulation.xsd
@@ -1,0 +1,1905 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:tro="http://datex2.eu/schema/3/trafficRegulation" version="1" targetNamespace="http://datex2.eu/schema/3/trafficRegulation" xmlns:com="http://datex2.eu/schema/3/common" xmlns:loc="http://datex2.eu/schema/3/locationReferencing" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:import namespace="http://datex2.eu/schema/3/locationReferencing" schemaLocation="DATEXII_3_LocationReferencing.xsd" />
+  <xs:import namespace="http://datex2.eu/schema/3/common" schemaLocation="DATEXII_3_Common.xsd" />
+  <xs:complexType name="_AccessConditionTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:AccessConditionTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_AccessRestrictionTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:AccessRestrictionTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_AmbientWarningTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:AmbientWarningTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_ConditionOperator">
+    <xs:simpleContent>
+      <xs:extension base="tro:ConditionOperator">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_DirectionRestrictionTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:DirectionRestrictionTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_DriverCharacteristicsTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:DriverCharacteristicsTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_LicenseCharacteristicsEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:LicenseCharacteristicsEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_NonVehicularRoadUserTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:NonVehicularRoadUserTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_PriorityRuleTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:PriorityRuleTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_ReasonForRegulationEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:ReasonForRegulationEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_RoadOrCarriagewayOrLaneLayoutType">
+    <xs:simpleContent>
+      <xs:extension base="tro:RoadOrCarriagewayOrLaneLayoutType">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_RoadTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:RoadTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_RoadWarningTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:RoadWarningTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_StandingOrParkingRestricitonTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:StandingOrParkingRestricitonTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_SteepHillDirectionTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:SteepHillDirectionTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TrafficAheadTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:TrafficAheadTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TrafficRegulationInstallerTypeEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:TrafficRegulationInstallerTypeEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TrafficRegulationOrderStatusEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:TrafficRegulationOrderStatusEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_TrafficRegulationStatusEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:TrafficRegulationStatusEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="_UnitOfSpeedEnum">
+    <xs:simpleContent>
+      <xs:extension base="tro:UnitOfSpeedEnum">
+        <xs:attribute name="_extendedValue" type="xs:string" />
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  <xs:complexType name="AccessCondition">
+    <xs:annotation>
+      <xs:documentation>Conditions for the access of a road or carriageway or lane.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Condition">
+        <xs:sequence>
+          <xs:element name="accessConditionType" type="tro:_AccessConditionTypeEnum" minOccurs="1" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>Type of access condition.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="otherAccessRestriction" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Other access restriction not listed elsewhere.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="applicableLocation" type="loc:LocationReference" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Location where access condition applies.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_accessConditionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="AccessConditionTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Access is only permitted under certain conditions.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="accessOnly">
+        <xs:annotation>
+          <xs:documentation>Access only.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="destinationTraffic">
+        <xs:annotation>
+          <xs:documentation>Access is restricted, if the destination of traffic lies in a specific region.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="loadingAndUnloading">
+        <xs:annotation>
+          <xs:documentation>Loading or unloading of vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="passengerLoadingAndUnloading">
+        <xs:annotation>
+          <xs:documentation>Pick up or set down passengers.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sourceAndDestinationTraffic">
+        <xs:annotation>
+          <xs:documentation>Access is restricted, if the source and destination of traffic lies in a specific region.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sourceTraffic">
+        <xs:annotation>
+          <xs:documentation>Access is restricted, if the source of traffic lies in a specific region.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="throughTraffic">
+        <xs:annotation>
+          <xs:documentation>Access is restricted, if the traffic goes through a specific region.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="AccessRestriction">
+    <xs:annotation>
+      <xs:documentation>Class for access restriction, e.g. road closures for specific vehicle types.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="nonVehicularRoadUser" type="tro:_NonVehicularRoadUserTypeEnum" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Types of non vehicular road users for which the access restriction applies.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="accessRestrictionType" type="tro:_AccessRestrictionTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Type of access restriction.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_accessRestrictionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="AccessRestrictionTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of access restrictions.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="noEntry">
+        <xs:annotation>
+          <xs:documentation>No entry.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="noUseOfAudibleWarningDevices">
+        <xs:annotation>
+          <xs:documentation>The use of audible warning devices is prohibited.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="noPassingWithoutStopping">
+        <xs:annotation>
+          <xs:documentation>The driver must stop at the line to be able to respect the order by the customs officer or authority representatives.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="ActivatedRegulation">
+    <xs:annotation>
+      <xs:documentation>A general permission used currently to implement a traffic regulation.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="actor" type="com:MultilingualString" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Actor entitled by the regulation order  to install traffic regulations.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="issuingAuthority" type="com:MultilingualString" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The competent authority that issued a traffic regulation order that permits the actor to install traffic regulations.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="regulationId" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A (external) unique identification of the traffic regulation. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="trafficRegulation" type="tro:TrafficRegulation" maxOccurs="unbounded" />
+      <xs:element name="_activatedRegulationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AdHocTrafficRegulation">
+    <xs:annotation>
+      <xs:documentation>Ad hoc traffic regulations in urgent (usually safety relevant) situations without a traffic regulation order.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="installer" type="tro:_TrafficRegulationInstallerTypeEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The actor that decided to install the traffic regulation without traffic regulation order.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="trafficRegulation" type="tro:TrafficRegulation" maxOccurs="unbounded" />
+      <xs:element name="_adHocTrafficRegulationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AdHocTrafficRegulations">
+    <xs:annotation>
+      <xs:documentation>Traffic regulations implemented by road operators without formal order due to urgent safety requirements.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="adHocTrafficRegulation" type="tro:AdHocTrafficRegulation" maxOccurs="unbounded" />
+      <xs:element name="_adHocTrafficRegulationsExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="AlternateRoadOrCarriagewayOrLaneLayout">
+    <xs:annotation>
+      <xs:documentation>This class describes a regulation where a road/carriageway/lane has temporarily another layout.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="deviationToHardshoulder" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Traffic lanes move across to the right, making use of the hard shoulder.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="deviationToOtherCarrriageway" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Set this value to true if the road runs over the oncoming lane. Otherwise, no value should be assigned to the attribute.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="mergedToOtherLane" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation> Closure of a traffic lane, two lanes to one.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="yellowMarkings" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>This flag indicates whether the alternate road/carriageway/lane layout is indicated by yellow markings.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="roadOrCarriagewayOrLaneLayoutType" type="tro:_RoadOrCarriagewayOrLaneLayoutType" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Road or carriageway or lane layout type.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="newLayout" type="loc:LinearLocation" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Location of alternate road or carriageway or lane.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="speedLimit" type="tro:SpeedLimit" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Speed limit for alternate road or carriageway or lane.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_alternateRoadOrCarriagewayOrLaneLayoutExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="AmbientWarnings">
+    <xs:annotation>
+      <xs:documentation>Warnings about ambient factors i.e. conditions more likely to occur due to the location or surroundings of the road.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Warning">
+        <xs:sequence>
+          <xs:element name="ambientWarningsType" type="tro:_AmbientWarningTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Type of the ambient warning.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_ambientWarningsExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="AmbientWarningTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of environmental dangers.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="accompaniedHorsesCrossing">
+        <xs:annotation>
+          <xs:documentation>Accompanied horses or ponies likely to be in or crossing the road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="airfield">
+        <xs:annotation>
+          <xs:documentation>Low-flying aircraft or sudden aircraft noise.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="cattle">
+        <xs:annotation>
+          <xs:documentation>Cattle or other animals crossing.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fallingRocks">
+        <xs:annotation>
+          <xs:documentation>Risk of falling or fallen rocks.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="looseGravel">
+        <xs:annotation>
+          <xs:documentation>Loose gravel.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="migratoryToadCrossing">
+        <xs:annotation>
+          <xs:documentation>Migratory toad crossing.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="otherDanger">
+        <xs:annotation>
+          <xs:documentation>Other danger.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="pedestrianCrossing">
+        <xs:annotation>
+          <xs:documentation>Pedestrian crossing.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="quaysideOrRiverBank">
+        <xs:annotation>
+          <xs:documentation>Road leads on to quay or river.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="riskOfIce">
+        <xs:annotation>
+          <xs:documentation>Risk of ice.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sideWindsLeft">
+        <xs:annotation>
+          <xs:documentation>Side winds from left.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="sideWindsRight">
+        <xs:annotation>
+          <xs:documentation>Side winds from right.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="wildAnimalsCrossing">
+        <xs:annotation>
+          <xs:documentation>Cattle or other animals crossing.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="insufficientStructureGauge">
+        <xs:annotation>
+          <xs:documentation>Insufficient structure gauge.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="poorVisibility">
+        <xs:annotation>
+          <xs:documentation>Poor visibility through snow, rain and fog.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="AmountOfMoney">
+    <xs:annotation>
+      <xs:documentation>A monetary value expressed to two decimal places.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:Decimal">
+      <xs:totalDigits value="8" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="AutomatedTrafficManagement">
+    <xs:annotation>
+      <xs:documentation>Technical systems that perform traffic regulation (e.g. speed limits) automatically to manage traffic.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:PlannedDynamicTrafficRegulation">
+        <xs:sequence>
+          <xs:element name="trafficRegulation" type="tro:TrafficRegulation" minOccurs="0" maxOccurs="unbounded" />
+          <xs:element name="_automatedTrafficManagementExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Condition" abstract="true">
+    <xs:annotation>
+      <xs:documentation>Abstract class that specifies a condition for applicabilities or exemptions of a traffic regulation.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="negate" type="com:Boolean" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>If set to true means that the entire condition shall be negated.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="legalBasis" type="tro:LegalBasis" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Legal basis where applicability characteristics or exemptions are specified.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_conditionExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="ConditionOperator">
+    <xs:annotation>
+      <xs:documentation>The logical operator to be used in a test of conditions.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="or">
+        <xs:annotation>
+          <xs:documentation>The OR logical operator – a logical operation to determine if any.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="xor">
+        <xs:annotation>
+          <xs:documentation>The XOR logical operator - a logical operation that outputs true only.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="and">
+        <xs:annotation>
+          <xs:documentation>The AND logical operator – a logical operation to determine if all.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="ConditionSet">
+    <xs:annotation>
+      <xs:documentation>Groups a number of conditions into a condition set.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Condition">
+        <xs:sequence>
+          <xs:element name="operator" type="tro:_ConditionOperator" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Specifies the operator to be applied between the conditions in the set.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="conditions" type="tro:Condition" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>Specifies the conditions that are present in the set</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_conditionSetExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="DirectionRestriction">
+    <xs:annotation>
+      <xs:documentation>Restriction of direction to be followed.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="directionRestrictionType" type="tro:_DirectionRestrictionTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Direction to be followed.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="respectBicycle" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Respect bicycles when turning into a priority road or following a priority road or driving on one-way road.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="respectPedestrian" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Respect pedestrians when turning into a priority road or following a priority road or driving on one-way road.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="respectMotorisedPersonalTransportDevices" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Respect motorised personal transport devices when turning into a priority road or following a priority road or driving on one-way road.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_directionRestrictionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="DirectionRestrictionTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Direction to be followed.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="aheadOnly">
+        <xs:annotation>
+          <xs:documentation>Ahead only.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="keepLeft">
+        <xs:annotation>
+          <xs:documentation>Keep left.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="keepRight">
+        <xs:annotation>
+          <xs:documentation>Keep right.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roundabout">
+        <xs:annotation>
+          <xs:documentation>Roundabout circulation, give way to vehicles from the immediate right.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="straightAheadOrTurnLeft">
+        <xs:annotation>
+          <xs:documentation>Straight ahead or turn left.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="straightAheadOrTurnRight">
+        <xs:annotation>
+          <xs:documentation>Straight ahead or turn right.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="turnLeft">
+        <xs:annotation>
+          <xs:documentation>Turn left.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="turnLeftAhead">
+        <xs:annotation>
+          <xs:documentation>Turn left ahead.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="turnLeftOrTurnRight">
+        <xs:annotation>
+          <xs:documentation>Turn left or turn right.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="turnRight">
+        <xs:annotation>
+          <xs:documentation>Turn right.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="turnRightAhead">
+        <xs:annotation>
+          <xs:documentation>Turn right ahead.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="oneWayTraffic">
+        <xs:annotation>
+          <xs:documentation>One-way traffic.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="noUTurn">
+        <xs:annotation>
+          <xs:documentation>No U-turns allowed.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="noLeftTurn">
+        <xs:annotation>
+          <xs:documentation>No left turn allowed.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="noRightTurn">
+        <xs:annotation>
+          <xs:documentation>No right turn allowed.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="passEitherSide">
+        <xs:annotation>
+          <xs:documentation>Vehicles may pass either side to reach the same destination.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="noReversing">
+        <xs:annotation>
+          <xs:documentation>No reversing allowed.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="noThroughRoad">
+        <xs:annotation>
+          <xs:documentation>No through road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="DriverCharacteristicsTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of driver characteristics.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="disabledWithPermit">
+        <xs:annotation>
+          <xs:documentation>Disabled with permit.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="learnerdriver">
+        <xs:annotation>
+          <xs:documentation>Driver of vehicle is learnerdriver.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="localResident">
+        <xs:annotation>
+          <xs:documentation>The driver is a local resident.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="DriverCondition">
+    <xs:annotation>
+      <xs:documentation>Conditions for the driver, e.g. holding a disabled permit.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Condition">
+        <xs:sequence>
+          <xs:element name="driverCharacteristicsType" type="tro:_DriverCharacteristicsTypeEnum" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Type of driver characteristics.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="ageOfDriver" type="com:NonNegativeInteger" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>The age of the driver in years.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="licenseCharacteristics" type="tro:_LicenseCharacteristicsEnum" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Characteristics of the driver's license.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="timeLicenseHeld" type="tro:Duration" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Period in which the driver has held and continues to hold a driving license.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_driverConditionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="Duration">
+    <xs:annotation>
+      <xs:documentation>DIN ISO 8601 duration value.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="com:String" />
+  </xs:simpleType>
+  <xs:complexType name="LegalBasis">
+    <xs:annotation>
+      <xs:documentation>Class for specification of a legal basis.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="name" type="com:MultilingualString" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Name of legal basis.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="version" type="com:String" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Version of legal basis.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="date" type="com:Date" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Date of legal basis.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_legalBasisExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="LicenseCharacteristicsEnum">
+    <xs:annotation>
+      <xs:documentation>Characteristics of the drivers license.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="provisional">
+        <xs:annotation>
+          <xs:documentation>A restricted license that is given to a person who is learning to drive, but has not yet satisfied the prerequisite to obtain a driver's license.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="permanent">
+        <xs:annotation>
+          <xs:documentation>The driver's license is permanent.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="LocationCondition">
+    <xs:annotation>
+      <xs:documentation>Conditions for the location of a traffic regulation.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Condition">
+        <xs:sequence>
+          <xs:element name="implementedLocation" type="loc:LocationReference" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>The actual (implemented) location of the traffic regulation.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="locationByOrder" type="loc:LocationReference" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>The ordered (planned) location as defined in the original traffic regulation order, if existent,</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="trafficImpactLocation" type="loc:LocationReference" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>The spatial location (typically area) of the road upon which the impact of a regulation is considered to be effective (which is not always the same as the implementedLocation).</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_locationConditionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="MandatoryRoadOrCarriagewayOrLaneUsage">
+    <xs:annotation>
+      <xs:documentation>This class describes a regulation where the use of a road or carriageway or lane is mandatory for specific vehicle types.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="exclusive" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Lane or carriageway or road exclusive for mandatory traffic.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="respectMandatoryTraffic" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Attribute indicating that other that the mandatory traffic should be respected by other traffic.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="segregatedLanes" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Mandatory lanes are segregated.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="contraFlowLane" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Mandatory contra-flow lane.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="otherObligation" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Other obligation not listed elsewhere (By instance "Switch on headlights").</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_mandatoryRoadOrCarriagewayOrLaneUsageExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="MinimumDistanceRestriction">
+    <xs:annotation>
+      <xs:documentation>Driving of vehicles more than x metres apart prohibited.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="value" type="com:MetresAsFloat" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Value of minimum distance between vehicles.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_minimumDistanceRestrictionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="NonVehicularRoadUserCondition">
+    <xs:annotation>
+      <xs:documentation>Conditions for non vehicular road users.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Condition">
+        <xs:sequence>
+          <xs:element name="nonVehicularRoadUser" type="tro:_NonVehicularRoadUserTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Types of non-vehicular road users for which the condition applies.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_nonVehicularRoadUserConditionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="NonVehicularRoadUserTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Collection of non vehicular road user types.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="cattleDrive">
+        <xs:annotation>
+          <xs:documentation>Cattle drive.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="pedestrians">
+        <xs:annotation>
+          <xs:documentation>Pedestrians.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="riddenOrAccompaniedHorses">
+        <xs:annotation>
+          <xs:documentation>Ridden or accompanied by horses.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="OccupantCondition">
+    <xs:annotation>
+      <xs:documentation>Conditions for the occupants of a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Condition">
+        <xs:sequence>
+          <xs:element name="disabledWithPermit" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Occupant is disabled with permit.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="numberOfOccupants" type="com:NonNegativeInteger" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Total number of occupants including the driver.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_occupantConditionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="OvertakingBan">
+    <xs:annotation>
+      <xs:documentation>No overtaking.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="_overtakingBanExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="PermitCondition">
+    <xs:annotation>
+      <xs:documentation>Condition for which a permit is required for vehicles with certain characteristics. Sometimes restricted to specific locations.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Condition">
+        <xs:sequence>
+          <xs:element name="whereToApplyForPermit" type="com:Url" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>URL of the competent authority where an application for a permit can be requested</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="locationRelatedPermit" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>indication whether the permit is related to a specific location or route in the zone.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="maxDurationOfPermit" type="tro:Duration" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>the maximum validity duration a permit could have in hours</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="whereToCallForPermit" type="com:String" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Phone number for contacting the railway operator (at level crossings without a dedicated phone).</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="permitSubjectToFee" type="tro:PermitSubjectToFee" minOccurs="0" />
+          <xs:element name="_permitConditionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="PermitSubjectToFee">
+    <xs:annotation>
+      <xs:documentation>Access permitted when fee is paid.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="amountDue" type="tro:AmountOfMoney" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>amount due in Euro</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="maximumAccessDuration" type="tro:Duration" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>maximum time permitted in CZ after first entry</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="minimumTimeToNextEntry" type="tro:Duration" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>minimum time between two entries</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="paymentInformation" type="com:Url" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>link to the website where payment information can be found</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_permitSubjectToFeeExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PlannedDynamicTrafficRegulation">
+    <xs:annotation>
+      <xs:documentation>A traffic regulation, often dynamically changeable, implemented by means of an automated or controllable technical system.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="issuingAuthority" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The competent authority that issued the corresponding traffic regulation order.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_plannedDynamicTrafficRegulationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PlannedDynamicTrafficRegulations">
+    <xs:annotation>
+      <xs:documentation>This class describes traffic regulations, often dynamically changeable, implemented by means of an automated or controllable technical system.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="plannedDynamicTrafficRegulation" type="tro:PlannedDynamicTrafficRegulation" maxOccurs="unbounded" />
+      <xs:element name="_plannedDynamicTrafficRegulationsExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="PriorityRule">
+    <xs:annotation>
+      <xs:documentation>Class for priority rules.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="priorityRuleType" type="tro:_PriorityRuleTypeEnum" minOccurs="1" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>Type of priority rule.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="respectBicycle" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Give way and respect bicycles.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_priorityRuleExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="PriorityRuleTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Possible values for priority rules.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="giveWay">
+        <xs:annotation>
+          <xs:documentation>Give way to traffic on major road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="giveWayToTram">
+        <xs:annotation>
+          <xs:documentation>Give way to tram.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="giveWayToOncomingVehicles">
+        <xs:annotation>
+          <xs:documentation>Give priority to vehicles from opposite direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="stop">
+        <xs:annotation>
+          <xs:documentation>Stop and give way.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="giveWayToRail">
+        <xs:annotation>
+          <xs:documentation>Give way to rail.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="giveWayToSchoolCrossingPatrol">
+        <xs:annotation>
+          <xs:documentation>Give way to school crossing patrol.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="bendOfPriorityRoadFromLeft">
+        <xs:annotation>
+          <xs:documentation>Bend of priority road coming from left.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="bendOfPriorityRoadFromRight">
+        <xs:annotation>
+          <xs:documentation>Bend of priority road coming from right.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="priorityAtNextJunction">
+        <xs:annotation>
+          <xs:documentation>Priority at next junction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="priorityRoad">
+        <xs:annotation>
+          <xs:documentation>Traffic on this lane or carriageway or road has priority.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="priorityOverOncomingVehicles">
+        <xs:annotation>
+          <xs:documentation>Vehicles from opposite direction must give priority.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="ReasonForRegulationEnum">
+    <xs:annotation>
+      <xs:documentation>This enumeration lists possible reasons for a road traffic authority to issue a traffic regulation order.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="trafficSafety">
+        <xs:annotation>
+          <xs:documentation>Regulation due to safety concerns.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="trafficOrder">
+        <xs:annotation>
+          <xs:documentation>Regulation due to traffic order concerns.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadworks">
+        <xs:annotation>
+          <xs:documentation>Regulation due to roadworks.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="protectionOfRoad">
+        <xs:annotation>
+          <xs:documentation>Regulation to prevent extraordinary damage to the road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="protectionOfNoiseAndEmissions">
+        <xs:annotation>
+          <xs:documentation>Regulation to protect resident population against noise and emissions.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="protectionOfWaters">
+        <xs:annotation>
+          <xs:documentation>Regulation to protect waters in the area.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="publicSafety">
+        <xs:annotation>
+          <xs:documentation>Regulatin to maintain public safety.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="researchAndTest">
+        <xs:annotation>
+          <xs:documentation>Regulation intended to research accident incidents, traffic behaviour, traffic flows and to test planned traffic safety or traffic regulation measures.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="other">
+        <xs:annotation>
+          <xs:documentation>Regulation due to a reason not covered by the other literals.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="Rerouting">
+    <xs:annotation>
+      <xs:documentation>Class for Rerouting.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="_reroutingExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="RoadCondition">
+    <xs:annotation>
+      <xs:documentation>Specification of road types (e.g. motorway, express way, etc.).</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Condition">
+        <xs:sequence>
+          <xs:element name="roadType" type="tro:_RoadTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Type of road (e.g. motorway, express way, etc.).</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_roadConditionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="RoadOrCarriagewayOrLaneLayoutType">
+    <xs:annotation>
+      <xs:documentation>Layout types for road, carriageway or lane.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="road">
+        <xs:annotation>
+          <xs:documentation>Road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lane">
+        <xs:annotation>
+          <xs:documentation>Lane.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="carriageway">
+        <xs:annotation>
+          <xs:documentation>Carriageway.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:simpleType name="RoadTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Collection of road types.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="motorway">
+        <xs:annotation>
+          <xs:documentation>A major road that has been specially built for fast travel over long distances. Motorways have several lanes and special places where traffic gets on and leaves.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="expressRoad">
+        <xs:annotation>
+          <xs:documentation>A wide road that is specially designed for fast traffic. It is usually divided, so that traffic travelling in one direction is separated from the traffic travelling in the opposite direction.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="insideBuiltUpAreas">
+        <xs:annotation>
+          <xs:documentation>Roads inside built-up areas.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="outsideBuiltUpAreas">
+        <xs:annotation>
+          <xs:documentation>Roads outside built-up areas.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="RoadWarning">
+    <xs:annotation>
+      <xs:documentation>A warning concerning the road or the conditions of the road.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Warning">
+        <xs:sequence>
+          <xs:element name="roadWarningType" type="tro:_RoadWarningTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Type of the road condition warning.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_roadWarningExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="RoadWarningTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of road related dangers.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="bendLeft">
+        <xs:annotation>
+          <xs:documentation>Bend left.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="bendRight">
+        <xs:annotation>
+          <xs:documentation>Bend right.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="crossroadsWithPriorityFromRight">
+        <xs:annotation>
+          <xs:documentation>Crossroads with priority from right.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="doubleBendFirstToLeft">
+        <xs:annotation>
+          <xs:documentation>Double bend first to left.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="doubleBendFirstToRight">
+        <xs:annotation>
+          <xs:documentation>Double bend first to right.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadNarrowsBothSides">
+        <xs:annotation>
+          <xs:documentation>Road narrows on both sides.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadNarrowsLeft">
+        <xs:annotation>
+          <xs:documentation>Road narrows on the left side.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadNarrowsRight">
+        <xs:annotation>
+          <xs:documentation>Road narrows on the right side.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadWorks">
+        <xs:annotation>
+          <xs:documentation>Road works.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="trafficLightsAhead">
+        <xs:annotation>
+          <xs:documentation>Traffic lights ahead.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="unevenRoad">
+        <xs:annotation>
+          <xs:documentation>Uneven road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="slipperyRoad">
+        <xs:annotation>
+          <xs:documentation>Slippery road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadHump">
+        <xs:annotation>
+          <xs:documentation>Uneven road (hump).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadDip">
+        <xs:annotation>
+          <xs:documentation>Uneven road (dip).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="lateralStep">
+        <xs:annotation>
+          <xs:documentation>Uneven road (lateral step).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="accident">
+        <xs:annotation>
+          <xs:documentation>Accident.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roundabout">
+        <xs:annotation>
+          <xs:documentation>Warning of roundabout (Anti-clockwise).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="swingBridge">
+        <xs:annotation>
+          <xs:documentation>Opening or swing bridge.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="obstacleOnTheRoad">
+        <xs:annotation>
+          <xs:documentation>Obstacle on the road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="RushHourLaneRestriction">
+    <xs:annotation>
+      <xs:documentation>Class for rush hour lane restrictions.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="clearRushHourLane" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Traffic to clear rush hour lane.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="rushHourLaneOpen" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Rush hour lane open to traffic.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_rushHourLaneRestrictionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Speed">
+    <xs:annotation>
+      <xs:documentation>Class for the specification of a speed.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="numericValue" type="com:Decimal" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Numeric value of the speed.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="unitOfMeasure" type="tro:_UnitOfSpeedEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The unit of measure of the specified speed.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_speedExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="SpeedLimit">
+    <xs:annotation>
+      <xs:documentation>An upper limit of the permissible speed.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="weatherRelatedRoadConditionType" type="com:_WeatherRelatedRoadConditionTypeEnum" minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+              <xs:documentation>Speed limit only under certain weather related conditions.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="walkingSpeed" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Maximum speed limited to walking speed.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="minValue" type="tro:Speed" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Minimum speed value.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="maxValue" type="tro:Speed" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Maximum speed value.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="advisorySpeed" type="tro:Speed" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>Speed at which it is advisable to drive if circumstances permit and if the driver is not required to comply with a lower limit specific to his category of vehicle.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_speedLimitExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="StandingOrParkingRestricitonTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Standing and/or parking restriction type.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="parkingProhibited">
+        <xs:annotation>
+          <xs:documentation>Drivers should stop no longer than a specified amount of time, except for loading and unloading or to set down or pick up passengers.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="standingAndParkingProhibited">
+        <xs:annotation>
+          <xs:documentation>No standing or parking permitted.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="StandingOrParkingRestriction">
+    <xs:annotation>
+      <xs:documentation>Standing and/or parking restrictions.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="standingOrParkingRestrictionType" type="tro:_StandingOrParkingRestricitonTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Type of standing and/or parking restriction.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="vergeOrFootwayAlso" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Waiting or parking restriction also applies for parking on the verge or footway.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="vergeOrFootwayOnly" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Waiting or parking restriction only applies for parking on the verge or footway.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="permittedStandingTime" type="tro:Duration" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Duration for which standing is permitted.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="permittedParkingTime" type="tro:Duration" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Duration for which parking is permitted.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="paidParking" type="com:Boolean" minOccurs="0" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Parking for which payment is required.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_standingOrParkingRestrictionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="SteepHill">
+    <xs:annotation>
+      <xs:documentation>A steep hill ahead.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Warning">
+        <xs:sequence>
+          <xs:element name="roadGradientValue" type="com:Percentage" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Value of the road gradient in percent.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="steepHillDirectionType" type="tro:_SteepHillDirectionTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Direction of steep hill.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_steepHillExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="SteepHillDirectionTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Direction of steep hill,</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="downwards">
+        <xs:annotation>
+          <xs:documentation>Steep hill downwards.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="upwards">
+        <xs:annotation>
+          <xs:documentation>Steep hill upwards.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TrafficAhead">
+    <xs:annotation>
+      <xs:documentation>A warning of traffic ahead.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Warning">
+        <xs:sequence>
+          <xs:element name="trafficAheadType" type="tro:_TrafficAheadTypeEnum" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Type of traffic ahead.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_trafficAheadExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:simpleType name="TrafficAheadTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Types of traffic on the road.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="children">
+        <xs:annotation>
+          <xs:documentation>Children crossing the road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="cycleRoute">
+        <xs:annotation>
+          <xs:documentation>Cyclist entering or crossing.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="pedestrianCrossing">
+        <xs:annotation>
+          <xs:documentation>Pedestrians crossing the road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="levelCrossing">
+        <xs:annotation>
+          <xs:documentation> Level crossing without barrier or gate ahead.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="ridingPath">
+        <xs:annotation>
+          <xs:documentation>Ridden or accompanied horses on the road or crossing the road.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="trafficQueues">
+        <xs:annotation>
+          <xs:documentation>Traffic queues.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="twoWayTraffic">
+        <xs:annotation>
+          <xs:documentation>Two-way traffic straight ahead.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="tramsCrossingAhead">
+        <xs:annotation>
+          <xs:documentation>Intersection with a tramway line.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="levelCrossingWithGate">
+        <xs:annotation>
+          <xs:documentation>Level crossing with barrier or gate ahead.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="busCrossing">
+        <xs:annotation>
+          <xs:documentation>Intersection with a dedicated bus lane (by instance High Quality Service Buses).</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TrafficRegulation">
+    <xs:annotation>
+      <xs:documentation>Legal agreement or order that restricts or prohibits the use of the highway network.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="status" type="tro:_TrafficRegulationStatusEnum" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Implementation status of the traffic regulation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="typeOfRegulation" type="tro:TypeOfRegulation" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>Type of traffic regulation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="condition" type="tro:Condition" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>Conditions for the validity of a traffic regulation.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_trafficRegulationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="TrafficRegulationInstallerTypeEnum">
+    <xs:annotation>
+      <xs:documentation>Possible performers of traffic regulations without traffic regulation order.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="police">
+        <xs:annotation>
+          <xs:documentation>Police.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="roadOperator">
+        <xs:annotation>
+          <xs:documentation>Road operator.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="publicWorkOrUtilityCompanies">
+        <xs:annotation>
+          <xs:documentation>Public work or utility companies.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="fireBrigade">
+        <xs:annotation>
+          <xs:documentation>Fire brigade.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TrafficRegulationOrder">
+    <xs:annotation>
+      <xs:documentation>A legally recognised document or publication issued to enact a specific traffic regulation or regulations by a competent authority.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="description" type="com:MultilingualString" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Further textual description of the regulation order.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="issuingAuthority" type="com:MultilingualString" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The competent authority that issued the traffic regulation order.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="reason" type="tro:_ReasonForRegulationEnum" minOccurs="0" maxOccurs="unbounded">
+        <xs:annotation>
+          <xs:documentation>The reason justifying the traffic regulation order.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="regulationId" type="com:String" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>A (external) unique identification of the traffic regulation order. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="status" type="tro:_TrafficRegulationOrderStatusEnum" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>The current lifecycle status of the traffic regulation order. </xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="implementedValidity" type="com:Validity" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>The actual (implemented) time period governed by the traffic regulation order.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="validityByOrder" type="com:Validity" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>The ordered (planned) time period governed by the traffic regulation order.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="implementedLocation" type="loc:LocationReference" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>The actual (implemented) location governed by the traffic regulation order.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="locationByOrder" type="loc:LocationReference" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>The ordered (planned) location governed by the traffic regulation order.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="trafficRegulation" type="tro:TrafficRegulation" maxOccurs="unbounded" />
+      <xs:element name="legalBasis" type="tro:LegalBasis" minOccurs="0">
+        <xs:annotation>
+          <xs:documentation>The legal basis of the Traffic Regulation Order.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+      <xs:element name="_trafficRegulationOrderExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+    <xs:attribute name="id" type="xs:string" use="required" />
+    <xs:attribute name="version" type="xs:string" use="required" />
+  </xs:complexType>
+  <xs:simpleType name="TrafficRegulationOrderStatusEnum">
+    <xs:annotation>
+      <xs:documentation>Lifecycle states of a traffic regulation order.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="planned">
+        <xs:annotation>
+          <xs:documentation>The traffic regulation is defined and proposed but not approved yet.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="madeButNotImplemented">
+        <xs:annotation>
+          <xs:documentation>Made but not implemented.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="madeAndPartiallyImplemented">
+        <xs:annotation>
+          <xs:documentation>Made and partially implemented.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="madeAndImplemented">
+        <xs:annotation>
+          <xs:documentation>Made and implemented.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="partiallyWithdrawn">
+        <xs:annotation>
+          <xs:documentation>Partially withdrawn.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="withdrawn">
+        <xs:annotation>
+          <xs:documentation>Withdrawn.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TrafficRegulationPublication">
+    <xs:annotation>
+      <xs:documentation>Publication of traffic regulations.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="com:PayloadPublication">
+        <xs:sequence>
+          <xs:element name="trafficRegulationsFromCompetentAuthorities" type="tro:TrafficRegulationsFromCompetentAuthorities" minOccurs="0" />
+          <xs:element name="trafficRegulationsByAuthorisedActors" type="tro:TrafficRegulationsByAuthorisedActors" minOccurs="0" />
+          <xs:element name="adHocTrafficRegulations" type="tro:AdHocTrafficRegulations" minOccurs="0" />
+          <xs:element name="plannedDynamicTrafficRegulations" type="tro:PlannedDynamicTrafficRegulations" minOccurs="0" />
+          <xs:element name="_trafficRegulationPublicationExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+        <xs:attribute name="id" type="xs:string" use="required" />
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TrafficRegulationsByAuthorisedActors">
+    <xs:annotation>
+      <xs:documentation>Traffic regulations from an actor that has received a general permission from a competent authority.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="activatedRegulation" type="tro:ActivatedRegulation" maxOccurs="unbounded" />
+      <xs:element name="_trafficRegulationsByAuthorisedActorsExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:complexType name="TrafficRegulationsFromCompetentAuthorities">
+    <xs:annotation>
+      <xs:documentation>A traffic regulation ordered by a competent authority.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="trafficRegulationOrder" type="tro:TrafficRegulationOrder" maxOccurs="unbounded" />
+      <xs:element name="_trafficRegulationsFromCompetentAuthoritiesExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="TrafficRegulationStatusEnum">
+    <xs:annotation>
+      <xs:documentation>Implementation lifecycle values for traffic regulations.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="active">
+        <xs:annotation>
+          <xs:documentation>The regulation is currently implemented.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="beingSetUp">
+        <xs:annotation>
+          <xs:documentation>The regulation is currently in the process of being set up.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="beingShutDown">
+        <xs:annotation>
+          <xs:documentation>The regulation is currently in the process of being taken away.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="scheduled">
+        <xs:annotation>
+          <xs:documentation>The regulation is planned for the future.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="TrafficSignals">
+    <xs:annotation>
+      <xs:documentation>Signalling devices positioned at road intersections, pedestrian crossings, and other locations to control flows of traffic.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:PlannedDynamicTrafficRegulation">
+        <xs:sequence>
+          <xs:element name="signalPhaseAndTimingReference" type="com:Reference" minOccurs="1" maxOccurs="1">
+            <xs:annotation>
+              <xs:documentation>Reference to the signal phase and timing class describing the dynamic regulation behaviour of a traffic signal.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_trafficSignalsExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="TypeOfRegulation" abstract="true">
+    <xs:annotation>
+      <xs:documentation>The abstract base class of all types of traffic restrictions.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="_typeOfRegulationExtension" type="com:_ExtensionType" minOccurs="0" />
+    </xs:sequence>
+  </xs:complexType>
+  <xs:simpleType name="UnitOfSpeedEnum">
+    <xs:annotation>
+      <xs:documentation>Units of speed.</xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="kilometresPerHour">
+        <xs:annotation>
+          <xs:documentation>Kilometres per hour.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="milesPerHour">
+        <xs:annotation>
+          <xs:documentation>Miles per hour.</xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
+      <xs:enumeration value="_extended" />
+    </xs:restriction>
+  </xs:simpleType>
+  <xs:complexType name="ValidityCondition">
+    <xs:annotation>
+      <xs:documentation>Conditions for time validity of a traffic regulation.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Condition">
+        <xs:sequence>
+          <xs:element name="implementedValidity" type="com:Validity" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>The actual (implemented) validity of the traffic regulation.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="validityByOrder" type="com:Validity" minOccurs="0">
+            <xs:annotation>
+              <xs:documentation>The ordered (planned) validity as defined in the original traffic regulation order, if existent.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_validityConditionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="VehicleCondition">
+    <xs:annotation>
+      <xs:documentation>Conditions for a vehicle.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:Condition">
+        <xs:sequence>
+          <xs:element name="vehicleCharacteristics" type="com:VehicleCharacteristics">
+            <xs:annotation>
+              <xs:documentation>Traffic regulation only for special vehicles.</xs:documentation>
+            </xs:annotation>
+          </xs:element>
+          <xs:element name="_vehicleConditionExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:complexType name="Warning" abstract="true">
+    <xs:annotation>
+      <xs:documentation>The abstract base class of all types of traffic warnings.</xs:documentation>
+    </xs:annotation>
+    <xs:complexContent>
+      <xs:extension base="tro:TypeOfRegulation">
+        <xs:sequence>
+          <xs:element name="_warningExtension" type="com:_ExtensionType" minOccurs="0" />
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:schema>

--- a/spec/datex2/example.xml
+++ b/spec/datex2/example.xml
@@ -47,37 +47,56 @@
         </typeOfRegulation>
 
         <condition xsi:type="ConditionSet">
-            <operator>and</operator>
-            <conditions xsi:type="ValidityCondition">
-                <negate>false</negate>
-                <validityByOrder>
-                    <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
-                    <com:validityTimeSpecification>
-                    <com:overallStartTime>2022-05-10T09:00:00.000Z</com:overallStartTime>
-                    <com:overallEndTime>2022-06-10T16:30:00.000Z</com:overallEndTime>
-                    <com:exceptionPeriod>
-                        <com:recurringDayWeekMonthPeriod>
-                            <com:applicableDay>saturday</com:applicableDay>
-                            <com:applicableDay>sunday</com:applicableDay>
-                        </com:recurringDayWeekMonthPeriod>
-                    </com:exceptionPeriod>
-                    <com:exceptionPeriod>
-                        <com:recurringSpecialDay>
-                            <com:intersectWithApplicableDays>true</com:intersectWithApplicableDays>
-                            <com:specialDayType>publicHoliday</com:specialDayType>
-                        </com:recurringSpecialDay>
-                    </com:exceptionPeriod>
-                    </com:validityTimeSpecification>
-                </validityByOrder>
-            </conditions>
-            <conditions xsi:type="LocationCondition">
-                <negate>false</negate>
-                <implementedLocation xsi:type="loc:LinearLocation">
-                  <loc:gmlLineString>
-                    <loc:posList>47.366334 -1.944703 47.370631 -1.94021</loc:posList>
-                  </loc:gmlLineString>
-                </implementedLocation>
-            </conditions>
+          <operator>and</operator>
+
+          <conditions xsi:type="ValidityCondition">
+            <negate>false</negate>
+            <validityByOrder>
+              <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+              <com:validityTimeSpecification>
+                <com:overallStartTime>2022-05-10T09:00:00.000Z</com:overallStartTime>
+                <com:overallEndTime>2022-06-10T16:30:00.000Z</com:overallEndTime>
+                <com:exceptionPeriod>
+                  <com:recurringDayWeekMonthPeriod>
+                    <com:applicableDay>saturday</com:applicableDay>
+                    <com:applicableDay>sunday</com:applicableDay>
+                  </com:recurringDayWeekMonthPeriod>
+                </com:exceptionPeriod>
+                <com:exceptionPeriod>
+                  <com:recurringSpecialDay>
+                    <com:intersectWithApplicableDays>true</com:intersectWithApplicableDays>
+                    <com:specialDayType>publicHoliday</com:specialDayType>
+                  </com:recurringSpecialDay>
+                </com:exceptionPeriod>
+              </com:validityTimeSpecification>
+            </validityByOrder>
+          </conditions>
+
+          <conditions xsi:type="LocationCondition">
+            <negate>false</negate>
+            <implementedLocation xsi:type="loc:LinearLocation">
+              <loc:gmlLineString>
+                <loc:posList>47.366334 -1.944703 47.370631 -1.94021</loc:posList>
+              </loc:gmlLineString>
+            </implementedLocation>
+          </conditions>
+
+          <conditions xsi:type="VehicleCondition">
+            <negate>false</negate>
+            <vehicleCharacteristics>
+              <com:vehicleUsage>cityLogistics</com:vehicleUsage>
+            </vehicleCharacteristics>
+          </conditions>
+
+          <conditions xsi:type="VehicleCondition">
+            <negate>true</negate>
+            <vehicleCharacteristics>
+              <com:lengthCharacteristic>
+                <com:comparisonOperator>lessThan</com:comparisonOperator>
+                <com:vehicleLength>12</com:vehicleLength>
+              </com:lengthCharacteristic>
+            </vehicleCharacteristics>
+          </conditions>
         </condition>
 
       </trafficRegulation>

--- a/spec/datex2/example.xml
+++ b/spec/datex2/example.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<d2:payload
+  modelBaseVersion="3"
+  lang="EN"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:d2="http://datex2.eu/schema/3/d2Payload"
+  xmlns:com="http://datex2.eu/schema/3/common"
+  xmlns="http://datex2.eu/schema/3/trafficRegulation"
+  xsi:schemaLocation="http://datex2.eu/schema/3/d2Payload DATEXII_3_D2Payload.xsd"
+  xsi:type="TrafficRegulationPublication"
+  id="910928b3-58a1-4462-881b-53dec84602f9"
+>
+  <com:publicationTime>2022-11-10T15:11:00.000Z</com:publicationTime>
+
+  <com:publicationCreator>
+    <com:country>fr</com:country>
+    <com:nationalIdentifier>DiaLog</com:nationalIdentifier>
+  </com:publicationCreator>
+
+  <trafficRegulationsFromCompetentAuthorities>
+    <trafficRegulationOrder id="T-SN2022-05-154" version="1">
+      <description>
+        <com:values>
+          <com:value>
+            Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye
+          </com:value>
+        </com:values>
+      </description>
+
+      <issuingAuthority>
+        <com:values>
+          <com:value>Commune de Savenay</com:value>
+        </com:values>
+      </issuingAuthority>
+
+      <regulationId>T-SN2022-05-154</regulationId>
+
+      <status>madeAndImplemented</status>
+
+      <trafficRegulation>
+        <status>active</status>
+
+        <typeOfRegulation xsi:type="AccessRestriction">
+          <accessRestrictionType>noEntry</accessRestrictionType>
+        </typeOfRegulation>
+
+        <condition xsi:type="ValidityCondition">
+          <negate>true</negate>
+          <validityByOrder>
+            <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+            <com:validityTimeSpecification>
+              <com:overallStartTime>2022-05-10T09:00:00.000Z</com:overallStartTime>
+              <com:overallEndTime>2022-06-10T16:30:00.000Z</com:overallEndTime>
+              <com:exceptionPeriod>
+                <com:recurringDayWeekMonthPeriod>
+                  <com:applicableDay>saturday</com:applicableDay>
+                  <com:applicableDay>sunday</com:applicableDay>
+                </com:recurringDayWeekMonthPeriod>
+              </com:exceptionPeriod>
+              <com:exceptionPeriod>
+                <com:recurringSpecialDay>
+                  <com:intersectWithApplicableDays>true</com:intersectWithApplicableDays>
+                  <com:specialDayType>publicHoliday</com:specialDayType>
+                </com:recurringSpecialDay>
+              </com:exceptionPeriod>
+            </com:validityTimeSpecification>
+          </validityByOrder>
+        </condition>
+      </trafficRegulation>
+    </trafficRegulationOrder>
+  </trafficRegulationsFromCompetentAuthorities>
+</d2:payload>

--- a/spec/datex2/example.xml
+++ b/spec/datex2/example.xml
@@ -6,6 +6,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:d2="http://datex2.eu/schema/3/d2Payload"
   xmlns:com="http://datex2.eu/schema/3/common"
+  xmlns:loc="http://datex2.eu/schema/3/locationReferencing"
   xmlns="http://datex2.eu/schema/3/trafficRegulation"
   xsi:schemaLocation="http://datex2.eu/schema/3/d2Payload DATEXII_3_D2Payload.xsd"
   xsi:type="TrafficRegulationPublication"
@@ -45,28 +46,40 @@
           <accessRestrictionType>noEntry</accessRestrictionType>
         </typeOfRegulation>
 
-        <condition xsi:type="ValidityCondition">
-          <negate>true</negate>
-          <validityByOrder>
-            <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
-            <com:validityTimeSpecification>
-              <com:overallStartTime>2022-05-10T09:00:00.000Z</com:overallStartTime>
-              <com:overallEndTime>2022-06-10T16:30:00.000Z</com:overallEndTime>
-              <com:exceptionPeriod>
-                <com:recurringDayWeekMonthPeriod>
-                  <com:applicableDay>saturday</com:applicableDay>
-                  <com:applicableDay>sunday</com:applicableDay>
-                </com:recurringDayWeekMonthPeriod>
-              </com:exceptionPeriod>
-              <com:exceptionPeriod>
-                <com:recurringSpecialDay>
-                  <com:intersectWithApplicableDays>true</com:intersectWithApplicableDays>
-                  <com:specialDayType>publicHoliday</com:specialDayType>
-                </com:recurringSpecialDay>
-              </com:exceptionPeriod>
-            </com:validityTimeSpecification>
-          </validityByOrder>
+        <condition xsi:type="ConditionSet">
+            <operator>and</operator>
+            <conditions xsi:type="ValidityCondition">
+                <negate>false</negate>
+                <validityByOrder>
+                    <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                    <com:validityTimeSpecification>
+                    <com:overallStartTime>2022-05-10T09:00:00.000Z</com:overallStartTime>
+                    <com:overallEndTime>2022-06-10T16:30:00.000Z</com:overallEndTime>
+                    <com:exceptionPeriod>
+                        <com:recurringDayWeekMonthPeriod>
+                            <com:applicableDay>saturday</com:applicableDay>
+                            <com:applicableDay>sunday</com:applicableDay>
+                        </com:recurringDayWeekMonthPeriod>
+                    </com:exceptionPeriod>
+                    <com:exceptionPeriod>
+                        <com:recurringSpecialDay>
+                            <com:intersectWithApplicableDays>true</com:intersectWithApplicableDays>
+                            <com:specialDayType>publicHoliday</com:specialDayType>
+                        </com:recurringSpecialDay>
+                    </com:exceptionPeriod>
+                    </com:validityTimeSpecification>
+                </validityByOrder>
+            </conditions>
+            <conditions xsi:type="LocationCondition">
+                <negate>false</negate>
+                <implementedLocation xsi:type="loc:LinearLocation">
+                  <loc:gmlLineString>
+                    <loc:posList>47.366334 -1.944703 47.370631 -1.94021</loc:posList>
+                  </loc:gmlLineString>
+                </implementedLocation>
+            </conditions>
         </condition>
+
       </trafficRegulation>
     </trafficRegulationOrder>
   </trafficRegulationsFromCompetentAuthorities>


### PR DESCRIPTION
Refs #11 

Cette PR ajoute un fichier [`spec/datex2/example.xml`](https://github.com/MTES-MCT/dialog/blob/e640b931c817ec934a2f521dfecc8c4fbab2247a/spec/datex2/example.xml) qui traduit l'arrêté imaginaire suivant :

> La circulation rouitère est interdite sur la route départementale 93 du PR 21+703 au PR 22 sur la commune de Savenay :
>
> * Pour les véhicles affectés au transport de marchandises d'une longueur de plus de 12 mètres.
> * Du mardi 10 juin à 9h au vendredi 10 juin à 16h30.
>
> L'interdiction sera conservée 24h/24, elle ne s'appliquera pas les weekends et jours fériés.

Cette PR ajoute aussi les fichiers `.xsd` (schémas XML) de DATEX II v3.3 (`TrafficRegulation` et ses dépendances) qui ont permis de construire le fichier d'exemple.

Les fichiers XSD ont été générés comme suit :

* Se rendre sur le [Webtool DATEX II](https://webtool.datex2.eu/wizard/).
* "1. Source" - Choisir V3.3 DATEX II.
* "2. Selection file" - Cliquer sur "Next".
* "3. Profile Selection" - Cliquer sur "Next".
* "4. Profile Location" - Cliquer sur "Next".
* "5. Selection" - Cocher `TrafficRegulationPublication` uniquement. Cliquer sur "Next".
* "6. Options" - S'assurer que "XML Schema" est choisi. Cliquer sur "Next" pour télécharger le `.zip` avec les fichiers XSD.