### PR TITLE
Add TrafficRegulation & RegulationCondition models

### DIFF
--- a/src/Domain/TrafficRegulation/Enum/TrafficRegulationType.php
+++ b/src/Domain/TrafficRegulation/Enum/TrafficRegulationType.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\TrafficRegulation\Enum;
+
+enum TrafficRegulationType: string
+{
+    case NO_ENTRY = 'noEntry';
+}

--- a/src/Domain/TrafficRegulation/RegulationCondition.php
+++ b/src/Domain/TrafficRegulation/RegulationCondition.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\TrafficRegulation;
+
+class RegulationCondition
+{
+    public function __construct(
+        private string $uuid,
+        private bool $negate,
+        private TrafficRegulation $trafficRegulation,
+    ) {
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function isNegate(): bool
+    {
+        return $this->negate;
+    }
+
+    public function getTrafficRegulation(): TrafficRegulation
+    {
+        return $this->trafficRegulation;
+    }
+}

--- a/src/Domain/TrafficRegulation/TrafficRegulation.php
+++ b/src/Domain/TrafficRegulation/TrafficRegulation.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\TrafficRegulation;
+
+use App\Domain\TrafficRegulation\Enum\TrafficRegulationType;
+
+class TrafficRegulation
+{
+    public function __construct(
+        private string $uuid,
+        private TrafficRegulationType $type = TrafficRegulationType::NO_ENTRY,
+    ) {
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function getType(): TrafficRegulationType
+    {
+        return $this->type;
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/TrafficRegulation.RegulationCondition.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/TrafficRegulation.RegulationCondition.orm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity
+    name="App\Domain\TrafficRegulation\RegulationCondition"
+    table="regulation_condition">
+    <id name="uuid" type="guid" column="uuid"/>
+    <field name="negate" type="boolean" column="negate" nullable="false"/>
+    <one-to-one field="trafficRegulation" target-entity="App\Domain\TrafficRegulation\TrafficRegulation">
+        <join-column name="traffic_regulation_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE"/>
+    </one-to-one>
+  </entity>
+</doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/TrafficRegulation.TrafficRegulation.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/TrafficRegulation.TrafficRegulation.orm.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity
+    name="App\Domain\TrafficRegulation\TrafficRegulation"
+    table="traffic_regulation">
+    <id name="uuid" type="guid" column="uuid"/>
+    <field name="type" type="string" column="type" length="10" nullable="false"/>
+  </entity>
+</doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20221122162137.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20221122162137.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221122162137 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE regulation_condition (uuid UUID NOT NULL, traffic_regulation_uuid UUID NOT NULL, negate BOOLEAN NOT NULL, PRIMARY KEY(uuid))');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_9D8762B73E2272A ON regulation_condition (traffic_regulation_uuid)');
+        $this->addSql('CREATE TABLE traffic_regulation (uuid UUID NOT NULL, type VARCHAR(10) NOT NULL, PRIMARY KEY(uuid))');
+        $this->addSql('ALTER TABLE regulation_condition ADD CONSTRAINT FK_9D8762B73E2272A FOREIGN KEY (traffic_regulation_uuid) REFERENCES traffic_regulation (uuid) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE regulation_condition DROP CONSTRAINT FK_9D8762B73E2272A');
+        $this->addSql('DROP TABLE regulation_condition');
+        $this->addSql('DROP TABLE traffic_regulation');
+    }
+}

--- a/tests/Unit/Domain/RegulationOrder/RegulationOrderRecordTest.php
+++ b/tests/Unit/Domain/RegulationOrder/RegulationOrderRecordTest.php
@@ -29,5 +29,6 @@ final class RegulationOrderRecordTest extends TestCase
         $this->assertSame($regulationOrder, $regulationOrderRecord->getRegulationOrder());
         $this->assertSame($organization, $regulationOrderRecord->getOrganization());
         $this->assertSame($createdAt, $regulationOrderRecord->getCreatedAt());
+        $this->assertSame(RegulationOrderRecordStatus::PUBLISHED, $regulationOrderRecord->getStatus());
     }
 }

--- a/tests/Unit/Domain/TrafficRegulation/RegulationConditionTest.php
+++ b/tests/Unit/Domain/TrafficRegulation/RegulationConditionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain\TrafficRegulation;
+
+use App\Domain\TrafficRegulation\RegulationCondition;
+use App\Domain\TrafficRegulation\TrafficRegulation;
+use PHPUnit\Framework\TestCase;
+
+final class RegulationConditionTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $trafficRegulation = new TrafficRegulation('6598fd41-85cb-42a6-9693-1bc45f4dd392');
+        $regulationCondition = new RegulationCondition(
+            '9f3cbc01-8dbe-4306-9912-91c8d88e194f',
+            false,
+            $trafficRegulation,
+        );
+
+        $this->assertSame('9f3cbc01-8dbe-4306-9912-91c8d88e194f', $regulationCondition->getUuid());
+        $this->assertSame(false, $regulationCondition->isNegate());
+        $this->assertSame($trafficRegulation, $regulationCondition->getTrafficRegulation());
+        $this->assertSame('6598fd41-85cb-42a6-9693-1bc45f4dd392', $regulationCondition->getTrafficRegulation()->getUuid());
+    }
+}

--- a/tests/Unit/Domain/TrafficRegulation/TrafficRegulationTest.php
+++ b/tests/Unit/Domain/TrafficRegulation/TrafficRegulationTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Domain\TrafficRegulation;
+
+use App\Domain\TrafficRegulation\Enum\TrafficRegulationType;
+use App\Domain\TrafficRegulation\TrafficRegulation;
+use PHPUnit\Framework\TestCase;
+
+final class TrafficRegulationTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $trafficRegulation = new TrafficRegulation('6598fd41-85cb-42a6-9693-1bc45f4dd392');
+
+        $this->assertSame('6598fd41-85cb-42a6-9693-1bc45f4dd392', $trafficRegulation->getUuid());
+        $this->assertSame(TrafficRegulationType::NO_ENTRY, $trafficRegulation->getType());
+    }
+}


### PR DESCRIPTION
Cette PR permet de rajouter les entités TrafficRegulation & RegulationCondition.

Pour lancer la migration, exécuter : 
```bash
make database_run_migration
```

Pour valider le schéma, lancer la commande : 
```bash
make console CMD="doctrine:schema:validate"
```