### PR TITLE
Add user password and role to prepare authentification

### DIFF
--- a/src/Domain/User/Enum/UserRoleEnum.php
+++ b/src/Domain/User/Enum/UserRoleEnum.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Enum;
+
+enum UserRoleEnum: string
+{
+    case ROLE_ADMIN = 'ROLE_ADMIN';
+}

--- a/src/Domain/User/User.php
+++ b/src/Domain/User/User.php
@@ -4,12 +4,16 @@ declare(strict_types=1);
 
 namespace App\Domain\User;
 
+use App\Domain\User\Enum\UserRoleEnum;
+
 class User
 {
     public function __construct(
         private string $uuid,
         private string $fullName,
         private string $email,
+        private UserRoleEnum $role,
+        private ?string $password = null,
     ) {
     }
 
@@ -26,5 +30,15 @@ class User
     public function getEmail(): string
     {
         return $this->email;
+    }
+
+    public function getRole(): UserRoleEnum
+    {
+        return $this->role;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
     }
 }

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/User.User.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/User.User.orm.xml
@@ -2,10 +2,12 @@
 <doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
   <entity
     name="App\Domain\User\User"
-    table="user">
+    table="`user`">
     <id name="uuid" type="guid" column="uuid"/>
     <field name="fullName" type="string" column="full_name" nullable="false"/>
     <field name="email" type="string" column="email" nullable="false"/>
+    <field name="password" type="string" column="password" nullable="true"/>
+    <field name="role" type="string" column="role" length="20" nullable="false"/>
     <unique-constraints>
         <unique-constraint columns="email" name="user_email" />
     </unique-constraints>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20221129151507.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20221129151507.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20221129151507 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE "user" ADD password VARCHAR(255) DEFAULT NULL');
+        $this->addSql('ALTER TABLE "user" ADD role VARCHAR(20) NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE "user" DROP password');
+        $this->addSql('ALTER TABLE "user" DROP role');
+    }
+}

--- a/tests/Unit/Domain/User/UserTest.php
+++ b/tests/Unit/Domain/User/UserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Domain\User;
 
+use App\Domain\User\Enum\UserRoleEnum;
 use App\Domain\User\User;
 use PHPUnit\Framework\TestCase;
 
@@ -15,10 +16,15 @@ final class UserTest extends TestCase
             '9cebe00d-04d8-48da-89b1-059f6b7bfe44',
             'Mathieu Marchois',
             'mathieu@fairness.coop',
+            UserRoleEnum::ROLE_ADMIN,
+            'password'
         );
+
 
         $this->assertSame('9cebe00d-04d8-48da-89b1-059f6b7bfe44', $user->getUuid());
         $this->assertSame('Mathieu Marchois', $user->getFullName());
         $this->assertSame('mathieu@fairness.coop', $user->getEmail());
+        $this->assertSame('password', $user->getPassword());
+        $this->assertSame(UserRoleEnum::ROLE_ADMIN, $user->getRole());
     }
 }


### PR DESCRIPTION
Cette PR a pour objectif de préparer l'authentification :
* Ajout d'un champs `password`, nullable. Il y aura deux façons de s'authentifier : 
    * via un SSO comme mon compte pro (sans l'information du password sur notre DB)
    * via un provider issu de notre DB (utile aux admins, d'où la notion de champs password).

* Ajout d'un champs `role`