### PR TITLE
Update LocationCondition in MCD

### DIFF
--- a/docs/adr/002_mcd.md
+++ b/docs/adr/002_mcd.md
@@ -1,7 +1,7 @@
 # 002 - Modèle Conceptuel de Données DiaLog
 
 * Date : 2022-11-09
-* Modifié le : 2022-12-02
+* Modifié le : 2022-01-10
 * Personnes impliquées : Mathieu Marchois, Florimond Manca
 * Statut : Accepté
 
@@ -60,7 +60,13 @@ class VehicleCharacteristics {
 
 class LocationCondition {
     id*: uuid
-    location: geometry
+    postal_code: varchar[5]
+    city: varchar[255]
+    road_name: varchar[255]
+    from_house_number: varchar[8]
+    from_point: geometry
+    to_house_number: varchar[8]
+    to_point: geometry
 }
 
 class ConditionSet {


### PR DESCRIPTION
Refs #43 

Cette PR modifie `LocationCondition` dans le MCD pour inclure les champs nécessaires.

La modélisation d'une localisation concernant plusieurs rues au sein d'une ville se fera avec un `ConditionSet[operator="or"]` de plusieurs `LocationCondition` ayant toutes la même ville. (Cette contrainte sera vérifiée au niveau applicatif : on ne doit pas pouvoir enregistrer un `RegulationOrder` si ses `LocationCondition` ne concernent pas la même ville.)