### PR TITLE
Setup postgis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ dbinstall: ## Setup databases
 	make dbmigrate
 	make console CMD="doctrine:database:create --env=test --if-not-exists"
 	make dbmigrate ARGS="--env=test"
+	make dbfixtures
 
 dbmigration: ## Generate new db migration
 	${BIN_CONSOLE} doctrine:migrations:diff
@@ -72,8 +73,6 @@ dbshell: ## Connect to the database
 	docker-compose exec database psql ${DATABASE_URL}
 
 dbfixtures: ## Load tests fixtures
-	make console CMD="doctrine:database:create --if-not-exists --env=test"
-	make console CMD="doctrine:migrations:migrate -n --all-or-nothing --env=test"
 	make console CMD="doctrine:fixtures:load --env=test -n --purge-with-truncate"
 
 ##

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "doctrine/doctrine-bundle": "^2.7",
         "doctrine/doctrine-migrations-bundle": "^3.2",
         "doctrine/orm": "^2.13",
+        "jsor/doctrine-postgis": "^2.1",
         "sentry/sentry-symfony": "^4.5",
         "symfony/asset": "6.2.*",
         "symfony/console": "6.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48d4b365f7a0c4439018d994617bcee4",
+    "content-hash": "57ff90447dee070d0a65c49d6bbd8142",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1781,6 +1781,74 @@
                 "source": "https://github.com/Jean85/pretty-package-versions/tree/2.0.5"
             },
             "time": "2021-10-08T21:21:46+00:00"
+        },
+        {
+            "name": "jsor/doctrine-postgis",
+            "version": "v2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jsor/doctrine-postgis.git",
+                "reference": "c82053b1cf4089d68e91f4f827afcdd3735a9b03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jsor/doctrine-postgis/zipball/c82053b1cf4089d68e91f4f827afcdd3735a9b03",
+                "reference": "c82053b1cf4089d68e91f4f827afcdd3735a9b03",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "^2.13 || ^3.1",
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "doctrine/orm": "^2.9",
+                "friendsofphp/php-cs-fixer": "^3.1",
+                "phpunit/phpunit": "^9.5",
+                "vimeo/psalm": "^4.10"
+            },
+            "suggest": {
+                "doctrine/orm": "For using with the Doctrine ORM"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jsor\\Doctrine\\PostGIS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com"
+                }
+            ],
+            "description": "Spatial and Geographic Data with PostGIS and Doctrine.",
+            "keywords": [
+                "database",
+                "dbal",
+                "doctrine",
+                "geo",
+                "geography",
+                "geometry",
+                "gis",
+                "orm",
+                "postgis",
+                "spatial"
+            ],
+            "support": {
+                "issues": "https://github.com/jsor/doctrine-postgis/issues",
+                "source": "https://github.com/jsor/doctrine-postgis/tree/v2.1.0"
+            },
+            "time": "2022-04-21T20:57:00+00:00"
         },
         {
             "name": "laminas/laminas-code",

--- a/config/packages/jsor_doctrine_postgis.yaml
+++ b/config/packages/jsor_doctrine_postgis.yaml
@@ -6,8 +6,6 @@ services:
 doctrine:
     dbal:
         schema_filter: ~^(?!tiger)(?!topology)~
-        mapping_types:
-            _text: string
         types:
             geometry: 
                 class: 'Jsor\Doctrine\PostGIS\Types\GeometryType'

--- a/config/packages/jsor_doctrine_postgis.yaml
+++ b/config/packages/jsor_doctrine_postgis.yaml
@@ -1,0 +1,19 @@
+services:
+    Jsor\Doctrine\PostGIS\Event\ORMSchemaEventSubscriber:
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
+
+doctrine:
+    dbal:
+        schema_filter: ~^(?!tiger)(?!topology)~
+        mapping_types:
+            _text: string
+        types:
+            geometry: 
+                class: 'Jsor\Doctrine\PostGIS\Types\GeometryType'
+                commented: false
+    orm:
+        dql:
+            string_functions:
+                ST_AsGeoJSON: 'Jsor\Doctrine\PostGIS\Functions\ST_AsGeoJSON'
+                ST_GeomFromGeoJSON: 'Jsor\Doctrine\PostGIS\Functions\ST_GeomFromGeoJSON'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ volumes:
 
 services:
   database:
-    image: postgres:14-alpine
+    image: postgis/postgis:14-3.3-alpine
     environment:
       POSTGRES_DB: dialog
       POSTGRES_PASSWORD: dialog

--- a/symfony.lock
+++ b/symfony.lock
@@ -71,6 +71,18 @@
             ".php-cs-fixer.dist.php"
         ]
     },
+    "jsor/doctrine-postgis": {
+        "version": "2.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.7",
+            "ref": "211979f7917bf6edb8fc5006a17b2e84e8e84d50"
+        },
+        "files": [
+            "config/packages/jsor_doctrine_postgis.yaml"
+        ]
+    },
     "phpunit/phpunit": {
         "version": "9.5",
         "recipe": {


### PR DESCRIPTION
Extrait de #84 

Puisque l'intégration Postgis <-> DAMATestBundle pose des problèmes, je fais cette PR qui configure seulement Postgis.

Effectivement on a le même problème que décrit dans #84.

Si on désactive `enable_static_connection`, les tests passent. Mais dans ce cas, le DAMATestBundle semble ne plus avoir l'effet escompté d'enveloppe de transaction. En effet le premier lancement de `make test` réussit, mais un deuxième lancement échouent en raison d'interférences de données manifestes, avec le même effet que si on retire l'extension dans `phpunit.xml.dist`.

Au bout d'une investigation dans le code source de DAMATestBundle et de Doctrine, je pense avoir trouvé et résolu le problème, même si je ne le comprends pas complètement.

TL;DR: Si on supprime `mapping_types`, le problème disparaît.

À la base j'ai ajouté ce type car la documentation du plugin Postgis le proposait : https://github.com/jsor/doctrine-postgis/blob/main/docs/symfony.md#unknown-database-types Mais à la relecture, je crois que ce n'était qu'un exemple...

---

### Investigation "May not alter the nested transaction with savepoints behavior while a transaction is open"

Quand le test s'exécute, la connexion à la DB est créée, ce qui est géré par le StaticConnectionFactory du DAMATestBundle, ici:

https://github.com/dmaicher/doctrine-test-bundle/blob/b60538abb4ad2410b03c9b150e1a806079c3d0ac/src/DAMA/DoctrineTestBundle/Doctrine/DBAL/StaticConnectionFactory.php#L25

Si `mapping_types` n'est pas défini, il est vide, et dans ce cas, ce bloc-ci ne s'exécute pas :

https://github.com/doctrine/DoctrineBundle/blob/206731dd0dd7ef63b7e68dc1b89ca6c5b90fa735/ConnectionFactory.php#L108-L113

Donc on'appelle pas `$connection->getDatabasePlatform()`

Ce qui n'appelle pas `$connection->detectDatabasePlatform()`

Ce qui n'appelle pas `getDatabasePlatformVersion()` :

https://github.com/doctrine/dbal/blob/1507fc7a0262f5ca41c7164398f95663b57b7801/src/Connection.php#L378

Ce qui n'appelle pas `$connection->connect()`

https://github.com/doctrine/dbal/blob/1507fc7a0262f5ca41c7164398f95663b57b7801/src/Connection.php#L416

Ce qui n'appelle pas `$connection->driver->connect()`

https://github.com/doctrine/dbal/blob/1507fc7a0262f5ca41c7164398f95663b57b7801/src/Connection.php#L345

... Mais je suis incapable de comprendre quelles opérations font que le problème de transaction n'apparaît plus.

Le coeur du problème semble être que la connexion "statique" (réutilisée ?) est créée et configurée pour la première fois _à l'intérieur du test_, i.e. une fois que le DAMATestBundle a fait son ouvrage. Le retrait de `mapping_types` est plutôt un heureux hasard pour faire passer les tests, je dirais.