### PR TITLE
Add adr/005_geocoding.md

### DIFF
--- a/docs/adr/005_geocoding.md
+++ b/docs/adr/005_geocoding.md
@@ -1,0 +1,126 @@
+# 005 - Choix d'un service de géocodage
+
+* Date : 2023-01-17
+* Personnes impliquées : Florimond Manca (auteur), Mathieu Marchois
+* Statut : BROUILLON <!-- [BROUILLON|ACCEPTÉ|REJETÉ|DÉPRÉCIÉ] -->
+
+## Contexte
+
+Dans le cadre du MVP, il a été décidé de modéliser la localisation où s'applique une réglementation par une portion de rue. La portion de rue est représentée par : code postal, ville, rue, numéro de début, numéro de fin. (Voir [#43](https://github.com/MTES-MCT/dialog/issues/43) pour plus d'informations.)
+
+Étant données deux points de coordonnées géographiques, le format de données DATEX II (voir [ADR-001](./001_exchangeformat.md)) permet de représenter une portion linéaire de route par l'entité `LinearWithinLinearElement`.
+
+L'approche fut donc de transformer l'adresse de début (adresse + numéro de début) et l'adresse de fin (adresse + numéro de fin) en coordonnées géographiques en vue de l'intégrer à l'export DATEX II et _in fine_ les mettre à disposition des GPS.
+
+Cette opération _adresse -> coordonnées géographiques_ s'appelle le **géocodage** (_geocoding_ en anglais).
+
+Il s'agissait donc de décider quel service de géocodage utiliser.
+
+## Décision
+
+Nous avons décidé d'utiliser l'[API Géocodage 2.0]() (TODO) de l'[IGN](https://www.ign.fr). Cette API fait partie des [Géoservices](https://geoservices.ign.fr) de l'IGN.
+
+## Conséquences
+
+<!--
+Décrire ici ce qui devra être mis en place suite à la décision.
+
+Exemple :
+
+* Les décisions importantes d'architecture seront archivées dans le dossier `adr`.
+* Le fichier d'ADR sera nommé `nnn_titre.md`.
+* L'ADR sera créée via une PR dont le titre de commit commence par `ADR:`.
+-->
+
+## Options envisagées
+
+### Option 1 - API Géocodage 2.0 de l'IGN
+
+**Description**
+
+L'API Géocodage 2.0 de l'IGN est une API Web (XML ou HTTP GET) qui permet de rechercher des éléments géographiques à partir d'une adresse textuelle.
+
+**Utilisation**
+
+En tant qu'API de recherche, l'API peut renvoyer plusieurs résultats, il faut donc appliquer les paramètres de recherche appropriés.
+
+En l'occurrence, nous obtenons des résultats probants avec les paramètres suivants:
+
+* `q=...` - Adresse textuelle
+* `type=housenumber` : ne renvoyer que les éléments géographiques correspondant à des numéros de rue
+* `limit=1` : renvoyer un seul résultat (le plus pertinent)
+
+Exemple de requête et de réponse pour l'adresse textuelle "3 Rue des tournesols 82000 Montauban" :
+
+```http
+GET https://wxs.ign.fr/calcul/geoportail/geocodage/rest/0.1/search?q=3%20Rue%20des%20tournesols%2082000%20Montauban&type=housenumber&limit=1 HTTP/1.1
+Accept: application/json
+```
+
+```json
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "properties": {
+        "label": "3 Rue des Tournesols 82000 Montauban",
+        "score": 0.9698190909090907,
+        "housenumber": "3",
+        "id": "82121_7724_00003",
+        "name": "3 Rue des Tournesols",
+        "postcode": "82000",
+        "citycode": "82121",
+        "x": 570724.97,
+        "y": 6329107.22,
+        "city": "Montauban",
+        "context": "82, Tarn-et-Garonne, Occitanie",
+        "type": "housenumber",
+        "importance": 0.66801,
+        "street": "Rue des Tournesols",
+        "_score": 0.9698190909090907,
+        "_type": "ban"
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          1.386715,
+          44.049081
+        ]
+      }
+    }
+  ]
+}
+```
+
+Les coordonnées (longitude, latitude) peuvent alors être obtenues par :
+
+```php
+$lonLat = $data['features'][0]['geometry']['coordinates'];
+```
+
+**Avantages**
+
+* Elle répond au besoin à l'instant T, à savoir convertir une adresse textuelle en coordonnées géographiques (latitude, longitude).
+* Elle est alimentée par diverses sources, dont : BD TOPO®, ... (TODO)
+
+**Inconvénients**
+
+* La disponibilité du service est incertaine. (TODO)
+* La documentation peut être moins détaillée que des alternatives tierces (voir Option 3). Nos expérimentations ont cependant montré qu'elle était suffisante pour nos besoins.
+
+### Option 2 - API Géocodage historique de l'IGN
+
+TODO
+
+### Option 3 - API de géocodage tierce
+
+Exemples : _Geocoding API_ de Google, de Mapbox, d'ArcGIS, d'OpenStreetMap...
+
+Cette option n'a pas été envisagée car la priorité a été donnée aux outils du service public dès lors qu'ils pouvaient répondre au besoin.
+
+## Références
+
+TODO
+
+* Lien de la documentation API Géocodage 2.0

--- a/docs/adr/005_geocoding.md
+++ b/docs/adr/005_geocoding.md
@@ -10,7 +10,9 @@ Dans le cadre du [MVP](https://github.com/MTES-MCT/dialog/milestone/1), il a ét
 
 Étant donnés deux points de coordonnées géographiques, le format de données DATEX II (voir [ADR-001](./001_exchangeformat.md)) permet de représenter une portion linéaire de route par l'entité `LinearWithinLinearElement`.
 
-L'approche technique est donc de transformer l'adresse de début et l'adresse de fin (adresse + numéro de fin) en coordonnées géographiques en vue de l'intégrer à l'export DATEX II et _in fine_ les mettre à disposition des GPS.
+L'approche technique est proposée est donc de transformer l'adresse de début et l'adresse de fin (adresse + numéro de fin) en coordonnées géographiques en vue de l'intégrer à l'export DATEX II et _in fine_ les mettre à disposition des GPS.
+
+(La représentation DATEX II évoquée ici pourra évoluer avec le retour des GPS et n'est pas l'objet de ce document.)
 
 Cette opération adresse => coordonnées géographiques s'appelle le **géocodage** (_geocoding_ en anglais).
 
@@ -18,13 +20,13 @@ Il s'agit donc de décider quel service de géocodage utiliser.
 
 ## Décision
 
-<!-- Nous avons décidé d'utiliser l'[API Géocodage 2.0]() (TODO) de l'[IGN](https://www.ign.fr). Cette API fait partie des [Géoservices](https://geoservices.ign.fr) de l'IGN. -->
+Nous utiliserons l'[API Adresse](https://adresse.data.gouv.fr/api-doc/adresse) pour le géocodage des adresses.
 
 ## Conséquences
 
-<!-- * Une intégration technique avec l'API Géocodage 2.0 sera réalisée. -->
-<!-- * Comme pour toute intégration d'API tierce, un soin particulier sera apporté à la gestion des erreurs : réponse inattendue, service indisponible. -->
-<!-- * L'API étant ouverte, il n'y aura pas d'identifiants à générer. -->
+* Une intégration technique (appels HTTP) avec l'API Adresse sera réalisée.
+* Comme pour toute intégration d'API tierce, un soin particulier sera apporté à la gestion des erreurs : réponse inattendue, service indisponible.
+* L'API étant ouverte, il n'y aura pas d'identifiants à gérer.
 * Les [limites inhérentes au géocodage](https://guides.etalab.gouv.fr/apis-geo/1-api-adresse.html#les-limites-du-geocodage) seront prises en compte dans l'implémentation côté DiaLog.
 
 ## Options envisagées
@@ -100,12 +102,12 @@ $lonLat = $data['features'][0]['geometry']['coordinates'];
 * L'API Adresse répond à notre besoin à l'instant T.
 * Les coordonnées géographiques sont renvoyées selon la projection standard WSG-84 (EPSG:4326).
 * Les sources de données suggèrent une bonne couverture de l'ensemble du territoire français.
-* La BAN fait aujourd'hui référence. Elle est la "seule base nationale de référence sur l'adresse à faire partie du socle de souveraineté de l'Etat" ([source](https://doc.adresse.data.gouv.fr/)). [La BAN est portée par l'IGN depuis mars 2022](https://www.numerique.gouv.fr/espace-presse/la-base-adresse-nationale-ban-franchit-de-nouvelles-etapes-en-poursuivant-son-action-au-sein-de-lign/) : "L'IGN cesse les mises à jour de ses outils et bases historiques [...] et implique ses équipes dans l'administration de la BAN."
+* La BAN fait aujourd'hui référence. Elle est la "seule base nationale de référence sur l'adresse à faire partie du socle de souveraineté de l'Etat" ([source](https://doc.adresse.data.gouv.fr/)). [La BAN est portée par l'IGN depuis mars 2022](https://www.ign.fr/espace-presse/la-base-adresse-nationale-franchit-de-nouvelles-etapes/) : "L'IGN cesse les mises à jour de ses outils et bases historiques [...] et implique ses équipes dans l'administration de la BAN."
 * L'API Adresse est [bien documentée](https://adresse.data.gouv.fr/api-doc/adresse).
 
 **Inconvénients**
 
-* RAS
+* La requête n'accepte qu'une adresse textuelle, et les éléments géographiques retournés sont uniquement ponctuels. Par exemple, il n'est pas possible d'obtenir l'abscisse curviligne d'une adresse sur la route où elle se situe. C'est une limite du géocodage. Si un autre cas d'usage se fait sentir pour la définition de la localisation ou l'export DATEX II, il faudra envisager d'autres approches.
 
 ### Option 2 - Géocodeur alternatif
 
@@ -119,24 +121,23 @@ A fortiori, les géocodeurs propriétaires (exemple : _Geocoding API_ de Google)
 
 ### Option 3 - API Géocodage 2.0 de l'IGN
 
-L'API Géocodage 2.0 de l'IGN est une API Web (HTTP GET renvoyant du XML) qui permet de rechercher des éléments géographiques à partir d'une adresse textuelle.
+[L'API Géocodage 2.0](https://geoservices.ign.fr/documentation/services/api-et-services-ogc/service-de-geocodage-20) de l'IGN est une API Web (HTTP GET renvoyant du XML) qui permet de rechercher des éléments géographiques à partir d'une adresse textuelle.
 
-Cette API a une interface similaire à l'API Adresse. En fait, la version 2.0 découle probablement de la démarche de l'IGN de prendre la BAN comme référence.
-
+Cette API est très similaire à l'API Adresse, de par son interface comme les données qu'elle intègre. En fait, la version 2.0 découle probablement de la [prise en main de la BAN par l'IGN en mars 2022](https://www.ign.fr/espace-presse/la-base-adresse-nationale-franchit-de-nouvelles-etapes).
 
 **Avantages**
 
 * Elle répond au besoin à l'instant T, à savoir convertir une adresse textuelle en coordonnées géographiques (latitude, longitude).
-* Elle est alimentée par diverses sources, dont : BD TOPO®, ... (TODO)
+* Elle s'appuie sur la BAN.
 
 **Inconvénients**
 
-* La disponibilité du service est incertaine. (TODO)
-* La documentation peut être moins détaillée que des alternatives tierces (voir Option 3). Nos expérimentations ont cependant montré qu'elle était suffisante pour nos besoins.
+* La documentation est moins détaillée que les alternatives. Nos expérimentations ont cependant montré qu'elle était suffisante pour nos besoins.
 * L'utiliser alors que l'API Adresse suffit dérogerait aux [pratiques habituelles Etalab en matière de géocodage](https://guides.etalab.gouv.fr/apis-geo/1-api-adresse.html). Cela peut impacter la reprise du projet par d'autres personnes (effet de surprise).
 
 ## Références
 
-TODO
-
-* Lien de la documentation API Géocodage 2.0
+* [Documentation de l'API Adresse](https://adresse.data.gouv.fr/api-doc/adresse)
+* [Guide Etalab sur l'API Adresse](https://guides.etalab.gouv.fr/apis-geo/1-api-adresse.html)
+* [Documentation d'adresse.data.gouv.fr](https://doc.adresse.data.gouv.fr/) (portail Base Adresse Nationale (BAN))
+* [Documentation technique de l'API Géocodage 2.0 de l'IGN](https://geoservices.ign.fr/documentation/services/api-et-services-ogc/geocodage-20/doc-technique-api-geocodage)

--- a/docs/adr/005_geocoding.md
+++ b/docs/adr/005_geocoding.md
@@ -115,7 +115,7 @@ Etalab cite des [géocodeurs alternatifs](https://guides.etalab.gouv.fr/apis-geo
 
 > Leurs principaux intérêts sont de pouvoir chercher des POIs, par exemple un centre commercial ou une enseigne ainsi que de marcher sur des données internationales, contrairement à [l'API Adresse].
 
-À l'instant T, le besoin de DiaLog n'incluait ni la rechercher par POI, ni l'accès à des données internationales. Il ne semblait donc pas justifié d'utiliser un géocodeur alternatif.
+À l'instant T, le besoin de DiaLog n'incluait ni la recherche par POI, ni l'accès à des données internationales. Il ne semblait donc pas justifié d'utiliser un géocodeur alternatif.
 
 A fortiori, les géocodeurs propriétaires (exemple : _Geocoding API_ de Google) n'ont pas été envisagés.
 

--- a/docs/adr/005_geocoding.md
+++ b/docs/adr/005_geocoding.md
@@ -1,95 +1,91 @@
 # 005 - Choix d'un service de géocodage
 
 * Date : 2023-01-17
-* Personnes impliquées : Florimond Manca (auteur), Mathieu Marchois
+* Personnes impliquées : Florimond Manca (auteur principal), Mathieu Marchois
 * Statut : BROUILLON <!-- [BROUILLON|ACCEPTÉ|REJETÉ|DÉPRÉCIÉ] -->
 
 ## Contexte
 
-Dans le cadre du MVP, il a été décidé de modéliser la localisation où s'applique une réglementation par une portion de rue. La portion de rue est représentée par : code postal, ville, rue, numéro de début, numéro de fin. (Voir [#43](https://github.com/MTES-MCT/dialog/issues/43) pour plus d'informations.)
+Dans le cadre du [MVP](https://github.com/MTES-MCT/dialog/milestone/1), il a été décidé de modéliser la localisation où s'applique une réglementation par une portion de rue. La portion de rue est représentée par : code postal, ville, rue, numéro de début, numéro de fin. (Voir [#43](https://github.com/MTES-MCT/dialog/issues/43) pour plus d'informations.)
 
-Étant données deux points de coordonnées géographiques, le format de données DATEX II (voir [ADR-001](./001_exchangeformat.md)) permet de représenter une portion linéaire de route par l'entité `LinearWithinLinearElement`.
+Étant donnés deux points de coordonnées géographiques, le format de données DATEX II (voir [ADR-001](./001_exchangeformat.md)) permet de représenter une portion linéaire de route par l'entité `LinearWithinLinearElement`.
 
-L'approche fut donc de transformer l'adresse de début (adresse + numéro de début) et l'adresse de fin (adresse + numéro de fin) en coordonnées géographiques en vue de l'intégrer à l'export DATEX II et _in fine_ les mettre à disposition des GPS.
+L'approche technique est donc de transformer l'adresse de début et l'adresse de fin (adresse + numéro de fin) en coordonnées géographiques en vue de l'intégrer à l'export DATEX II et _in fine_ les mettre à disposition des GPS.
 
-Cette opération _adresse -> coordonnées géographiques_ s'appelle le **géocodage** (_geocoding_ en anglais).
+Cette opération adresse => coordonnées géographiques s'appelle le **géocodage** (_geocoding_ en anglais).
 
-Il s'agissait donc de décider quel service de géocodage utiliser.
+Il s'agit donc de décider quel service de géocodage utiliser.
 
 ## Décision
 
-Nous avons décidé d'utiliser l'[API Géocodage 2.0]() (TODO) de l'[IGN](https://www.ign.fr). Cette API fait partie des [Géoservices](https://geoservices.ign.fr) de l'IGN.
+<!-- Nous avons décidé d'utiliser l'[API Géocodage 2.0]() (TODO) de l'[IGN](https://www.ign.fr). Cette API fait partie des [Géoservices](https://geoservices.ign.fr) de l'IGN. -->
 
 ## Conséquences
 
-<!--
-Décrire ici ce qui devra être mis en place suite à la décision.
-
-Exemple :
-
-* Les décisions importantes d'architecture seront archivées dans le dossier `adr`.
-* Le fichier d'ADR sera nommé `nnn_titre.md`.
-* L'ADR sera créée via une PR dont le titre de commit commence par `ADR:`.
--->
+<!-- * Une intégration technique avec l'API Géocodage 2.0 sera réalisée. -->
+<!-- * Comme pour toute intégration d'API tierce, un soin particulier sera apporté à la gestion des erreurs : réponse inattendue, service indisponible. -->
+<!-- * L'API étant ouverte, il n'y aura pas d'identifiants à générer. -->
+* Les [limites inhérentes au géocodage](https://guides.etalab.gouv.fr/apis-geo/1-api-adresse.html#les-limites-du-geocodage) seront prises en compte dans l'implémentation côté DiaLog.
 
 ## Options envisagées
 
-### Option 1 - API Géocodage 2.0 de l'IGN
+### Option 1 - API Adresse
+
+Site web : https://api.gouv.fr/les-api/base-adresse-nationale
 
 **Description**
 
-L'API Géocodage 2.0 de l'IGN est une API Web (XML ou HTTP GET) qui permet de rechercher des éléments géographiques à partir d'une adresse textuelle.
+L'API Adresse permet de faire du géocodage.
+
+Les données proviennent de la [Base Adresse Nationale (BAN)](https://adresse.data.gouv.fr/) (pour les communes qui disposent d'une Base Adresse Locale), ou d'autres bases comme l'IGN, La Poste, la DGFIP, etc (pour les autres communes). Le moteur de calcul est le moteur de recherche open source [Addok](https://github.com/addok/addok).
 
 **Utilisation**
 
-En tant qu'API de recherche, l'API peut renvoyer plusieurs résultats, il faut donc appliquer les paramètres de recherche appropriés.
+Voir la [Documentation](https://adresse.data.gouv.fr/api-doc/adresse)
 
-En l'occurrence, nous obtenons des résultats probants avec les paramètres suivants:
+Exemple de requête / réponse :
 
-* `q=...` - Adresse textuelle
-* `type=housenumber` : ne renvoyer que les éléments géographiques correspondant à des numéros de rue
-* `limit=1` : renvoyer un seul résultat (le plus pertinent)
-
-Exemple de requête et de réponse pour l'adresse textuelle "3 Rue des tournesols 82000 Montauban" :
-
-```http
-GET https://wxs.ign.fr/calcul/geoportail/geocodage/rest/0.1/search?q=3%20Rue%20des%20tournesols%2082000%20Montauban&type=housenumber&limit=1 HTTP/1.1
-Accept: application/json
+```bash
+curl "https://api-adresse.data.gouv.fr/search/?q=17+route+lac+44260+Savenay&limit=1&autocomplete=0" 
 ```
 
 ```json
 {
   "type": "FeatureCollection",
+  "version": "draft",
   "features": [
     {
       "type": "Feature",
-      "properties": {
-        "label": "3 Rue des Tournesols 82000 Montauban",
-        "score": 0.9698190909090907,
-        "housenumber": "3",
-        "id": "82121_7724_00003",
-        "name": "3 Rue des Tournesols",
-        "postcode": "82000",
-        "citycode": "82121",
-        "x": 570724.97,
-        "y": 6329107.22,
-        "city": "Montauban",
-        "context": "82, Tarn-et-Garonne, Occitanie",
-        "type": "housenumber",
-        "importance": 0.66801,
-        "street": "Rue des Tournesols",
-        "_score": 0.9698190909090907,
-        "_type": "ban"
-      },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          1.386715,
-          44.049081
+          -1.938313,
+          47.358325
         ]
+      },
+      "properties": {
+        "label": "17 Route du Lac 44260 Savenay",
+        "score": 0.9620518181818181,
+        "housenumber": "17",
+        "id": "44195_0800_00017",
+        "name": "17 Route du Lac",
+        "postcode": "44260",
+        "citycode": "44195",
+        "x": 327487.03,
+        "y": 6706984.59,
+        "city": "Savenay",
+        "context": "44, Loire-Atlantique, Pays de la Loire",
+        "type": "housenumber",
+        "importance": 0.58257,
+        "street": "Route du Lac"
       }
     }
-  ]
+  ],
+  "attribution": "BAN",
+  "licence": "ETALAB-2.0",
+  "query": "17 Route du Lac 44260 Savenay",
+  "filters": {},
+  "limit": 1
 }
 ```
 
@@ -101,6 +97,35 @@ $lonLat = $data['features'][0]['geometry']['coordinates'];
 
 **Avantages**
 
+* L'API Adresse répond à notre besoin à l'instant T.
+* Les coordonnées géographiques sont renvoyées selon la projection standard WSG-84 (EPSG:4326).
+* Les sources de données suggèrent une bonne couverture de l'ensemble du territoire français.
+* La BAN fait aujourd'hui référence. Elle est la "seule base nationale de référence sur l'adresse à faire partie du socle de souveraineté de l'Etat" ([source](https://doc.adresse.data.gouv.fr/)). [La BAN est portée par l'IGN depuis mars 2022](https://www.numerique.gouv.fr/espace-presse/la-base-adresse-nationale-ban-franchit-de-nouvelles-etapes-en-poursuivant-son-action-au-sein-de-lign/) : "L'IGN cesse les mises à jour de ses outils et bases historiques [...] et implique ses équipes dans l'administration de la BAN."
+* L'API Adresse est [bien documentée](https://adresse.data.gouv.fr/api-doc/adresse).
+
+**Inconvénients**
+
+* RAS
+
+### Option 2 - Géocodeur alternatif
+
+Etalab cite des [géocodeurs alternatifs](https://guides.etalab.gouv.fr/apis-geo/1-api-adresse.html#geocodeurs-alternatifs) (open source ou service public tel que l'IGN), avec cette note :
+
+> Leurs principaux intérêts sont de pouvoir chercher des POIs, par exemple un centre commercial ou une enseigne ainsi que de marcher sur des données internationales, contrairement à [l'API Adresse].
+
+À l'instant T, le besoin de DiaLog n'incluait ni la rechercher par POI, ni l'accès à des données internationales. Il ne semblait donc pas justifié d'utiliser un géocodeur alternatif.
+
+A fortiori, les géocodeurs propriétaires (exemple : _Geocoding API_ de Google) n'ont pas été envisagés.
+
+### Option 3 - API Géocodage 2.0 de l'IGN
+
+L'API Géocodage 2.0 de l'IGN est une API Web (HTTP GET renvoyant du XML) qui permet de rechercher des éléments géographiques à partir d'une adresse textuelle.
+
+Cette API a une interface similaire à l'API Adresse. En fait, la version 2.0 découle probablement de la démarche de l'IGN de prendre la BAN comme référence.
+
+
+**Avantages**
+
 * Elle répond au besoin à l'instant T, à savoir convertir une adresse textuelle en coordonnées géographiques (latitude, longitude).
 * Elle est alimentée par diverses sources, dont : BD TOPO®, ... (TODO)
 
@@ -108,16 +133,7 @@ $lonLat = $data['features'][0]['geometry']['coordinates'];
 
 * La disponibilité du service est incertaine. (TODO)
 * La documentation peut être moins détaillée que des alternatives tierces (voir Option 3). Nos expérimentations ont cependant montré qu'elle était suffisante pour nos besoins.
-
-### Option 2 - API Géocodage historique de l'IGN
-
-TODO
-
-### Option 3 - API de géocodage tierce
-
-Exemples : _Geocoding API_ de Google, de Mapbox, d'ArcGIS, d'OpenStreetMap...
-
-Cette option n'a pas été envisagée car la priorité a été donnée aux outils du service public dès lors qu'ils pouvaient répondre au besoin.
+* L'utiliser alors que l'API Adresse suffit dérogerait aux [pratiques habituelles Etalab en matière de géocodage](https://guides.etalab.gouv.fr/apis-geo/1-api-adresse.html). Cela peut impacter la reprise du projet par d'autres personnes (effet de surprise).
 
 ## Références
 

--- a/docs/adr/005_geocoding.md
+++ b/docs/adr/005_geocoding.md
@@ -1,7 +1,7 @@
 # 005 - Choix d'un service de géocodage
 
 * Date : 2023-01-17
-* Personnes impliquées : Florimond Manca (auteur principal), Mathieu Marchois
+* Personnes impliquées : Florimond Manca (auteur principal), Mathieu Marchois (relecture technique), équipe DiaLog (relecture et commentaires)
 * Statut : BROUILLON <!-- [BROUILLON|ACCEPTÉ|REJETÉ|DÉPRÉCIÉ] -->
 
 ## Contexte

--- a/docs/adr/005_geocoding.md
+++ b/docs/adr/005_geocoding.md
@@ -10,7 +10,7 @@ Dans le cadre du [MVP](https://github.com/MTES-MCT/dialog/milestone/1), il a ét
 
 Étant donnés deux points de coordonnées géographiques, le format de données DATEX II (voir [ADR-001](./001_exchangeformat.md)) permet de représenter une portion linéaire de route par l'entité `LinearWithinLinearElement`.
 
-L'approche technique est proposée est donc de transformer l'adresse de début et l'adresse de fin (adresse + numéro de fin) en coordonnées géographiques en vue de l'intégrer à l'export DATEX II et _in fine_ les mettre à disposition des GPS.
+L'approche technique proposée est donc de transformer l'adresse de début et l'adresse de fin (adresse + numéro de fin) en coordonnées géographiques en vue de l'intégrer à l'export DATEX II et _in fine_ les mettre à disposition des GPS.
 
 (La représentation DATEX II évoquée ici pourra évoluer avec le retour des GPS et n'est pas l'objet de ce document.)
 


### PR DESCRIPTION
Refs #43, suggéré dans le cadre de #89 

---

[Aperçu du document](https://github.com/MTES-MCT/dialog/blob/adr/geocoding/docs/adr/005_geocoding.md)

---

Cette PR documente la décision du choix de l'API de géocodage pour les besoins techniques de la conversion adresse textuelle -> coordonnées géographiques pour export DATEX II.
