### PR TITLE
Fix swapped coordinates

### DIFF
--- a/docs/tools/services.md
+++ b/docs/tools/services.md
@@ -19,6 +19,8 @@ DiaLog s'interface avec l'[API Adresse](https://adresse.data.gouv.fr/api-doc/adr
 
 Utilisez la commande utilitaire `app:geocode`.
 
+La valeur affichée est un `POINT(X Y)` selon le format WKT, dans la projection standard EPSG:4326 (X = longitude et Y = latitude).
+
 Exemple :
 
 ```bash
@@ -26,5 +28,5 @@ make console CMD="app:geocode '3 Rue des Tournesols 82000 Montauban'"
 ```
 
 ```console
-POINT(44.049081 1.386715)
+POINT(1.386715 44.049081)
 ```

--- a/src/Domain/Geography/Coordinates.php
+++ b/src/Domain/Geography/Coordinates.php
@@ -7,13 +7,13 @@ namespace App\Domain\Geography;
 class Coordinates
 {
     private function __construct(
-        public readonly float $latitude,
         public readonly float $longitude,
+        public readonly float $latitude,
     ) {
     }
 
-    public static function fromLatLon(float $latitude, float $longitude): self
+    public static function fromLonLat(float $longitude, float $latitude): self
     {
-        return new self($latitude, $longitude);
+        return new self($longitude, $latitude);
     }
 }

--- a/src/Domain/Geography/GeometryFormatter.php
+++ b/src/Domain/Geography/GeometryFormatter.php
@@ -6,17 +6,22 @@ namespace App\Domain\Geography;
 
 class GeometryFormatter
 {
-    // See: https://github.com/jsor/doctrine-postgis
-    // "Values provided for the properties must be in the WKT format."
-
-    // NOTE: We need to decide what precision to use.
-    // The default for `sprintf` is 6.
-    // 1e-6 degree amounts to about 10cm, which is well enough for coordinates.
-    // (See: https://www.rfc-editor.org/rfc/rfc7946#section-11.2)
-    // So let's use 6 explicitly.
-
     public function formatPoint(float $latitude, float $longitude): string
     {
-        return sprintf('POINT(%.6f %.6f)', $latitude, $longitude);
+        // See: https://github.com/jsor/doctrine-postgis
+        // "Values provided for the properties must be in the WKT format."
+
+        // WKT is "Well-known text": https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry
+
+        // In WKT, 2D points are in the form: `POINT(X Y)`.
+        // When using the standard EPSG:4326 projection, X is the longitude (East<>West axis) and Y is the latitude (North<>South axis).
+
+        // NOTE: We need to decide what precision to use.
+        // The default for `sprintf` is 6.
+        // 1e-6° amounts to about 10cm, which is enough for coordinates.
+        // (See: https://www.rfc-editor.org/rfc/rfc7946#section-11.2)
+        // So we use 6 explicitly.
+
+        return sprintf('POINT(%.6f %.6f)', $longitude, $latitude);
     }
 }

--- a/src/Infrastructure/Adapter/APIAdresseGeocoder.php
+++ b/src/Infrastructure/Adapter/APIAdresseGeocoder.php
@@ -93,21 +93,15 @@ final class APIAdresseGeocoder implements GeocoderInterface
             throw new GeocodingFailureException($message);
         }
 
-        // Caution: GeoJSON uses (longitude, latitude).
+        // GeoJSON uses (longitude, latitude).
         // See: https://www.rfc-editor.org/rfc/rfc7946#section-3.1.1
-        // But we process (latitude, longitude). (There's no standard on this.)
         $lonLat = $point['geometry']['coordinates'];
-
-        // Phew. Let's do a final check on the coordinates.
 
         if (\count($lonLat) !== 2) {
             $message = sprintf('%s: expected 2 coordinates, got %d', $errorMsgPrefix, \count($lonLat));
             throw new GeocodingFailureException($message);
         }
 
-        $longitude = $lonLat[0];
-        $latitude = $lonLat[1];
-
-        return Coordinates::fromLatLon($latitude, $longitude);
+        return Coordinates::fromLonLat($lonLat[0], $lonLat[1]);
     }
 }

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/LocationFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/LocationFixture.php
@@ -20,9 +20,9 @@ final class LocationFixture extends Fixture implements DependentFixtureInterface
             'Savenay',
             'Route du Grand Brossais',
             '15',
-            'POINT(47.347024 -1.935836)',
+            'POINT(-1.935836 47.347024)',
             '37bis',
-            'POINT(47.347917 -1.930973)',
+            'POINT(-1.930973 47.347917)',
         );
 
         $manager->persist($location);

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep2CommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep2CommandHandlerTest.php
@@ -37,9 +37,9 @@ final class SaveRegulationStep2CommandHandlerTest extends TestCase
         $this->city = 'Savenay';
         $this->roadName = 'Route du Grand Brossais';
         $this->fromHouseNumber = '15';
-        $this->fromPoint = 'POINT(47.347024 -1.935836)';
+        $this->fromPoint = 'POINT(-1.935836 47.347024)';
         $this->toHouseNumber = '37bis';
-        $this->toPoint = 'POINT(47.347917 -1.930973)';
+        $this->toPoint = 'POINT(-1.930973 47.347917)';
 
         $this->regulationCondition = $this->createMock(RegulationCondition::class);
         $this->regulationOrder = $this->createMock(RegulationOrder::class);
@@ -73,8 +73,8 @@ final class SaveRegulationStep2CommandHandlerTest extends TestCase
             ->expects(self::exactly(2))
             ->method('computeCoordinates')
             ->willReturnOnConsecutiveCalls(
-                Coordinates::fromLatLon(47.347024, -1.935836),
-                Coordinates::fromLatLon(47.347917, -1.930973),
+                Coordinates::fromLonLat(-1.935836, 47.347024),
+                Coordinates::fromLonLat(-1.930973, 47.347917),
             );
 
         $geometryFormatter = $this->createMock(GeometryFormatter::class);
@@ -82,8 +82,8 @@ final class SaveRegulationStep2CommandHandlerTest extends TestCase
             ->expects(self::exactly(2))
             ->method('formatPoint')
             ->willReturnOnConsecutiveCalls(
-                'POINT(47.347024 -1.935836)',
-                'POINT(47.347917 -1.930973)',
+                'POINT(-1.935836 47.347024)',
+                'POINT(-1.930973 47.347917)',
             );
 
         $location = new Location(
@@ -147,8 +147,8 @@ final class SaveRegulationStep2CommandHandlerTest extends TestCase
             ->expects(self::exactly(2))
             ->method('computeCoordinates')
             ->willReturnOnConsecutiveCalls(
-                Coordinates::fromLatLon(47.347024, -1.935836),
-                Coordinates::fromLatLon(47.347917, -1.930973),
+                Coordinates::fromLonLat(-1.935836, 47.347024),
+                Coordinates::fromLonLat(-1.930973, 47.347917),
             );
 
         $geometryFormatter = $this->createMock(GeometryFormatter::class);
@@ -156,8 +156,8 @@ final class SaveRegulationStep2CommandHandlerTest extends TestCase
             ->expects(self::exactly(2))
             ->method('formatPoint')
             ->willReturnOnConsecutiveCalls(
-                'POINT(47.347024 -1.935836)',
-                'POINT(47.347917 -1.930973)',
+                'POINT(-1.935836 47.347024)',
+                'POINT(-1.930973 47.347917)',
             );
     
         $locationRepository = $this->createMock(LocationRepositoryInterface::class);

--- a/tests/Unit/Domain/Condition/LocationTest.php
+++ b/tests/Unit/Domain/Condition/LocationTest.php
@@ -20,9 +20,9 @@ final class LocationTest extends TestCase
             'Savenay',
             'Route du Grand Brossais',
             '15',
-            'POINT(47.347024 -1.935836)',
+            'POINT(-1.935836 47.347024)',
             '37bis',
-            'POINT(47.347917 -1.930973)',
+            'POINT(-1.930973 47.347917)',
         );
 
         $this->assertSame('b4812143-c4d8-44e6-8c3a-34688becae6e', $location->getUuid());
@@ -31,9 +31,9 @@ final class LocationTest extends TestCase
         $this->assertSame('Savenay', $location->getCity());
         $this->assertSame('Route du Grand Brossais', $location->getRoadName());
         $this->assertSame('15', $location->getFromHouseNumber());
-        $this->assertSame('POINT(47.347024 -1.935836)', $location->getFromPoint());
+        $this->assertSame('POINT(-1.935836 47.347024)', $location->getFromPoint());
         $this->assertSame('37bis', $location->getToHouseNumber());
-        $this->assertSame('POINT(47.347917 -1.930973)', $location->getToPoint());
+        $this->assertSame('POINT(-1.930973 47.347917)', $location->getToPoint());
     }
 
     public function testUpdate(): void
@@ -47,18 +47,18 @@ final class LocationTest extends TestCase
             'Savenay',
             'Route du Grand Brossais',
             '15',
-            'POINT(47.347024 -1.935836)',
+            'POINT(-1.935836 47.347024)',
             '37bis',
-            'POINT(47.347917 -1.930973)',
+            'POINT(-1.930973 47.347917)',
         );
 
         $newPostalCode = '44750';
         $newCity = 'Campbon';
         $newRoadName = 'La Forge Hervé';
         $newFromHouseNumber = '1';
-        $newFromPoint = 'POINT(47.358454 -1.938727)';
+        $newFromPoint = 'POINT(-1.938727 47.358454)';
         $newToHouseNumber = '4';
-        $newToPoint = 'POINT(47.388473 -1.940304)';
+        $newToPoint = 'POINT(-1.940304 47.388473)';
 
         $location->update(
             $newPostalCode,

--- a/tests/Unit/Domain/Geography/CoordinatesTest.php
+++ b/tests/Unit/Domain/Geography/CoordinatesTest.php
@@ -11,8 +11,8 @@ final class CoordinatesTest extends TestCase
 {
     public function testGetters(): void
     {
-        $coords = Coordinates::fromLatLon(43.6, -1.9);
-        $this->assertSame(43.6, $coords->latitude);
+        $coords = Coordinates::fromLonLat(-1.9, 43.6);
         $this->assertSame(-1.9, $coords->longitude);
+        $this->assertSame(43.6, $coords->latitude);
     }
 }

--- a/tests/Unit/Domain/Geography/GeometryFormatterTest.php
+++ b/tests/Unit/Domain/Geography/GeometryFormatterTest.php
@@ -13,6 +13,6 @@ final class GeometryFormatterTest extends TestCase
     {
         $formatter = new GeometryFormatter();
         $point = $formatter->formatPoint(43.6, -1.9);
-        $this->assertSame('POINT(43.600000 -1.900000)', $point);
+        $this->assertSame('POINT(-1.900000 43.600000)', $point);
     }
 }

--- a/tests/Unit/Infrastructure/Symfony/Command/GeocodeCommandTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Command/GeocodeCommandTest.php
@@ -22,12 +22,12 @@ class GeocodeCommandTest extends TestCase
             ->expects(self::once())
             ->method('computeCoordinates')
             ->with('3 Rue des Tournesols 82000 Montauban')
-            ->willReturn(Coordinates::fromLatLon(44.049081, 1.386715));
+            ->willReturn(Coordinates::fromLonLat(1.386715, 44.049081));
 
         $geometryFormatter
             ->expects(self::once())
             ->method('formatPoint')
-            ->willReturn('POINT(44.049081 1.386715)');
+            ->willReturn('POINT(1.386715 44.049081)');
 
         $command = new GeocodeCommand($geocoder, $geometryFormatter);
         $commandTester = new CommandTester($command);
@@ -41,6 +41,6 @@ class GeocodeCommandTest extends TestCase
         $commandTester->assertCommandIsSuccessful();
 
         $output = $commandTester->getDisplay();
-        $this->assertStringContainsString('POINT(44.049081 1.386715)', $output);
+        $this->assertStringContainsString('POINT(1.386715 44.049081)', $output);
     }
 }


### PR DESCRIPTION
Correctif pour #89 

Le `GeographyFormatter` retournait un `POINT(latitude longitude)`

Mais en WKT, un point est un `POINT(X Y)`. https://en.wikipedia.org/wiki/Well-known_text_representation_of_geometry

La signification de X et de Y dépend de la projection utilisée. Dans la projection standard EPSG:4326, que l'on utilise, X est la longitude (axe est-ouest) et Y et la latitude (axe nord-sud) : http://www.postgis.fr/chrome/site/docs/workshop-foss4g/doc/geography.html

Il faut donc en fait renvoyer `POINT(longitude latitude)` !

En fait, API Adresse, l'IGN et GeoJSON utilisent tous la convention `lon-lat`, probablement parce que ça correspond au `(X, Y)` dans la projection utilisée (EPSG:4326). Par cohérence, je modifie ici aussi le code pour utiliser cette convention-là plutôt que `lat-lon`.

**Contexte** : je m'en suis rendu compte parce que les coordonnées étaient inversées dans #102 