### PR TITLE
Add more form texts and tweaks

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -1,4 +1,4 @@
-/* Set by Symfony for form types with required: true */
-label.required::after {
+/* label.required is set by Symfony for form types with 'required => true' */
+label.required > .fr-x-label-content::after {
     content: ' *';
 }

--- a/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep1Command.xml
+++ b/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep1Command.xml
@@ -3,13 +3,13 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
     <class name="App\Application\Regulation\Command\Steps\SaveRegulationStep1Command">
-        <property name="description">
+        <property name="issuingAuthority">
             <constraint name="NotBlank" />
             <constraint name="Length">
                 <option name="max">255</option>
             </constraint>
         </property>
-        <property name="issuingAuthority">
+        <property name="description">
             <constraint name="NotBlank" />
             <constraint name="Length">
                 <option name="max">255</option>

--- a/src/Application/Regulation/Command/Steps/SaveRegulationStep1Command.php
+++ b/src/Application/Regulation/Command/Steps/SaveRegulationStep1Command.php
@@ -9,8 +9,8 @@ use App\Domain\Regulation\RegulationOrderRecord;
 
 final class SaveRegulationStep1Command implements CommandInterface
 {
-    public ?string $description;
     public ?string $issuingAuthority;
+    public ?string $description;
 
     public function __construct(
         public readonly ?RegulationOrderRecord $regulationOrderRecord = null,
@@ -22,8 +22,8 @@ final class SaveRegulationStep1Command implements CommandInterface
     ): self {
         $regulationOrder = $regulationOrderRecord?->getRegulationOrder();
         $command = new self($regulationOrderRecord);
-        $command->description = $regulationOrder?->getDescription();
         $command->issuingAuthority = $regulationOrder?->getIssuingAuthority();
+        $command->description = $regulationOrder?->getDescription();
 
         return $command;
     }

--- a/src/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandler.php
+++ b/src/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandler.php
@@ -38,8 +38,8 @@ final class SaveRegulationStep1CommandHandler
             $regulationOrder = $this->regulationOrderRepository->save(
                 new RegulationOrder(
                     uuid: $this->idFactory->make(),
-                    description: $command->description,
                     issuingAuthority: $command->issuingAuthority,
+                    description: $command->description,
                     regulationCondition: $regulationCondition,
                 ),
             );
@@ -58,8 +58,8 @@ final class SaveRegulationStep1CommandHandler
         }
 
         $command->regulationOrderRecord->getRegulationOrder()->update(
-            description: $command->description,
             issuingAuthority: $command->issuingAuthority,
+            description: $command->description,
         );
 
         return $command->regulationOrderRecord->getUuid();

--- a/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
@@ -24,8 +24,8 @@ final class GetRegulationOrdersToDatexFormatQueryHandler
         foreach ($regulationOrders as $regulationOrder) {
             $regulationOrderViews[] = new RegulationOrderListForDatexFormatView(
                 $regulationOrder['uuid'],
-                $regulationOrder['description'],
                 $regulationOrder['issuingAuthority'],
+                $regulationOrder['description'],
                 new PeriodView(
                     $regulationOrder['startPeriod'],
                     $regulationOrder['endPeriod'],

--- a/src/Application/Regulation/View/RegulationOrderListForDatexFormatView.php
+++ b/src/Application/Regulation/View/RegulationOrderListForDatexFormatView.php
@@ -8,8 +8,8 @@ final class RegulationOrderListForDatexFormatView
 {
     public function __construct(
         public readonly string $uuid,
-        public readonly string $description,
         public readonly string $issuingAuthority,
+        public readonly string $description,
         public readonly PeriodView $period,
         public readonly ?DatexLocationView $location,
     ) {

--- a/src/Domain/Regulation/RegulationOrder.php
+++ b/src/Domain/Regulation/RegulationOrder.php
@@ -10,8 +10,8 @@ class RegulationOrder
 {
     public function __construct(
         private string $uuid,
-        private string $description,
         private string $issuingAuthority,
+        private string $description,
         private RegulationCondition $regulationCondition,
     ) {
     }
@@ -21,14 +21,14 @@ class RegulationOrder
         return $this->uuid;
     }
 
-    public function getDescription(): string
-    {
-        return $this->description;
-    }
-
     public function getIssuingAuthority(): string
     {
         return $this->issuingAuthority;
+    }
+
+    public function getDescription(): string
+    {
+        return $this->description;
     }
 
     public function getRegulationCondition(): RegulationCondition
@@ -36,9 +36,11 @@ class RegulationOrder
         return $this->regulationCondition;
     }
 
-    public function update(string $description, string $issuingAuthority): void
-    {
-        $this->description = $description;
+    public function update(
+        string $issuingAuthority,
+        string $description,
+    ): void {
         $this->issuingAuthority = $issuingAuthority;
+        $this->description = $description;
     }
 }

--- a/src/Infrastructure/Form/Regulation/Step1FormType.php
+++ b/src/Infrastructure/Form/Regulation/Step1FormType.php
@@ -15,19 +15,19 @@ final class Step1FormType extends AbstractType
     {
         $builder
             ->add(
-                'description',
-                TextType::class,
-                options: [
-                    'label' => 'regulation.step1.description',
-                    'help' => 'regulation.step1.description.help',
-                ],
-            )
-            ->add(
                 'issuingAuthority',
                 TextType::class,
                 options: [
                     'label' => 'regulation.step1.issuing_authority',
                     'help' => 'regulation.step1.issuing_authority.help',
+                ],
+            )
+            ->add(
+                'description',
+                TextType::class,
+                options: [
+                    'label' => 'regulation.step1.description',
+                    'help' => 'regulation.step1.description.help',
                 ],
             )
             ->add(

--- a/src/Infrastructure/Form/Regulation/Step1FormType.php
+++ b/src/Infrastructure/Form/Regulation/Step1FormType.php
@@ -19,6 +19,7 @@ final class Step1FormType extends AbstractType
                 TextType::class,
                 options: [
                     'label' => 'regulation.step1.description',
+                    'help' => 'regulation.step1.description.help',
                 ],
             )
             ->add(
@@ -26,6 +27,7 @@ final class Step1FormType extends AbstractType
                 TextType::class,
                 options: [
                     'label' => 'regulation.step1.issuing_authority',
+                    'help' => 'regulation.step1.issuing_authority.help',
                 ],
             )
             ->add(

--- a/src/Infrastructure/Form/Regulation/Step3FormType.php
+++ b/src/Infrastructure/Form/Regulation/Step3FormType.php
@@ -19,6 +19,7 @@ final class Step3FormType extends AbstractType
                 DateType::class,
                 options: [
                     'label' => 'regulation.step3.start_period',
+                    'help' => 'regulation.step3.start_period.help',
                     'widget' => 'single_text',
                 ],
             )
@@ -27,6 +28,7 @@ final class Step3FormType extends AbstractType
                 DateType::class,
                 options: [
                     'label' => 'regulation.step3.end_period',
+                    'help' => 'regulation.step3.end_period.help',
                     'widget' => 'single_text',
                     'required' => false,
                 ],

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
@@ -14,24 +14,24 @@ final class RegulationOrderFixture extends Fixture implements DependentFixtureIn
     public function load(ObjectManager $manager): void
     {
         $regulationOrder = new RegulationOrder(
-            '54eacea0-e1e0-4823-828d-3eae72b76da8',
-            'Description 1',
-            'Autorité 1',
-            $this->getReference('regulationCondition1'),
+            uuid: '54eacea0-e1e0-4823-828d-3eae72b76da8',
+            issuingAuthority: 'Autorité 1',
+            description: 'Description 1',
+            regulationCondition: $this->getReference('regulationCondition1'),
         );
 
         $regulationOrder2 = new RegulationOrder(
-            '2e5eb289-90c8-4c3f-8e7c-2e9e7de8948c',
-            'Description 2',
-            'Autorité 2',
-            $this->getReference('regulationCondition2'),
+            uuid: '2e5eb289-90c8-4c3f-8e7c-2e9e7de8948c',
+            issuingAuthority: 'Autorité 2',
+            description: 'Description 2',
+            regulationCondition: $this->getReference('regulationCondition2'),
         );
 
         $regulationOrder3 = new RegulationOrder(
-            'c147cc20-ed02-4bd9-9f6b-91b67df296bd',
-            'Description 3',
-            'Autorité 3',
-            $this->getReference('regulationCondition3'),
+            uuid: 'c147cc20-ed02-4bd9-9f6b-91b67df296bd',
+            issuingAuthority: 'Description 3',
+            description: 'Autorité 3',
+            regulationCondition: $this->getReference('regulationCondition3'),
         );
 
         $manager->persist($regulationOrder);

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.RegulationOrder.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.RegulationOrder.orm.xml
@@ -4,8 +4,8 @@
     name="App\Domain\Regulation\RegulationOrder"
     table="regulation_order">
     <id name="uuid" type="guid" column="uuid"/>
-    <field name="description" type="text" column="description" nullable="false"/>
     <field name="issuingAuthority" type="string" column="issuing_authority" nullable="false"/>
+    <field name="description" type="text" column="description" nullable="false"/>
     <one-to-one field="regulationCondition" target-entity="App\Domain\Condition\RegulationCondition" inversed-by="regulationOrder">
         <join-column name="regulation_condition_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE"/>
     </one-to-one>

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRepository.php
@@ -28,8 +28,8 @@ final class RegulationOrderRepository extends ServiceEntityRepository implements
         return $this->createQueryBuilder('ro')
             ->select(
                 'ro.uuid',
-                'ro.description',
                 'ro.issuingAuthority',
+                'ro.description',
                 'o.startPeriod',
                 'o.endPeriod',
                 'loc.postalCode',

--- a/templates/common/attr.html.twig
+++ b/templates/common/attr.html.twig
@@ -1,0 +1,4 @@
+{%- for name, value in attr -%}
+    {{- " " -}}
+    {{- name }}="{{ value }}"
+{%- endfor -%}

--- a/templates/common/attr.html.twig
+++ b/templates/common/attr.html.twig
@@ -1,4 +1,0 @@
-{%- for name, value in attr -%}
-    {{- " " -}}
-    {{- name }}="{{ value }}"
-{%- endfor -%}

--- a/templates/common/form/dsfr_theme.html.twig
+++ b/templates/common/form/dsfr_theme.html.twig
@@ -19,13 +19,25 @@
     {{- form_label(form) -}}
     {{- form_widget(form, widget_attr) -}}
     {{- form_errors(form) -}}
-    {{- form_help(form) -}}
   </div>
 {% endblock form_row %}
 
 {% block form_label %}
   {%- set label_class = (label_attr.class|default('') ~ ' fr-label')|trim -%}
   {%- set label_attr = label_attr|merge({class: label_class}) -%}
+  {{ parent() }}
+{% endblock %}
+
+{% block form_label_content %}
+  {%- set label_content_attr = label_content_attr|default({})|merge({class: label_content_attr.class|default('') ~ ' fr-x-label-content'}) -%}
+  <span {% with {attr: label_content_attr} %}{{ block('attributes')}}{% endwith %}>
+    {{ parent() }}
+  </span>
+  {{- form_help(form) -}}
+{% endblock %}
+
+{% block form_help %}
+  {%- set help_attr = help_attr|merge({class: (help_attr.class|default('') ~ ' fr-hint-text')}) -%}
   {{ parent() }}
 {% endblock %}
 

--- a/templates/regulation/steps/_stepper.html.twig
+++ b/templates/regulation/steps/_stepper.html.twig
@@ -1,6 +1,4 @@
-{%- set stepper_attr = stepper_attr|default({})|merge({class: stepper_attr.class|default('') ~ ' fr-stepper'}) -%}
-
-<div {% include 'common/attr.html.twig' with {attr: stepper_attr} %}>
+<div class="fr-stepper fr-col fr-col-lg-6">
     <h2 class="fr-stepper__title">
         <span class="fr-stepper__state">{{ 'regulation.stepper.steps'|trans({'%step%': stepNumber})}}</span>
         {{ stepName|trans }}

--- a/templates/regulation/steps/_stepper.html.twig
+++ b/templates/regulation/steps/_stepper.html.twig
@@ -1,4 +1,6 @@
-<div class="fr-stepper">
+{%- set stepper_attr = stepper_attr|default({})|merge({class: stepper_attr.class|default('') ~ ' fr-stepper'}) -%}
+
+<div {% include 'common/attr.html.twig' with {attr: stepper_attr} %}>
     <h2 class="fr-stepper__title">
         <span class="fr-stepper__state">{{ 'regulation.stepper.steps'|trans({'%step%': stepNumber})}}</span>
         {{ stepName|trans }}

--- a/templates/regulation/steps/base.html.twig
+++ b/templates/regulation/steps/base.html.twig
@@ -6,11 +6,16 @@
             { title: 'regulation.breadcrumb', path: 'app_regulations_list'},
             { title: 'regulation.list.add_button'},
         ]} %}
-        {% include "regulation/steps/_stepper.html.twig" with {
-            'stepName': 'regulation.stepper.step' ~ stepNumber,
-            'stepNumber': stepNumber,
-            'nextStep': 'regulation.stepper.step' ~ (stepNumber + 1),
-        } %}
+        <div class="fr-container--fluid">
+            <div class="fr-grid-row">
+                {% include "regulation/steps/_stepper.html.twig" with {
+                    stepper_attr: {class: 'fr-col fr-col-lg-6'},
+                    'stepName': 'regulation.stepper.step' ~ stepNumber,
+                    'stepNumber': stepNumber,
+                    'nextStep': 'regulation.stepper.step' ~ (stepNumber + 1),
+                } %}
+            </div>
+        </div>
         {% block step_body %}{% endblock %}
     </turbo-frame>
 {% endblock %}

--- a/templates/regulation/steps/base.html.twig
+++ b/templates/regulation/steps/base.html.twig
@@ -9,7 +9,6 @@
         <div class="fr-container--fluid">
             <div class="fr-grid-row">
                 {% include "regulation/steps/_stepper.html.twig" with {
-                    stepper_attr: {class: 'fr-col fr-col-lg-6'},
                     'stepName': 'regulation.stepper.step' ~ stepNumber,
                     'stepNumber': stepNumber,
                     'nextStep': 'regulation.stepper.step' ~ (stepNumber + 1),

--- a/templates/regulation/steps/step1.html.twig
+++ b/templates/regulation/steps/step1.html.twig
@@ -3,8 +3,17 @@
 {% block step_body %}
     {{ form_start(form) }}
         {{ form_errors(form) }}
-        {{ form_row(form.description, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
-        {{ form_row(form.issuingAuthority, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
+
+        {{ form_row(form.issuingAuthority, {group_class: 'fr-input-group', widget_class: 'fr-input', label_content_attr: {class: 'fr-text--bold'}}) }}
+
+        <fieldset class="fr-fieldset">
+            <legend class="fr-fieldset__legend">
+                {{ 'regulation.step1.expected_disruption'|trans }}
+            </legend>
+            <div class="fr-fieldset__element">
+                {{ form_row(form.description, {group_class: 'fr-input-group', widget_class: 'fr-input', help_attr: {class: 'fr-hint-text'}}) }}
+            </div>
+        </fieldset>
 
         <a href="{{ path('app_regulations_list') }}" class="fr-btn fr-btn--tertiary fr-mr-3w">
             {{ "common.cancel"|trans }}

--- a/templates/regulation/steps/step2.html.twig
+++ b/templates/regulation/steps/step2.html.twig
@@ -1,6 +1,14 @@
 {% extends 'regulation/steps/base.html.twig' %}
 
 {% block step_body %}
+    <h3 class="fr-text--md fr-mb-0">
+        {{ 'regulation.step2.subtitle'|trans }}
+    </h3>
+
+    <p class="fr-hint-text fr-text--sm">
+        {{'regulation.step2.help'|trans }}
+    </p>
+
     {{ form_start(form) }}
         {{ form_errors(form) }}
         {{ form_row(form.postalCode, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}

--- a/templates/regulation/steps/step3.html.twig
+++ b/templates/regulation/steps/step3.html.twig
@@ -1,6 +1,14 @@
 {% extends 'regulation/steps/base.html.twig' %}
 
 {% block step_body %}
+    <h3 class="fr-text--md fr-mb-0">
+        {{ 'regulation.step3.subtitle'|trans }}
+    </h3>
+
+    <p class="fr-hint-text fr-text--sm">
+        {{ 'regulation.step3.help'|trans }}
+    </p>
+
     {{ form_start(form) }}
         {{ form_errors(form) }}
         {{ form_row(form.startPeriod, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}

--- a/templates/regulation/steps/step4.html.twig
+++ b/templates/regulation/steps/step4.html.twig
@@ -6,7 +6,10 @@
 
         <fieldset class="fr-fieldset">
             <legend class="fr-fieldset__legend">
-                {{ "regulation.step4.vehicle_characteristics"|trans }}
+                {{ 'regulation.step4.vehicle_characteristics'|trans }}
+                <span class="fr-hint-text fr-text--sm">
+                    {{ 'regulation.step4.vehicle_characteristics.help'|trans }}
+                </span>
             </legend>
             <div class="fr-fieldset__element">
                 {{ form_row(form.maxWeight, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step1ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step1ControllerTest.php
@@ -19,8 +19,8 @@ final class Step1ControllerTest extends WebTestCase
 
         $saveButton = $crawler->selectButton('Suivant');
         $form = $saveButton->form();
-        $form["step1_form[description]"] = "Interdiction de circuler dans Paris";
         $form["step1_form[issuingAuthority]"] = "Ville de Paris";
+        $form["step1_form[description]"] = "Interdiction de circuler dans Paris";
 
         $client->submit($form);
         $this->assertResponseStatusCodeSame(303);
@@ -40,8 +40,8 @@ final class Step1ControllerTest extends WebTestCase
 
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
-        $this->assertSame("Cette valeur ne doit pas être vide.", $crawler->filter('#step1_form_description_error')->text());
         $this->assertSame("Cette valeur ne doit pas être vide.", $crawler->filter('#step1_form_issuingAuthority_error')->text());
+        $this->assertSame("Cette valeur ne doit pas être vide.", $crawler->filter('#step1_form_description_error')->text());
     }
 
     public function testRegulationOrderRecordNotFound(): void
@@ -79,13 +79,13 @@ final class Step1ControllerTest extends WebTestCase
 
         $saveButton = $crawler->selectButton('Suivant');
         $form = $saveButton->form();
-        $form["step1_form[description]"] = str_repeat('a', 256);
         $form["step1_form[issuingAuthority]"] = str_repeat('a', 256);
+        $form["step1_form[description]"] = str_repeat('a', 256);
 
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
-        $this->assertSame("Cette chaîne est trop longue. Elle doit avoir au maximum 255 caractères.", $crawler->filter('#step1_form_description_error')->text());
         $this->assertSame("Cette chaîne est trop longue. Elle doit avoir au maximum 255 caractères.", $crawler->filter('#step1_form_issuingAuthority_error')->text());
+        $this->assertSame("Cette chaîne est trop longue. Elle doit avoir au maximum 255 caractères.", $crawler->filter('#step1_form_description_error')->text());
     }
 
     public function testUxEnhancements(): void

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandlerTest.php
@@ -60,8 +60,8 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
                 $this->equalTo(
                     new RegulationOrder(
                         uuid: 'd035fec0-30f3-4134-95b9-d74c68eb53e3',
-                        description: 'Interdiction de circuler',
                         issuingAuthority: 'Ville de Paris',
+                        description: 'Interdiction de circuler',
                         regulationCondition: $regulationCondition,
                     )
                 )
@@ -94,8 +94,8 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
         );
 
         $command = new SaveRegulationStep1Command();
-        $command->description = 'Interdiction de circuler';
         $command->issuingAuthority = 'Ville de Paris';
+        $command->description = 'Interdiction de circuler';
 
         $uuid = $handler($command);
 
@@ -139,7 +139,10 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
         $regulationOrder
             ->expects(self::once())
             ->method('update')
-            ->with('Interdiction de circuler', 'Ville de Paris');
+            ->with(
+                'Ville de Paris',
+                'Interdiction de circuler',
+            );
 
         $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
         $regulationOrderRecord
@@ -160,8 +163,8 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
         );
 
         $command = new SaveRegulationStep1Command($regulationOrderRecord);
-        $command->description = 'Interdiction de circuler';
         $command->issuingAuthority = 'Ville de Paris';
+        $command->description = 'Interdiction de circuler';
 
         $uuid = $handler($command);
 

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandTest.php
@@ -15,22 +15,23 @@ final class SaveRegulationStep1CommandTest extends TestCase
     {
         $command = SaveRegulationStep1Command::create();
 
-        $this->assertEmpty($command->description);
         $this->assertEmpty($command->issuingAuthority);
+        $this->assertEmpty($command->description);
     }
 
     public function testWithRegulationOrderRecord(): void
     {
         $regulationOrder = $this->createMock(RegulationOrder::class);
-        $regulationOrder
-            ->expects(self::once())
-            ->method('getDescription')
-            ->willReturn('Description');
 
         $regulationOrder
             ->expects(self::once())
             ->method('getIssuingAuthority')
             ->willReturn('Autorité');
+
+        $regulationOrder
+            ->expects(self::once())
+            ->method('getDescription')
+            ->willReturn('Description');
 
         $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
         $regulationOrderRecord
@@ -40,7 +41,7 @@ final class SaveRegulationStep1CommandTest extends TestCase
 
         $command = SaveRegulationStep1Command::create($regulationOrderRecord);
 
-        $this->assertSame($command->description, 'Description');
         $this->assertSame($command->issuingAuthority, 'Autorité');
+        $this->assertSame($command->description, 'Description');
     }
 }

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
@@ -47,8 +47,8 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
         $regulationOrderRepository = $this->createMock(RegulationOrderRepositoryInterface::class);
         $regulationOrder1 = [
             'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
-            'description' => 'Description 1',
             'issuingAuthority' => 'Autorité 1',
+            'description' => 'Description 1',
             'startPeriod' => $startPeriod1,
             'endPeriod' => $endPeriod1,
             'postalCode' => $location1->postalCode,
@@ -63,8 +63,8 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
         ];
         $regulationOrder2 = [
             'uuid' => '247edaa2-58d1-43de-9d33-9753bf6f4d30',
-            'description' => 'Description 2',
             'issuingAuthority' => 'Autorité 2',
+            'description' => 'Description 2',
             'startPeriod' => $startPeriod2,
             'endPeriod' => null,
             'postalCode' => $location2->postalCode,
@@ -89,18 +89,18 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
         $this->assertEquals(
             [
                 new RegulationOrderListForDatexFormatView(
-                    '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
-                    'Description 1',
-                    'Autorité 1',
-                    new PeriodView($startPeriod1, $endPeriod1),
-                    $location1,
+                    uuid: '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
+                    issuingAuthority: 'Autorité 1',
+                    description: 'Description 1',
+                    period: new PeriodView($startPeriod1, $endPeriod1),
+                    location: $location1,
                 ),
                 new RegulationOrderListForDatexFormatView(
-                    '247edaa2-58d1-43de-9d33-9753bf6f4d30',
-                    'Description 2',
-                    'Autorité 2',
-                    new PeriodView($startPeriod2),
-                    $location2,
+                    uuid: '247edaa2-58d1-43de-9d33-9753bf6f4d30',
+                    issuingAuthority: 'Autorité 2',
+                    description: 'Description 2',
+                    period: new PeriodView($startPeriod2),
+                    location: $location2,
                 ),
             ],
             $regulationOrders,

--- a/tests/Unit/Domain/Regulation/RegulationOrderTest.php
+++ b/tests/Unit/Domain/Regulation/RegulationOrderTest.php
@@ -16,14 +16,14 @@ final class RegulationOrderTest extends TestCase
 
         $regulationOrder = new RegulationOrder(
             uuid: '6598fd41-85cb-42a6-9693-1bc45f4dd392',
-            description: 'Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye',
             issuingAuthority: 'Commune de Savenay',
+            description: 'Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye',
             regulationCondition: $regulationCondition,
         );
 
         $this->assertSame('6598fd41-85cb-42a6-9693-1bc45f4dd392', $regulationOrder->getUuid());
-        $this->assertSame('Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye', $regulationOrder->getDescription());
         $this->assertSame('Commune de Savenay', $regulationOrder->getIssuingAuthority());
+        $this->assertSame('Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye', $regulationOrder->getDescription());
         $this->assertSame($regulationCondition, $regulationOrder->getRegulationCondition());
     }
 
@@ -33,12 +33,15 @@ final class RegulationOrderTest extends TestCase
 
         $regulationOrder = new RegulationOrder(
             uuid: '6598fd41-85cb-42a6-9693-1bc45f4dd392',
-            description: 'Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye',
             issuingAuthority: 'Commune de Savenay',
+            description: 'Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye',
             regulationCondition: $regulationCondition,
         );
 
-        $regulationOrder->update('Arrêté temporaire', 'Commune de Paris');
+        $regulationOrder->update(
+            issuingAuthority: 'Commune de Paris',
+            description: 'Arrêté temporaire',
+        );
 
         $this->assertSame('Commune de Paris', $regulationOrder->getIssuingAuthority());
         $this->assertSame('Arrêté temporaire', $regulationOrder->getDescription());

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -130,13 +130,33 @@
                 <source>regulation.breadcrumb</source>
                 <target>Réglementations</target>
             </trans-unit>
+            <trans-unit id="regulation.step1.expected_disruption">
+                <source>regulation.step1.expected_disruption</source>
+                <target>Perturbation prévue</target>
+            </trans-unit>
             <trans-unit id="regulation.step1.description">
                 <source>regulation.step1.description</source>
                 <target>Description</target>
             </trans-unit>
+            <trans-unit id="regulation.step1.description.help">
+                <source>regulation.step1.description.help</source>
+                <target>Décrivez brièvement les raisons de la perturbation. (Exemple : "travaux sur la voie")</target>
+            </trans-unit>
             <trans-unit id="regulation.step1.issuing_authority">
                 <source>regulation.step1.issuing_authority</source>
-                <target>Autorité émettrice</target>
+                <target>Autorité compétente</target>
+            </trans-unit>
+            <trans-unit id="regulation.step1.issuing_authority.help">
+                <source>regulation.step1.issuing_authority.help</source>
+                <target>Commune, département ou entité responsable de la réglementation</target>
+            </trans-unit>
+            <trans-unit id="regulation.step2.subtitle">
+                <source>regulation.step2.subtitle</source>
+                <target>Ville et rue</target>
+            </trans-unit>
+            <trans-unit id="regulation.step2.help">
+                <source>regulation.step2.help</source>
+                <target>Indiquez la rue impactée par la restriction.</target>
             </trans-unit>
             <trans-unit id="regulation.step2.postal_code">
                 <source>regulation.step2.postal_code</source>
@@ -148,7 +168,7 @@
             </trans-unit>
             <trans-unit id="regulation.step2.road_name">
                 <source>regulation.step2.road_name</source>
-                <target>Rue</target>
+                <target>Nom de la voie</target>
             </trans-unit>
             <trans-unit id="regulation.step2.from_house_number">
                 <source>regulation.step2.from_house_number</source>
@@ -158,17 +178,37 @@
                 <source>regulation.step2.to_house_number</source>
                 <target>Numéro de fin</target>
             </trans-unit>
+            <trans-unit id="regulation.step3.subtitle">
+                <source>regulation.step3.subtitle</source>
+                <target>Période de restriction</target>
+            </trans-unit>
+            <trans-unit id="regulation.step3.help">
+                <source>regulation.step3.help</source>
+                <target>Pendant quelle période la circulation est-elle réglementée ? Si la restriction est permanente, une date de début suffit.</target>
+            </trans-unit>
             <trans-unit id="regulation.step3.start_period">
                 <source>regulation.step3.start_period</source>
                 <target>Date de début</target>
+            </trans-unit>
+            <trans-unit id="regulation.step3.start_period.help">
+                <source>regulation.step3.start_period.help</source>
+                <target>Début d'effet de la restriction</target>
             </trans-unit>
             <trans-unit id="regulation.step3.end_period">
                 <source>regulation.step3.end_period</source>
                 <target>Date de fin</target>
             </trans-unit>
+            <trans-unit id="regulation.step3.end_period.help">
+                <source>regulation.step3.end_period.help</source>
+                <target>Laisser vide si la restriction est permanente</target>
+            </trans-unit>
             <trans-unit id="regulation.step4.vehicle_characteristics">
                 <source>regulation.step4.vehicle_characteristics</source>
-                <target>Véhicules concernés</target>
+                <target>Véhicules concernés par la réglementation</target>
+            </trans-unit>
+            <trans-unit id="regulation.step4.vehicle_characteristics.help">
+                <source>regulation.step4.vehicle_characteristics.help</source>
+                <target>Quels véhicules sont limités de circulation ?</target>
             </trans-unit>
             <trans-unit id="regulation.step4.max_weight">
                 <source>regulation.step4.max_weight</source>


### PR DESCRIPTION
Objectif : se rapprocher de la maquette pour ce qui concerne ce qu'on a déjà implémenté

Diverses améliorations sont apportées au formulaire (1er commit).

* Ajout de tous les titres et textes d'aide manquants
* Taille de la barre de stepper

Par cohérence, `issuingAuthority` et `description` sont replacés dans le code dans l'ordre où ils apparaissent dans l'UI (2e commit).