### PR TITLE
Move DSFR CSS imports to CSS bundle

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -1,3 +1,10 @@
+@import url('../../node_modules/@gouvfr/dsfr/dist/dsfr.min.css');
+@import url('../../node_modules/@gouvfr/dsfr/dist/utility/icons/icons-design/icons-design.min.css');
+@import url('../../node_modules/@gouvfr/dsfr/dist/utility/icons/icons-system/icons-system.min.css');
+@import url('../../node_modules/@gouvfr/dsfr/dist/utility/icons/icons-user/icons-user.min.css');
+@import url('../../node_modules/@gouvfr/dsfr/dist/utility/icons/icons-business/icons-business.min.css');
+@import url('../../node_modules/@gouvfr/dsfr/dist/utility/icons/icons-map/icons-map.min.css');
+
 /* label.required is set by Symfony for form types with 'required => true' */
 label.required > .fr-x-label-content::after {
     content: ' *';

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -4,12 +4,6 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <link rel="stylesheet" href="{{ asset('build/dsfr/dsfr.min.css') }}"/>
-    <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-design/icons-design.min.css') }}">
-    <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-system/icons-system.min.css') }}">
-    <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-user/icons-user.min.css') }}">
-    <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-business/icons-business.min.css') }}">
-    <link rel="stylesheet" href="{{ asset('build/dsfr/utility/icons/icons-map/icons-map.min.css') }}">
     <link rel="apple-touch-icon" href="{{ asset('build/dsfr/favicon/apple-touch-icon.png') }}"><!-- 180×180 -->
     <link rel="icon" href="{{ asset('build/dsfr/favicon/favicon.svg') }}" type="image/svg+xml">
     <link rel="shortcut icon" href="{{ asset('build/dsfr/favicon/favicon.ico') }}" type="image/x-icon"><!-- 32×32 -->

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,6 +12,7 @@ Encore
     .setPublicPath('/build')
     .copyFiles({
         from: './node_modules/@gouvfr/dsfr/dist/',
+        pattern: /(dsfr.(no)?module.min.js)|(favicon\/)/,
         to: 'dsfr/[path][name].[ext]'
     })
 


### PR DESCRIPTION
Motivé par https://github.com/MTES-MCT/dialog/pull/114#discussion_r1090483935

Les imports du CSS du DSFR que l'on utilise sont déplacés dans le `app.scss` principal.

On économise ainsi 5 requêtes HTTP lors du chargement initial

Cela ouvre la voie à l'ajout d'une étape de treeshaking / purgeCSS sur le CSS du DSFR