### PR TITLE
Fix step5 checkbox label associations

### DIFF
--- a/templates/regulation/steps/step5.html.twig
+++ b/templates/regulation/steps/step5.html.twig
@@ -17,7 +17,7 @@
                                 name="status"
                                 {% if regulationOrderRecord.status == 'draft' %}checked{% endif %}
                             />
-                            <label class="fr-label" for="radio-rich-hint-1">
+                            <label class="fr-label" for="status-draft">
                                 <b>{{ 'regulation.step5.draft.save'|trans }}</b>
                                 <span class="fr-hint-text">{{ 'regulation.step5.draft.description'|trans }}</span>
                             </label>
@@ -32,7 +32,7 @@
                                 name="status"
                                 {% if regulationOrderRecord.status == 'published' %}checked{% endif %}
                             />
-                            <label class="fr-label" for="radio-rich-hint-2">
+                            <label class="fr-label" for="status-published">
                                 <b>{{ 'regulation.step5.published.save'|trans }}</b>
                                 <span class="fr-hint-text">{{ 'regulation.step5.published.description'|trans }}</span>
                             </label>

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step5ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step5ControllerTest.php
@@ -39,6 +39,14 @@ final class Step5ControllerTest extends WebTestCase
         $this->assertSame('http://localhost/regulations/form/e413a47e-5928-4353-a8b2-8b7dda27f9a5/4', $step4->filter('a')->link()->getUri());
         $this->assertCount(0, $step4->filter('li'));
 
+        // Status action
+        $draftInput = $crawler->filter('input[id="status-draft"]')->first();
+        $draftLabel = $draftInput->siblings()->filter('[for="status-draft"]')->first();
+        $this->assertStringStartsWith('Sauvegarder le brouillon', $draftLabel->text());
+        $publishedInput = $crawler->filter('input[id="status-published"]')->first();
+        $publishedLabel = $publishedInput->siblings()->filter('[for="status-published"]')->first();
+        $this->assertStringStartsWith('Valider la réglementation', $publishedLabel->text());
+
         $client->clickLink('Sauvegarder');
         $this->assertResponseStatusCodeSame(200);
         $this->assertRouteSame('app_regulations_list');


### PR DESCRIPTION
Correctif suite à #107 

Détecté en relisant #116 

Les `<checkbox id="..." />` et les `<label for="..." />` ne correspondaient pas, donc quand on cliquait sur les items rien ne se passait (le JS du DSFR doit s'appuyer sur ces paramètres pour changer l'item sélectionné lors du clic)