### PR TITLE
Add times to period fields

### DIFF
--- a/.env
+++ b/.env
@@ -15,6 +15,8 @@
 # https://symfony.com/doc/current/best_practices.html#use-environment-variables-for-infrastructure-configuration
 
 APP_ENV=dev
+APP_SERVER_TIMEZONE=UTC
+APP_CLIENT_TIMEZONE=Europe/Paris
 APP_SECRET=abc
 DATABASE_URL="postgresql://dialog:dialog@database:5432/dialog"
 API_ADRESSE_BASE_URL=https://api-adresse.data.gouv.fr

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,7 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
+APP_SERVER_TIMEZONE=UTC
+APP_CLIENT_TIMEZONE=Europe/Paris
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 PANTHER_APP_ENV=panther

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -4,12 +4,16 @@
 # Put parameters here that don't need to change on each machine where the app is deployed
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
+    server_timezone: '%env(APP_SERVER_TIMEZONE)%'
+    client_timezone: '%env(APP_CLIENT_TIMEZONE)%'
 
 services:
     # default configuration for services in *this* file
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+        bind:
+            $clientTimezone: '%client_timezone%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
@@ -65,6 +69,11 @@ services:
         class: DateTimeImmutable
 
 when@test:
+    parameters:
+        # Use known timezones
+        server_timezone: 'UTC'
+        client_timezone: 'Europe/Paris'
+
     services:
         App\Tests\Mock\APIAdresseMockClient:
             # See: https://symfony.com/doc/current/service_container/service_decoration.html

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -69,11 +69,6 @@ services:
         class: DateTimeImmutable
 
 when@test:
-    parameters:
-        # Use known timezones
-        server_timezone: 'UTC'
-        client_timezone: 'Europe/Paris'
-
     services:
         App\Tests\Mock\APIAdresseMockClient:
             # See: https://symfony.com/doc/current/service_container/service_decoration.html

--- a/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep3Command.xml
+++ b/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep3Command.xml
@@ -18,14 +18,15 @@
             <constraint name="Type">
                 <option name="type">\DateTimeInterface</option>
             </constraint>
-            <constraint name="GreaterThan">
-                <option name="propertyPath">startDate</option>
-            </constraint>
         </property>
         <property name="endTime">
             <constraint name="Type">
                 <option name="type">\DateTimeInterface</option>
             </constraint>
         </property>
+        <constraint name="Callback">
+            <value>App\Infrastructure\Form\Regulation\Steps\Step3FormType</value>
+            <value>validate</value>
+        </constraint>
     </class>
 </constraint-mapping>

--- a/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep3Command.xml
+++ b/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep3Command.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
     <class name="App\Application\Regulation\Command\Steps\SaveRegulationStep3Command">
         <property name="startDate">
             <constraint name="NotBlank" />
@@ -24,9 +24,6 @@
                 <option name="type">\DateTimeInterface</option>
             </constraint>
         </property>
-        <constraint name="Callback">
-            <value>App\Infrastructure\Form\Regulation\Steps\Step3FormType</value>
-            <value>validate</value>
-        </constraint>
+        <constraint name="App\Infrastructure\Validator\SaveRegulationStep3CommandConstraint" />
     </class>
 </constraint-mapping>

--- a/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep3Command.xml
+++ b/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep3Command.xml
@@ -3,18 +3,28 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
     <class name="App\Application\Regulation\Command\Steps\SaveRegulationStep3Command">
-        <property name="startPeriod">
+        <property name="startDate">
             <constraint name="NotBlank" />
             <constraint name="Type">
                 <option name="type">\DateTimeInterface</option>
             </constraint>
         </property>
-        <property name="endPeriod">
+        <property name="startTime">
+            <constraint name="Type">
+                <option name="type">\DateTimeInterface</option>
+            </constraint>
+        </property>
+        <property name="endDate">
             <constraint name="Type">
                 <option name="type">\DateTimeInterface</option>
             </constraint>
             <constraint name="GreaterThan">
-                <option name="propertyPath">startPeriod</option>
+                <option name="propertyPath">startDate</option>
+            </constraint>
+        </property>
+        <property name="endTime">
+            <constraint name="Type">
+                <option name="type">\DateTimeInterface</option>
             </constraint>
         </property>
     </class>

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -40,4 +40,4 @@ realpath_cache_size = 4096K
 realpath_cache_ttl = 600
 
 [Date]
-date.timezone = Europe/Paris
+date.timezone = UTC

--- a/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
+++ b/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
@@ -101,8 +101,10 @@ final class DuplicateRegulationCommandHandler
 
         if ($overallPeriod instanceof OverallPeriod) {
             $step3Command = new SaveRegulationStep3Command($duplicatedRegulationOrderRecord);
-            $step3Command->startPeriod = $overallPeriod->getStartPeriod();
-            $step3Command->endPeriod = $overallPeriod->getEndPeriod();
+            $step3Command->startDate = $overallPeriod->getStartDate();
+            $step3Command->startTime = $overallPeriod->getStartTime();
+            $step3Command->endDate = $overallPeriod->getEndDate();
+            $step3Command->endTime = $overallPeriod->getEndTime();
             $this->commandBus->handle($step3Command);
         }
     }

--- a/src/Application/Regulation/Command/Steps/SaveRegulationStep3Command.php
+++ b/src/Application/Regulation/Command/Steps/SaveRegulationStep3Command.php
@@ -10,8 +10,10 @@ use App\Domain\Regulation\RegulationOrderRecord;
 
 final class SaveRegulationStep3Command implements CommandInterface
 {
-    public ?\DateTimeInterface $startPeriod;
-    public ?\DateTimeInterface $endPeriod = null;
+    public ?\DateTimeInterface $startDate;
+    public ?\DateTimeInterface $startTime = null;
+    public ?\DateTimeInterface $endDate = null;
+    public ?\DateTimeInterface $endTime = null;
 
     public function __construct(
         public readonly RegulationOrderRecord $regulationOrderRecord,
@@ -24,8 +26,10 @@ final class SaveRegulationStep3Command implements CommandInterface
         OverallPeriod $overallPeriod = null,
     ): self {
         $command = new self($regulationOrderRecord, $overallPeriod);
-        $command->startPeriod = $overallPeriod?->getStartPeriod();
-        $command->endPeriod = $overallPeriod?->getEndPeriod();
+        $command->startDate = $overallPeriod?->getStartDate();
+        $command->startTime = $overallPeriod?->getStartTime();
+        $command->endDate = $overallPeriod?->getEndDate();
+        $command->endTime = $overallPeriod?->getEndTime();
 
         return $command;
     }

--- a/src/Application/Regulation/Command/Steps/SaveRegulationStep3CommandHandler.php
+++ b/src/Application/Regulation/Command/Steps/SaveRegulationStep3CommandHandler.php
@@ -26,14 +26,21 @@ final class SaveRegulationStep3CommandHandler
                 new OverallPeriod(
                     uuid: $this->idFactory->make(),
                     regulationCondition: $regulationCondition,
-                    startPeriod: $command->startPeriod,
-                    endPeriod: $command->endPeriod,
+                    startDate: $command->startDate,
+                    startTime: $command->startTime,
+                    endDate: $command->endDate,
+                    endTime: $command->endTime,
                 ),
             );
 
             return;
         }
 
-        $command->overallPeriod->update($command->startPeriod, $command->endPeriod);
+        $command->overallPeriod->update(
+            startDate: $command->startDate,
+            startTime: $command->startTime,
+            endDate: $command->endDate,
+            endTime: $command->endTime,
+        );
     }
 }

--- a/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
@@ -28,7 +28,10 @@ final class GetRegulationOrderRecordSummaryQueryHandler
             throw new RegulationOrderRecordNotFoundException();
         }
 
-        $hasPeriod = $row['startPeriod'] || $row['endPeriod'];
+        $hasPeriod = $row['startDate']
+            || $row['startTime']
+            || $row['endDate']
+            || $row['endTime'];
         $hasLocation = $row['postalCode']
             && $row['city']
             && $row['roadName']
@@ -45,8 +48,10 @@ final class GetRegulationOrderRecordSummaryQueryHandler
             $row['status'],
             $row['description'],
             $hasPeriod ? new PeriodView(
-                $row['startPeriod'],
-                $row['endPeriod'],
+                $row['startDate'],
+                $row['startTime'],
+                $row['endDate'],
+                $row['endTime'],
             ) : null,
             $hasLocation ? new DetailLocationView(
                 $row['postalCode'],

--- a/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
@@ -33,8 +33,10 @@ final class GetRegulationOrdersToDatexFormatQueryHandler
                 $regulationOrder['issuingAuthority'],
                 $regulationOrder['description'],
                 new PeriodView(
-                    $regulationOrder['startPeriod'],
-                    $regulationOrder['endPeriod'],
+                    $regulationOrder['startDate'],
+                    $regulationOrder['startTime'],
+                    $regulationOrder['endDate'],
+                    $regulationOrder['endTime'],
                 ),
                 new DatexLocationView(
                     postalCode: $regulationOrder['postalCode'],

--- a/src/Application/Regulation/Query/GetRegulationsQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationsQueryHandler.php
@@ -39,9 +39,11 @@ final class GetRegulationsQueryHandler
                     $regulation['roadName'],
                     $regulation['city'],
                 ) : null,
-                $regulation['startPeriod'] ? new PeriodView(
-                    $regulation['startPeriod'],
-                    $regulation['endPeriod'],
+                $regulation['startDate'] ? new PeriodView(
+                    $regulation['startDate'],
+                    $regulation['startTime'],
+                    $regulation['endDate'],
+                    $regulation['endTime'],
                 ) : null,
             );
         }

--- a/src/Application/Regulation/View/PeriodView.php
+++ b/src/Application/Regulation/View/PeriodView.php
@@ -7,8 +7,10 @@ namespace App\Application\Regulation\View;
 class PeriodView
 {
     public function __construct(
-        public readonly \DateTimeInterface $startPeriod,
-        public readonly ?\DateTimeInterface $endPeriod = null,
+        public readonly \DateTimeInterface $startDate,
+        public readonly ?\DateTimeInterface $startTime = null,
+        public readonly ?\DateTimeInterface $endDate = null,
+        public readonly ?\DateTimeInterface $endTime = null,
     ) {
     }
 }

--- a/src/Domain/Condition/Period/OverallPeriod.php
+++ b/src/Domain/Condition/Period/OverallPeriod.php
@@ -17,8 +17,10 @@ class OverallPeriod
     public function __construct(
         private string $uuid,
         private RegulationCondition $regulationCondition,
-        private \DateTimeInterface $startPeriod,
-        private ?\DateTimeInterface $endPeriod = null,
+        private \DateTimeInterface $startDate,
+        private ?\DateTimeInterface $startTime = null,
+        private ?\DateTimeInterface $endDate = null,
+        private ?\DateTimeInterface $endTime = null,
     ) {
     }
 
@@ -27,14 +29,24 @@ class OverallPeriod
         return $this->uuid;
     }
 
-    public function getStartPeriod(): \DateTimeInterface
+    public function getStartDate(): \DateTimeInterface
     {
-        return $this->startPeriod;
+        return $this->startDate;
     }
 
-    public function getEndPeriod(): ?\DateTimeInterface
+    public function getStartTime(): ?\DateTimeInterface
     {
-        return $this->endPeriod;
+        return $this->startTime;
+    }
+
+    public function getEndDate(): ?\DateTimeInterface
+    {
+        return $this->endDate;
+    }
+
+    public function getEndTime(): ?\DateTimeInterface
+    {
+        return $this->endTime;
     }
 
     public function addValidPeriod(Period $period): void
@@ -71,10 +83,14 @@ class OverallPeriod
     }
 
     public function update(
-        \DateTimeInterface $startPeriod,
-        ?\DateTimeInterface $endPeriod,
+        \DateTimeInterface $startDate,
+        ?\DateTimeInterface $startTime,
+        ?\DateTimeInterface $endDate,
+        ?\DateTimeInterface $endTime,
     ): void {
-        $this->startPeriod = $startPeriod;
-        $this->endPeriod = $endPeriod;
+        $this->startDate = $startDate;
+        $this->startTime = $startTime;
+        $this->endDate = $endDate;
+        $this->endTime = $endTime;
     }
 }

--- a/src/Infrastructure/Form/Regulation/Steps/Step3FormType.php
+++ b/src/Infrastructure/Form/Regulation/Steps/Step3FormType.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace App\Infrastructure\Form\Regulation\Steps;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 final class Step3FormType extends AbstractType
@@ -15,25 +16,52 @@ final class Step3FormType extends AbstractType
     {
         $builder
             ->add(
-                'startPeriod',
-                DateTimeType::class,
+                'startDate',
+                DateType::class,
                 options: [
-                    'label' => 'regulation.step3.start_period',
-                    'help' => 'regulation.step3.start_period.help',
+                    'label' => 'regulation.step3.start_date',
+                    'help' => 'regulation.step3.start_date.help',
                     'widget' => 'single_text',
-                    'model_timezone' => 'Europe/London',
+                    'model_timezone' => 'UTC',
                     'view_timezone' => 'Europe/Paris',
                 ],
             )
             ->add(
-                'endPeriod',
-                DateTimeType::class,
+                'startTime',
+                TimeType::class,
                 options: [
-                    'label' => 'regulation.step3.end_period',
-                    'help' => 'regulation.step3.end_period.help',
+                    'label' => 'regulation.step3.start_time',
+                    'help' => 'regulation.step3.start_time.help',
                     'widget' => 'single_text',
-                    'model_timezone' => 'Europe/London',
+                    'model_timezone' => 'UTC',
                     'view_timezone' => 'Europe/Paris',
+                    'reference_date' => new \DateTimeImmutable('Sunday, 01-Jan-2023 00:00:00 UTC'),
+                    'input' => 'datetime_immutable',
+                    'required' => false,
+                ],
+            )
+            ->add(
+                'endDate',
+                DateType::class,
+                options: [
+                    'label' => 'regulation.step3.end_date',
+                    'help' => 'regulation.step3.end_date.help',
+                    'widget' => 'single_text',
+                    'model_timezone' => 'UTC',
+                    'view_timezone' => 'Europe/Paris',
+                    'required' => false,
+                ],
+            )
+            ->add(
+                'endTime',
+                TimeType::class,
+                options: [
+                    'label' => 'regulation.step3.end_time',
+                    'widget' => 'single_text',
+                    'model_timezone' => 'UTC',
+                    'view_timezone' => 'Europe/Paris',
+                    'reference_date' => new \DateTimeImmutable('Sunday, 01-Jan-2023 00:00:00 UTC'),
+                    'input' => 'datetime_immutable',
                     'required' => false,
                 ],
             )

--- a/src/Infrastructure/Form/Regulation/Steps/Step3FormType.php
+++ b/src/Infrastructure/Form/Regulation/Steps/Step3FormType.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\Form\Regulation\Steps;
 
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\DateType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -16,20 +16,24 @@ final class Step3FormType extends AbstractType
         $builder
             ->add(
                 'startPeriod',
-                DateType::class,
+                DateTimeType::class,
                 options: [
                     'label' => 'regulation.step3.start_period',
                     'help' => 'regulation.step3.start_period.help',
                     'widget' => 'single_text',
+                    'model_timezone' => 'Europe/London',
+                    'view_timezone' => 'Europe/Paris',
                 ],
             )
             ->add(
                 'endPeriod',
-                DateType::class,
+                DateTimeType::class,
                 options: [
                     'label' => 'regulation.step3.end_period',
                     'help' => 'regulation.step3.end_period.help',
                     'widget' => 'single_text',
+                    'model_timezone' => 'Europe/London',
+                    'view_timezone' => 'Europe/Paris',
                     'required' => false,
                 ],
             )

--- a/src/Infrastructure/Form/Regulation/Steps/Step3FormType.php
+++ b/src/Infrastructure/Form/Regulation/Steps/Step3FormType.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Form\Regulation\Steps;
 
-use App\Application\Regulation\Command\Steps\SaveRegulationStep3Command;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TimeType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 final class Step3FormType extends AbstractType
 {
+    public function __construct(
+        private string $clientTimezone,
+    ) {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -24,8 +27,7 @@ final class Step3FormType extends AbstractType
                     'label' => 'regulation.step3.start_date',
                     'help' => 'regulation.step3.start_date.help',
                     'widget' => 'single_text',
-                    'model_timezone' => 'UTC',
-                    'view_timezone' => 'UTC',
+                    'view_timezone' => $this->clientTimezone,
                 ],
             )
             ->add(
@@ -35,8 +37,7 @@ final class Step3FormType extends AbstractType
                     'label' => 'regulation.step3.start_time',
                     'help' => 'regulation.step3.start_time.help',
                     'widget' => 'single_text',
-                    'model_timezone' => 'UTC',
-                    'view_timezone' => 'Europe/Paris',
+                    'view_timezone' => $this->clientTimezone,
                     'reference_date' => new \DateTimeImmutable('2023-01-01T00:00:00'),
                     'input' => 'datetime_immutable',
                     'required' => false,
@@ -49,8 +50,7 @@ final class Step3FormType extends AbstractType
                     'label' => 'regulation.step3.end_date',
                     'help' => 'regulation.step3.end_date.help',
                     'widget' => 'single_text',
-                    'model_timezone' => 'UTC',
-                    'view_timezone' => 'UTC',
+                    'view_timezone' => $this->clientTimezone,
                     'required' => false,
                 ],
             )
@@ -60,8 +60,7 @@ final class Step3FormType extends AbstractType
                 options: [
                     'label' => 'regulation.step3.end_time',
                     'widget' => 'single_text',
-                    'model_timezone' => 'UTC',
-                    'view_timezone' => 'Europe/Paris',
+                    'view_timezone' => $this->clientTimezone,
                     'reference_date' => new \DateTimeImmutable('2023-01-01T00:00:00'),
                     'input' => 'datetime_immutable',
                     'required' => false,
@@ -75,53 +74,5 @@ final class Step3FormType extends AbstractType
                 ],
             )
         ;
-    }
-
-    public static function validate(SaveRegulationStep3Command $command, ExecutionContextInterface $context, $payload): void
-    {
-        // First, check the dates.
-        // The end date must be strictly after the start date.
-
-        if (!$command->endDate) {
-            if ($command->endTime) {
-                $context->buildViolation('regulation.step3.error.end_time_without_end_date')
-                    ->atPath('endDate')
-                    ->addViolation();
-            }
-
-            return;
-        }
-
-        if ($command->startDate < $command->endDate) {
-            return;
-        }
-
-        if ($command->endDate < $command->startDate) {
-            $context->buildViolation('regulation.step3.error.end_date_before_start_date')
-                ->setParameter('{{ compared_value }}', $command->startDate->format('d/m/Y'))
-                ->atPath('endDate')
-                ->addViolation();
-
-            return;
-        }
-
-        // Same day: check the times.
-        // The end time (if set) must be strictly after the start time (if set).
-
-        if (!$command->endTime || !$command->startTime) {
-            return;
-        }
-
-        if ($command->endTime > $command->startTime) {
-            return;
-        }
-
-        $startTime = new \DateTimeImmutable($command->startTime->format('H:i:s'));
-        $viewStartTime = $startTime->setTimezone(new \DateTimeZone('Europe/Paris'))->format('H\\hi');
-
-        $context->buildViolation('regulation.step3.error.end_time_before_start_time')
-            ->setParameter('{{ compared_value }}', $viewStartTime)
-            ->atPath('endTime')
-            ->addViolation();
     }
 }

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/OverallPeriodFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/OverallPeriodFixture.php
@@ -17,9 +17,9 @@ final class OverallPeriodFixture extends Fixture implements DependentFixtureInte
             'bc8739de-968a-4b76-9874-b61ca474c892',
             $this->getReference('regulationCondition1'),
             startDate: new \DateTime('2022-12-08'),
-            startTime: new \DateTimeImmutable('08:00:00'),
-            endDate: new \DateTime('2022-12-18 00:00:00'),
-            endTime: new \DateTimeImmutable('16:00:00'),
+            startTime: new \DateTimeImmutable('08:00:00'), // UTC
+            endDate: new \DateTime('2022-12-18'),
+            endTime: new \DateTimeImmutable('16:00:00'), // UTC
         );
 
         $overallPeriod2 = new OverallPeriod(

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/OverallPeriodFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/OverallPeriodFixture.php
@@ -16,14 +16,16 @@ final class OverallPeriodFixture extends Fixture implements DependentFixtureInte
         $overallPeriod = new OverallPeriod(
             'bc8739de-968a-4b76-9874-b61ca474c892',
             $this->getReference('regulationCondition1'),
-            new \DateTime('2022-12-08'),
-            new \DateTime('2022-12-18'),
+            startDate: new \DateTime('2022-12-08'),
+            startTime: new \DateTimeImmutable('08:00:00'),
+            endDate: new \DateTime('2022-12-18 00:00:00'),
+            endTime: new \DateTimeImmutable('16:00:00'),
         );
 
         $overallPeriod2 = new OverallPeriod(
             '66a52b5d-71a8-4a09-abda-fca30ddce7b1',
             $this->getReference('regulationCondition2'),
-            new \DateTime('2022-10-08'),
+            startDate: new \DateTime('2022-10-08'),
         );
 
         $manager->persist($overallPeriod);

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Condition.Period.OverallPeriod.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Condition.Period.OverallPeriod.orm.xml
@@ -4,8 +4,10 @@
     name="App\Domain\Condition\Period\OverallPeriod"
     table="overall_period">
     <id name="uuid" type="guid" column="uuid"/>
-    <field name="startPeriod" type="datetimetz" column="start_period" nullable="false"/>
-    <field name="endPeriod" type="datetimetz" column="end_period" nullable="true"/>
+    <field name="startDate" type="datetimetz" column="start_date" nullable="false"/>
+    <field name="startTime" type="datetimetz_immutable" column="start_time" nullable="true"/>
+    <field name="endDate" type="datetimetz" column="end_date" nullable="true"/>
+    <field name="endTime" type="datetimetz_immutable" column="end_time" nullable="true"/>
     <one-to-many field="validPeriods" target-entity="App\Domain\Condition\Period\Period" mapped-by="overallValidPeriod"/>
     <one-to-many field="exceptionPeriods" target-entity="App\Domain\Condition\Period\Period" mapped-by="overallExceptionPeriod"/>
     <one-to-one field="regulationCondition" target-entity="App\Domain\Condition\RegulationCondition" inversed-by="overallPeriod">

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230221133525.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230221133525.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230221133525 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE overall_period ADD start_time TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE overall_period ADD end_time TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE overall_period RENAME COLUMN start_period TO start_date');
+        $this->addSql('ALTER TABLE overall_period RENAME COLUMN end_period TO end_date');
+        $this->addSql('COMMENT ON COLUMN overall_period.start_time IS \'(DC2Type:datetimetz_immutable)\'');
+        $this->addSql('COMMENT ON COLUMN overall_period.end_time IS \'(DC2Type:datetimetz_immutable)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE overall_period DROP start_time');
+        $this->addSql('ALTER TABLE overall_period DROP end_time');
+        $this->addSql('ALTER TABLE overall_period RENAME COLUMN start_date TO start_period');
+        $this->addSql('ALTER TABLE overall_period RENAME COLUMN end_date TO end_period');
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -25,7 +25,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
         string $status,
     ): array {
         return $this->createQueryBuilder('roc')
-            ->select('roc.uuid, o.startPeriod, o.endPeriod, roc.status, l.city, l.roadName')
+            ->select('roc.uuid, o.startDate, o.startTime, o.endDate, o.endTime, roc.status, l.city, l.roadName')
             ->where('roc.status = :status')
             ->andWhere('roc.organization = :organization')
             ->setParameters(['status' => $status, 'organization' => $organization->getUuid()])
@@ -33,7 +33,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->innerJoin('ro.regulationCondition', 'rc')
             ->leftJoin('rc.overallPeriod', 'o')
             ->leftJoin('rc.location', 'l')
-            ->orderBy('o.startPeriod', 'DESC')
+            ->orderBy('o.startDate', 'DESC')
             ->setFirstResult($maxItemsPerPage * ($page - 1))
             ->setMaxResults($maxItemsPerPage)
             ->getQuery()
@@ -75,8 +75,10 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
                 'org.uuid as organizationUuid',
                 'roc.status',
                 'ro.description',
-                'o.startPeriod',
-                'o.endPeriod',
+                'o.startDate',
+                'o.startTime',
+                'o.endDate',
+                'o.endTime',
                 'l.postalCode',
                 'l.city',
                 'l.roadName',
@@ -108,8 +110,10 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
                 'ro.uuid',
                 'ro.issuingAuthority',
                 'ro.description',
-                'o.startPeriod',
-                'o.endPeriod',
+                'o.startDate',
+                'o.startTime',
+                'o.endDate',
+                'o.endTime',
                 'loc.postalCode',
                 'loc.city',
                 'loc.roadName',

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -34,6 +34,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->leftJoin('rc.overallPeriod', 'o')
             ->leftJoin('rc.location', 'l')
             ->orderBy('o.startDate', 'DESC')
+            ->orderBy('o.startTime', 'DESC')
             ->setFirstResult($maxItemsPerPage * ($page - 1))
             ->setMaxResults($maxItemsPerPage)
             ->getQuery()

--- a/src/Infrastructure/Twig/AppExtension.php
+++ b/src/Infrastructure/Twig/AppExtension.php
@@ -24,12 +24,12 @@ class AppExtension extends \Twig\Extension\AbstractExtension
      */
     public function formatDateTime(\DateTimeInterface $date, ?\DateTimeInterface $time = null): string
     {
+        $dateTime = \DateTime::createFromInterface($date);
+        $format = 'd/m/Y';
+
         if ($time) {
+            $dateTime->setTime((int) $time->format('H'), (int) $time->format('i'), (int) $time->format('s'));
             $format = 'd/m/Y à H\hi';
-            $dateTime = new \DateTimeImmutable($date->format('Y-m-d') . ' ' . $time->format('H:i:s'));
-        } else {
-            $format = 'd/m/Y';
-            $dateTime = new \DateTimeImmutable($date->format('Y-m-d'));
         }
 
         return $dateTime->setTimezone(new \DateTimeZone($this->clientTimezone))->format($format);
@@ -41,10 +41,12 @@ class AppExtension extends \Twig\Extension\AbstractExtension
             $reference = new \DateTimeImmutable('now');
         }
 
+        $dateTime = \DateTime::createFromInterface($date);
+
         if ($time) {
-            $date = new \DateTimeImmutable($date->format('Y-m-d') . ' ' . $time->format('H:i:s'));
+            $dateTime->setTime((int) $time->format('H'), (int) $time->format('i'), (int) $time->format('s'));
         }
 
-        return $reference < $date;
+        return $reference < $dateTime;
     }
 }

--- a/src/Infrastructure/Twig/AppExtension.php
+++ b/src/Infrastructure/Twig/AppExtension.php
@@ -6,6 +6,11 @@ namespace App\Infrastructure\Twig;
 
 class AppExtension extends \Twig\Extension\AbstractExtension
 {
+    public function __construct(
+        private string $clientTimezone,
+    ) {
+    }
+
     public function getFunctions(): array
     {
         return [
@@ -27,7 +32,7 @@ class AppExtension extends \Twig\Extension\AbstractExtension
             $dateTime = new \DateTimeImmutable($date->format('Y-m-d'));
         }
 
-        return $dateTime->setTimezone(new \DateTimeZone('Europe/Paris'))->format($format);
+        return $dateTime->setTimezone(new \DateTimeZone($this->clientTimezone))->format($format);
     }
 
     public function isFuture(\DateTimeInterface $date, \DateTimeInterface $time = null, \DateTimeInterface $reference = null): bool

--- a/src/Infrastructure/Twig/AppExtension.php
+++ b/src/Infrastructure/Twig/AppExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Twig;
+
+class AppExtension extends \Twig\Extension\AbstractExtension
+{
+    public function getFunctions(): array
+    {
+        return [
+            new \Twig\TwigFunction('app_datetime', [$this, 'formatDateTime']),
+            new \Twig\TwigFunction('app_is_future', [$this, 'isFuture']),
+        ];
+    }
+
+    /**
+     * Format a $date with an optional $time
+     */
+    public function formatDateTime(\DateTimeInterface $date, ?\DateTimeInterface $time = null): string
+    {
+        if ($time) {
+            $format = 'd/m/Y à H\hi';
+            $dateTime = new \DateTimeImmutable($date->format('Y-m-d') . ' ' . $time->format('H:i:s'));
+        } else {
+            $format = 'd/m/Y';
+            $dateTime = new \DateTimeImmutable($date->format('Y-m-d'));
+        }
+
+        return $dateTime->setTimezone(new \DateTimeZone('Europe/Paris'))->format($format);
+    }
+
+    public function isFuture(\DateTimeInterface $date, \DateTimeInterface $time = null, \DateTimeInterface $reference = null): bool
+    {
+        if (!$reference) {
+            $reference = new \DateTimeImmutable('now');
+        }
+
+        if ($time) {
+            $date = new \DateTimeImmutable($date->format('Y-m-d') . ' ' . $time->format('H:i:s'));
+        }
+
+        return $reference < $date;
+    }
+}

--- a/src/Infrastructure/Validator/SaveRegulationStep3CommandConstraint.php
+++ b/src/Infrastructure/Validator/SaveRegulationStep3CommandConstraint.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+final class SaveRegulationStep3CommandConstraint extends Constraint
+{
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Infrastructure/Validator/SaveRegulationStep3CommandConstraintValidator.php
+++ b/src/Infrastructure/Validator/SaveRegulationStep3CommandConstraintValidator.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Validator;
+
+use App\Application\Regulation\Command\Steps\SaveRegulationStep3Command;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class SaveRegulationStep3CommandConstraintValidator extends ConstraintValidator
+{
+    public function __construct(
+        private string $clientTimezone,
+    ) {
+    }
+
+    public function validate(mixed $command, Constraint $constraint): void
+    {
+        if (!$command instanceof SaveRegulationStep3Command) {
+            throw new UnexpectedValueException($command, SaveRegulationStep3Command::class);
+        }
+
+        // First, check the dates.
+        // The end date must be strictly after the start date.
+
+        if (!$command->endDate) {
+            if ($command->endTime) {
+                $this->context->buildViolation('regulation.step3.error.end_time_without_end_date')
+                    ->atPath('endDate')
+                    ->addViolation();
+            }
+
+            return;
+        }
+
+        if ($command->startDate < $command->endDate) {
+            return;
+        }
+
+        if ($command->endDate < $command->startDate) {
+            $startDate = new \DateTimeImmutable($command->startDate->format('Y-m-d'));
+            $viewStartDate = $startDate->setTimezone(new \DateTimeZone($this->clientTimezone))->format('d/m/Y');
+
+            $this->context->buildViolation('regulation.step3.error.end_date_before_start_date')
+                ->setParameter('{{ compared_value }}', $viewStartDate)
+                ->atPath('endDate')
+                ->addViolation();
+
+            return;
+        }
+
+        // Same day: check the times.
+        // The end time (if set) must be strictly after the start time (if set).
+
+        if (!$command->endTime || !$command->startTime) {
+            return;
+        }
+
+        if ($command->endTime > $command->startTime) {
+            return;
+        }
+
+        $startTime = new \DateTimeImmutable($command->startTime->format('H:i:s'));
+        $viewStartTime = $startTime->setTimezone(new \DateTimeZone($this->clientTimezone))->format('H\\hi');
+
+        $this->context->buildViolation('regulation.step3.error.end_time_before_start_time')
+            ->setParameter('{{ compared_value }}', $viewStartTime)
+            ->atPath('endTime')
+            ->addViolation();
+    }
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -10,4 +10,10 @@ use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
+
+    public function boot(): void
+    {
+        parent::boot();
+        date_default_timezone_set('UTC');
+    }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -14,6 +14,6 @@ class Kernel extends BaseKernel
     public function boot(): void
     {
         parent::boot();
-        date_default_timezone_set('UTC');
+        date_default_timezone_set($this->getContainer()->getParameter('server_timezone'));
     }
 }

--- a/templates/api/regulations.xml.twig
+++ b/templates/api/regulations.xml.twig
@@ -20,8 +20,10 @@
 
     <trafficRegulationsFromCompetentAuthorities>
     {% for regulationOrder in regulationOrders %}
-        {% set startPeriod = regulationOrder.period.startPeriod %}
-        {% set endPeriod = regulationOrder.period.endPeriod %}
+        {% set startDate = regulationOrder.period.startDate %}
+        {% set startTime = regulationOrder.period.startTime %}
+        {% set endDate = regulationOrder.period.endDate %}
+        {% set endTime = regulationOrder.period.endTime %}
         {% set location = regulationOrder.location %}
         {% set vehicleCharacteristics = regulationOrder.vehicleCharacteristics %}
         <trafficRegulationOrder id="{{ regulationOrder.uuid }}" version="1">
@@ -49,9 +51,17 @@
                         <validityByOrder>
                             <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
                             <com:validityTimeSpecification>
-                                <com:overallStartTime>{{ startPeriod|date('Y-m-d') }}T00:00:00.000Z</com:overallStartTime>
-                                {% if endPeriod %}
-                                    <com:overallEndTime>{{ endPeriod|date('Y-m-d') }}T00:00:00.000Z</com:overallEndTime>
+                                {% if startTime %}
+                                <com:overallStartTime>{{ startDate|date('Y-m-d') }}T{{ startTime|date('h:i:s') }}.000Z</com:overallStartTime>
+                                {% else %}
+                                <com:overallStartTime>{{ startDate|date('Y-m-d') }}T00:00:00.000Z</com:overallStartTime>
+                                {% endif %}
+                                {% if endDate %}
+                                    {% if endTime %}
+                                    <com:overallEndTime>{{ endDate|date('Y-m-d') }}T{{ endTime|date('h:i:s') }}.000Z</com:overallEndTime>
+                                    {% else %}
+                                    <com:overallEndTime>{{ endDate|date('Y-m-d') }}T00:00:00.000Z</com:overallEndTime>
+                                    {% endif %}
                                 {% endif %}
                             </com:validityTimeSpecification>
                         </validityByOrder>

--- a/templates/api/regulations.xml.twig
+++ b/templates/api/regulations.xml.twig
@@ -51,17 +51,9 @@
                         <validityByOrder>
                             <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
                             <com:validityTimeSpecification>
-                                {% if startTime %}
-                                <com:overallStartTime>{{ startDate|date('Y-m-d') }}T{{ startTime|date('h:i:s') }}.000Z</com:overallStartTime>
-                                {% else %}
-                                <com:overallStartTime>{{ startDate|date('Y-m-d') }}T00:00:00.000Z</com:overallStartTime>
-                                {% endif %}
+                                <com:overallStartTime>{{ startDate|date('Y-m-d') }}T{{ startTime|default('00:00:00')|date('H:i:s') }}.000Z</com:overallStartTime>
                                 {% if endDate %}
-                                    {% if endTime %}
-                                    <com:overallEndTime>{{ endDate|date('Y-m-d') }}T{{ endTime|date('h:i:s') }}.000Z</com:overallEndTime>
-                                    {% else %}
-                                    <com:overallEndTime>{{ endDate|date('Y-m-d') }}T00:00:00.000Z</com:overallEndTime>
-                                    {% endif %}
+                                    <com:overallEndTime>{{ endDate|date('Y-m-d') }}T{{ endTime|default('23:59:59')|date('H:i:s') }}.000Z</com:overallEndTime>
                                 {% endif %}
                             </com:validityTimeSpecification>
                         </validityByOrder>

--- a/templates/regulation/_items.html.twig
+++ b/templates/regulation/_items.html.twig
@@ -13,7 +13,7 @@
         </thead>
         <tbody>
             {% for regulation in pagination.items %}
-                {% set isPresent = regulation.period ? "now"|date('U') >= regulation.period.startDate|date('U') : null %}
+                {% set isFuture = regulation.period ? app_is_future(regulation.period.startDate, regulation.period.startTime) : null %}
                 <tr>
                     <td>
                         {% if regulation.location %}
@@ -29,22 +29,19 @@
                             {% set endTime = regulation.period.endTime %}
                             {% if startDate and endDate %}
                                 <b>
-                                {{ 'common.date.from'|trans({ '%date%': startDate|date('d/m/Y') }) }}
-                                {% if startTime %}{{ 'common.time'|trans({ '%time%': startTime|date('H\\hi') }) }}{% endif %}
-                                {{ 'common.date.to'|trans({ '%date%': endDate|date('d/m/Y') }) }}
-                                {% if endTime %}{{ 'common.time'|trans({ '%time%': endTime|date('H\\hi') }) }}{% endif %}
+                                {{ 'common.date.from'|trans({ '%date%': app_datetime(startDate, startTime) }) }}
+                                {{ 'common.date.to'|trans({ '%date%': app_datetime(endDate, endTime) }) }}
                                 </b>
                             {% else %}
                                 <b>
-                                    {% if isPresent %}
-                                        {{ 'common.date.since'|trans({ '%date%': startDate|date('d/m/Y')  })}}
+                                    {% if isFuture %}
+                                        {{ 'common.date.starting'|trans({'%date%': app_datetime(startDate, startTime) }) }}
                                     {% else %}
-                                        {{ 'common.date.starting'|trans({'%date%': startDate|date('d/m/Y') }) }}
+                                        {{ 'common.date.since'|trans({ '%date%': app_datetime(startDate, startTime) })}}
                                     {% endif %}
-                                    {% if startTime %}{{ 'common.time'|trans({ '%time%': startTime|date('H\\hi') }) }}{% endif %}
                                 </b>
                                 <br/>
-                                <em>{{ 'common.permanent'|trans}}</em>
+                                <em>{{ 'common.permanent'|trans }}</em>
                             {% endif %}
                         {% endif %}
                     </td>
@@ -52,10 +49,10 @@
                         {% if regulation.status == 'draft' %}
                             <p class="fr-badge fr-badge--info">{{'regulation.status.draft'|trans}}</p>
                         {% elseif regulation.status == 'published' %}
-                            {% if isPresent %}
-                                <p class="fr-badge fr-badge--success">{{'regulation.present'|trans}}</p>
-                            {% else %}
+                            {% if isFuture %}
                                 <p class="fr-badge fr-badge--new">{{'regulation.future'|trans}}</p>
+                            {% else %}
+                                <p class="fr-badge fr-badge--success">{{'regulation.present'|trans}}</p>
                             {% endif %}
                         {% endif %}
                     </td>

--- a/templates/regulation/_items.html.twig
+++ b/templates/regulation/_items.html.twig
@@ -24,18 +24,24 @@
                     <td>
                         {% if regulation.period %}
                             {% set startDate = regulation.period.startDate %}
+                            {% set startTime = regulation.period.startTime %}
                             {% set endDate = regulation.period.endDate %}
+                            {% set endTime = regulation.period.endTime %}
                             {% if startDate and endDate %}
                                 <b>
-                                    {{ 'regulation.period.temporary'|trans({ '%startDate%': startDate|date('d/m/Y'), '%endDate%': endDate|date('d/m/Y') })}}
+                                {{ 'common.date.from'|trans({ '%date%': startDate|date('d/m/Y') }) }}
+                                {% if startTime %}{{ 'common.time'|trans({ '%time%': startTime|date('H\\hi') }) }}{% endif %}
+                                {{ 'common.date.to'|trans({ '%date%': endDate|date('d/m/Y') }) }}
+                                {% if endTime %}{{ 'common.time'|trans({ '%time%': endTime|date('H\\hi') }) }}{% endif %}
                                 </b>
                             {% else %}
                                 <b>
                                     {% if isPresent %}
-                                        {{ 'regulation.period.permanent.present'|trans({ '%date%': startDate|date('d/m/Y')  })}}
+                                        {{ 'common.date.since'|trans({ '%date%': startDate|date('d/m/Y')  })}}
                                     {% else %}
-                                        {{ 'regulation.period.permanent.future'|trans({ '%date%': startDate|date('d/m/Y') })}}
+                                        {{ 'common.date.starting'|trans({'%date%': startDate|date('d/m/Y') }) }}
                                     {% endif %}
+                                    {% if startTime %}{{ 'common.time'|trans({ '%time%': startTime|date('H\\hi') }) }}{% endif %}
                                 </b>
                                 <br/>
                                 <em>{{ 'common.permanent'|trans}}</em>

--- a/templates/regulation/_items.html.twig
+++ b/templates/regulation/_items.html.twig
@@ -13,7 +13,7 @@
         </thead>
         <tbody>
             {% for regulation in pagination.items %}
-                {% set isPresent = regulation.period ? "now"|date('U') >= regulation.period.startPeriod|date('U') : null %}
+                {% set isPresent = regulation.period ? "now"|date('U') >= regulation.period.startDate|date('U') : null %}
                 <tr>
                     <td>
                         {% if regulation.location %}
@@ -23,18 +23,18 @@
                     </td>
                     <td>
                         {% if regulation.period %}
-                            {% set startPeriod = regulation.period.startPeriod %}
-                            {% set endPeriod = regulation.period.endPeriod %}
-                            {% if startPeriod and endPeriod %}
+                            {% set startDate = regulation.period.startDate %}
+                            {% set endDate = regulation.period.endDate %}
+                            {% if startDate and endDate %}
                                 <b>
-                                    {{ 'regulation.period.temporary'|trans({ '%startPeriod%': startPeriod|date('d/m/Y'), '%endPeriod%': endPeriod|date('d/m/Y') })}}
+                                    {{ 'regulation.period.temporary'|trans({ '%startDate%': startDate|date('d/m/Y'), '%endDate%': endDate|date('d/m/Y') })}}
                                 </b>
                             {% else %}
                                 <b>
                                     {% if isPresent %}
-                                        {{ 'regulation.period.permanent.present'|trans({ '%date%': startPeriod|date('d/m/Y')  })}}
+                                        {{ 'regulation.period.permanent.present'|trans({ '%date%': startDate|date('d/m/Y')  })}}
                                     {% else %}
-                                        {{ 'regulation.period.permanent.future'|trans({ '%date%': startPeriod|date('d/m/Y') })}}
+                                        {{ 'regulation.period.permanent.future'|trans({ '%date%': startDate|date('d/m/Y') })}}
                                     {% endif %}
                                 </b>
                                 <br/>

--- a/templates/regulation/_summary.html.twig
+++ b/templates/regulation/_summary.html.twig
@@ -48,17 +48,17 @@
     <div class="summary-card__content">
         <h3 class="summary-card__title">{{ 'regulation.detail.when'|trans }}</h3>
         {% if regulationOrderRecord.period %}
-            {% set startPeriod = regulationOrderRecord.period.startPeriod %}
-            {% set endPeriod = regulationOrderRecord.period.endPeriod %}
+            {% set startDate = regulationOrderRecord.period.startDate %}
+            {% set endDate = regulationOrderRecord.period.endDate %}
             <ul class="fr-ml-1w fr-my-0">
                 <li>
-                    {% if startPeriod and endPeriod %}
+                    {% if startDate and endDate %}
                         {{ 'regulation.period.temporary'|trans({
-                            '%startPeriod%': startPeriod|date('d/m/Y'),
-                            '%endPeriod%': endPeriod|date('d/m/Y')
+                            '%startDate%': startDate|date('d/m/Y'),
+                            '%endDate%': endDate|date('d/m/Y')
                         }) }}
                     {% else %}
-                        {{ 'regulation.period.permanent.future'|trans({'%date%': startPeriod|date('d/m/Y') }) }}
+                        {{ 'regulation.period.permanent.future'|trans({'%date%': startDate|date('d/m/Y') }) }}
                     {% endif %}
                 </li>
             </ul>

--- a/templates/regulation/_summary.html.twig
+++ b/templates/regulation/_summary.html.twig
@@ -52,15 +52,16 @@
             {% set startTime = regulationOrderRecord.period.startTime %}
             {% set endDate = regulationOrderRecord.period.endDate %}
             {% set endTime = regulationOrderRecord.period.endTime %}
+            {% set isFuture = app_is_future(startDate, startTime) %}
             <ul class="fr-ml-1w fr-my-0">
                 <li>
                     {% if startDate and endDate %}
-                        {{ 'common.date.from'|trans({ '%date%': startDate|date('d/m/Y') }) }}
-                        {% if startTime %}{{ 'common.time'|trans({ '%time%': startTime|date('H\\hi') }) }}{% endif %}
-                        {{ 'common.date.to'|trans({ '%date%': endDate|date('d/m/Y') }) }}
-                        {% if endTime %}{{ 'common.time'|trans({ '%time%': endTime|date('H\\hi') }) }}{% endif %}
+                        {{ 'common.date.from'|trans({ '%date%': app_datetime(startDate, startTime) }) }}
+                        {{ 'common.date.to'|trans({ '%date%': app_datetime(endDate, endTime) }) }}
+                    {% elseif isFuture %}
+                        {{ 'common.date.starting'|trans({'%date%': app_datetime(startDate, startTime) }) }}
                     {% else %}
-                        {{ 'common.date.starting'|trans({'%date%': startDate|date('d/m/Y') }) }}
+                        {{ 'common.date.since'|trans({'%date%': app_datetime(startDate, startTime) }) }}
                     {% endif %}
                 </li>
             </ul>

--- a/templates/regulation/_summary.html.twig
+++ b/templates/regulation/_summary.html.twig
@@ -49,16 +49,18 @@
         <h3 class="summary-card__title">{{ 'regulation.detail.when'|trans }}</h3>
         {% if regulationOrderRecord.period %}
             {% set startDate = regulationOrderRecord.period.startDate %}
+            {% set startTime = regulationOrderRecord.period.startTime %}
             {% set endDate = regulationOrderRecord.period.endDate %}
+            {% set endTime = regulationOrderRecord.period.endTime %}
             <ul class="fr-ml-1w fr-my-0">
                 <li>
                     {% if startDate and endDate %}
-                        {{ 'regulation.period.temporary'|trans({
-                            '%startDate%': startDate|date('d/m/Y'),
-                            '%endDate%': endDate|date('d/m/Y')
-                        }) }}
+                        {{ 'common.date.from'|trans({ '%date%': startDate|date('d/m/Y') }) }}
+                        {% if startTime %}{{ 'common.time'|trans({ '%time%': startTime|date('H\\hi') }) }}{% endif %}
+                        {{ 'common.date.to'|trans({ '%date%': endDate|date('d/m/Y') }) }}
+                        {% if endTime %}{{ 'common.time'|trans({ '%time%': endTime|date('H\\hi') }) }}{% endif %}
                     {% else %}
-                        {{ 'regulation.period.permanent.future'|trans({'%date%': startDate|date('d/m/Y') }) }}
+                        {{ 'common.date.starting'|trans({'%date%': startDate|date('d/m/Y') }) }}
                     {% endif %}
                 </li>
             </ul>

--- a/templates/regulation/steps/step3.html.twig
+++ b/templates/regulation/steps/step3.html.twig
@@ -13,7 +13,7 @@
         {{ form_errors(form) }}
 
         <div class="fr-grid-row fr-mb-3w">
-            <div class="fr-grid-row fr-grid-row--gutters fr-col-12 fr-col-md-9 fr-col-lg-6">
+            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom fr-col-12 fr-col-md-9 fr-col-lg-6">
                 {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-7 fr-mb-0'}, widget_class: 'fr-input'}) }}
                 {{ form_row(form.startTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-5'}, widget_class: 'fr-input'}) }}
             </div>

--- a/templates/regulation/steps/step3.html.twig
+++ b/templates/regulation/steps/step3.html.twig
@@ -11,8 +11,8 @@
 
     {{ form_start(form) }}
         {{ form_errors(form) }}
-        {{ form_row(form.startPeriod, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
-        {{ form_row(form.endPeriod, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
+        {{ form_row(form.startPeriod, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
+        {{ form_row(form.endPeriod, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
 
         <a href="{{ path('app_regulations_steps_2', {uuid}) }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-arrow-left-line fr-mr-3w">
             {{ "common.back"|trans }}

--- a/templates/regulation/steps/step3.html.twig
+++ b/templates/regulation/steps/step3.html.twig
@@ -11,8 +11,10 @@
 
     {{ form_start(form) }}
         {{ form_errors(form) }}
-        {{ form_row(form.startPeriod, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
-        {{ form_row(form.endPeriod, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
+        {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
+        {{ form_row(form.startTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
+        {{ form_row(form.endDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
+        {{ form_row(form.endTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
 
         <a href="{{ path('app_regulations_steps_2', {uuid}) }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-arrow-left-line fr-mr-3w">
             {{ "common.back"|trans }}

--- a/templates/regulation/steps/step3.html.twig
+++ b/templates/regulation/steps/step3.html.twig
@@ -11,10 +11,20 @@
 
     {{ form_start(form) }}
         {{ form_errors(form) }}
-        {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
-        {{ form_row(form.startTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
-        {{ form_row(form.endDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
-        {{ form_row(form.endTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-8 fr-col-md-6'}, widget_class: 'fr-input'}) }}
+
+        <div class="fr-grid-row fr-mb-3w">
+            <div class="fr-grid-row fr-grid-row--gutters fr-col-12 fr-col-md-9 fr-col-lg-6">
+                {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-7 fr-mb-0'}, widget_class: 'fr-input'}) }}
+                {{ form_row(form.startTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-5'}, widget_class: 'fr-input'}) }}
+            </div>
+        </div>
+
+        <div class="fr-grid-row fr-mb-3w">
+            <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--bottom fr-col-12 fr-col-md-9 fr-col-lg-6">
+                {{ form_row(form.endDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-7 fr-mb-0'}, widget_class: 'fr-input'}) }}
+                {{ form_row(form.endTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-sm-5'}, widget_class: 'fr-input'}) }}
+            </div>
+        </div>
 
         <a href="{{ path('app_regulations_steps_2', {uuid}) }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-arrow-left-line fr-mr-3w">
             {{ "common.back"|trans }}

--- a/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
@@ -45,7 +45,7 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
         $pageTwoDraftRow1 = $pageTwoDraftRows->eq(0)->filter('td');
 
         $this->assertSame("Savenay Route du Grand Brossais", $pageTwoDraftRow1->eq(0)->text());
-        $this->assertSame("du 08/12/2022 à 08h00 au 18/12/2022 à 16h00", $pageTwoDraftRow1->eq(1)->text());
+        $this->assertSame("du 08/12/2022 à 09h00 au 18/12/2022 à 17h00", $pageTwoDraftRow1->eq(1)->text());
         $this->assertSame("Brouillon", $pageTwoDraftRow1->eq(2)->text());
 
         // Test published reglementation rendering

--- a/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
@@ -45,7 +45,7 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
         $pageTwoDraftRow1 = $pageTwoDraftRows->eq(0)->filter('td');
 
         $this->assertSame("Savenay Route du Grand Brossais", $pageTwoDraftRow1->eq(0)->text());
-        $this->assertSame("du 08/12/2022 au 18/12/2022", $pageTwoDraftRow1->eq(1)->text());
+        $this->assertSame("du 08/12/2022 à 08h00 au 18/12/2022 à 16h00", $pageTwoDraftRow1->eq(1)->text());
         $this->assertSame("Brouillon", $pageTwoDraftRow1->eq(2)->text());
 
         // Test published reglementation rendering

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -33,7 +33,7 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertSame('http://localhost/regulations/form/e413a47e-5928-4353-a8b2-8b7dda27f9a5/2', $step2->filter('a')->link()->getUri());
 
         // Step 3
-        $this->assertSame('du 08/12/2022 à 08h00 au 18/12/2022 à 16h00', $step3->filter('li')->eq(0)->text());
+        $this->assertSame('du 08/12/2022 à 09h00 au 18/12/2022 à 17h00', $step3->filter('li')->eq(0)->text());
         $this->assertSame('http://localhost/regulations/form/e413a47e-5928-4353-a8b2-8b7dda27f9a5/3', $step3->filter('a')->link()->getUri());
 
         // Step 4

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -33,7 +33,7 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertSame('http://localhost/regulations/form/e413a47e-5928-4353-a8b2-8b7dda27f9a5/2', $step2->filter('a')->link()->getUri());
 
         // Step 3
-        $this->assertSame('du 08/12/2022 au 18/12/2022', $step3->filter('li')->eq(0)->text());
+        $this->assertSame('du 08/12/2022 à 08h00 au 18/12/2022 à 16h00', $step3->filter('li')->eq(0)->text());
         $this->assertSame('http://localhost/regulations/form/e413a47e-5928-4353-a8b2-8b7dda27f9a5/3', $step3->filter('a')->link()->getUri());
 
         // Step 4

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step3ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step3ControllerTest.php
@@ -8,7 +8,51 @@ use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
 
 final class Step3ControllerTest extends AbstractWebTestCase
 {
-    public function testAdd(): void
+    public function provideAdd(): array {
+        return [
+            // Cover all valid cases.
+            [
+                // Start date only
+                'startDate' => '2022-12-07',
+                'startTime' => '',
+                'endDate' => '',
+                'endTime' => '',
+            ],
+            [
+                // Start date, and end date in the future
+                'startDate' => '2022-12-07',
+                'startTime' => '',
+                'endDate' => '2022-12-17',
+                'endTime' => '',
+            ],
+            [
+                // Same date, with start time only
+                'startDate' => '2022-12-07',
+                'startTime' => '09:00',
+                'endDate' => '2022-12-07',
+                'endTime' => '',
+            ],
+            [
+                // Same date, with end time only
+                'startDate' => '2022-12-07',
+                'startTime' => '',
+                'endDate' => '2022-12-07',
+                'endTime' => '06:00',
+            ],
+            [
+                // Same date, with end time in the future
+                'startDate' => '2022-12-07',
+                'startTime' => '09:00',
+                'endDate' => '2022-12-07',
+                'endTime' => '10:00',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideAdd
+     */
+    public function testAdd(string $startDate, string $startTime, string $endDate, string $endTime): void
     {
         $client = $this->login();
         $crawler = $client->request('GET', '/regulations/form/4ce75a1f-82f3-40ee-8f95-48d0f04446aa/3'); // Regulation Order Record without overall period
@@ -20,10 +64,10 @@ final class Step3ControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Suivant');
         $form = $saveButton->form();
-        $form["step3_form[startDate]"] = "2022-12-07";
-        $form["step3_form[startTime]"] = "09:00";
-        $form["step3_form[endDate]"] = "2022-12-17";
-        $form["step3_form[endTime]"] = "06:00";
+        $form["step3_form[startDate]"] = $startDate;
+        $form["step3_form[startTime]"] = $startTime;
+        $form["step3_form[endDate]"] = $endDate;
+        $form["step3_form[endTime]"] = $endTime;
 
         $client->submit($form);
         $this->assertResponseStatusCodeSame(303);
@@ -32,7 +76,6 @@ final class Step3ControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(200);
         $this->assertRouteSame('app_regulations_steps_4');
     }
-
     public function testInvalidPeriod(): void
     {
         $client = $this->login();
@@ -41,11 +84,11 @@ final class Step3ControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Suivant');
         $form = $saveButton->form();
+
         $form["step3_form[startDate]"] = "mauvais format";
         $form["step3_form[startTime]"] = "mauvais format";
         $form["step3_form[endDate]"] = "mauvais format";
         $form["step3_form[endTime]"] = "mauvais format";
-
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
         $this->assertCount(4, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
@@ -58,11 +101,28 @@ final class Step3ControllerTest extends AbstractWebTestCase
         $form["step3_form[startTime]"] = "";
         $form["step3_form[endDate]"] = "2022-12-05";
         $form["step3_form[endTime]"] = "";
-
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
         $this->assertCount(1, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
-        $this->assertCount(1, $crawler->filter('#step3_form_endDate_error')); // Cette valeur doit être supérieure à 7 déc. 2022.
+        $this->assertSame("La date de fin doit être après le 07/12/2022.", $crawler->filter('#step3_form_endDate_error')->text());
+
+        $form["step3_form[startDate]"] = "2022-12-07";
+        $form["step3_form[startTime]"] = "16:00";
+        $form["step3_form[endDate]"] = "2022-12-07";
+        $form["step3_form[endTime]"] = "15:59";
+        $crawler = $client->submit($form);
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertCount(1, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
+        $this->assertSame("L'heure de fin doit être après 16h00.", $crawler->filter('#step3_form_endTime_error')->text());
+
+        $form["step3_form[startDate]"] = "2022-12-07";
+        $form["step3_form[startTime]"] = "";
+        $form["step3_form[endDate]"] = "";
+        $form["step3_form[endTime]"] = "15:59";
+        $crawler = $client->submit($form);
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertCount(1, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
+        $this->assertSame("Veuillez indiquer une date de fin, ou retirer l'heure de fin.", $crawler->filter('#step3_form_endDate_error')->text());
     }
 
     public function testRegulationOrderRecordNotFound(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step3ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step3ControllerTest.php
@@ -21,7 +21,9 @@ final class Step3ControllerTest extends AbstractWebTestCase
         $saveButton = $crawler->selectButton('Suivant');
         $form = $saveButton->form();
         $form["step3_form[startDate]"] = "2022-12-07";
+        $form["step3_form[startTime]"] = "09:00";
         $form["step3_form[endDate]"] = "2022-12-17";
+        $form["step3_form[endTime]"] = "06:00";
 
         $client->submit($form);
         $this->assertResponseStatusCodeSame(303);

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step3ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step3ControllerTest.php
@@ -8,51 +8,7 @@ use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
 
 final class Step3ControllerTest extends AbstractWebTestCase
 {
-    public function provideAdd(): array {
-        return [
-            // Cover all valid cases.
-            [
-                // Start date only
-                'startDate' => '2022-12-07',
-                'startTime' => '',
-                'endDate' => '',
-                'endTime' => '',
-            ],
-            [
-                // Start date, and end date in the future
-                'startDate' => '2022-12-07',
-                'startTime' => '',
-                'endDate' => '2022-12-17',
-                'endTime' => '',
-            ],
-            [
-                // Same date, with start time only
-                'startDate' => '2022-12-07',
-                'startTime' => '09:00',
-                'endDate' => '2022-12-07',
-                'endTime' => '',
-            ],
-            [
-                // Same date, with end time only
-                'startDate' => '2022-12-07',
-                'startTime' => '',
-                'endDate' => '2022-12-07',
-                'endTime' => '06:00',
-            ],
-            [
-                // Same date, with end time in the future
-                'startDate' => '2022-12-07',
-                'startTime' => '09:00',
-                'endDate' => '2022-12-07',
-                'endTime' => '10:00',
-            ],
-        ];
-    }
-
-    /**
-     * @dataProvider provideAdd
-     */
-    public function testAdd(string $startDate, string $startTime, string $endDate, string $endTime): void
+    public function testAdd(): void
     {
         $client = $this->login();
         $crawler = $client->request('GET', '/regulations/form/4ce75a1f-82f3-40ee-8f95-48d0f04446aa/3'); // Regulation Order Record without overall period
@@ -64,10 +20,8 @@ final class Step3ControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Suivant');
         $form = $saveButton->form();
-        $form["step3_form[startDate]"] = $startDate;
-        $form["step3_form[startTime]"] = $startTime;
-        $form["step3_form[endDate]"] = $endDate;
-        $form["step3_form[endTime]"] = $endTime;
+        $form["step3_form[startDate]"] = "2022-12-07";
+        $form["step3_form[endDate]"] = "2022-12-17";
 
         $client->submit($form);
         $this->assertResponseStatusCodeSame(303);
@@ -97,6 +51,7 @@ final class Step3ControllerTest extends AbstractWebTestCase
         $this->assertSame("Veuillez entrer une date valide.", $crawler->filter('#step3_form_endDate_error')->text());
         $this->assertSame("Veuillez saisir une heure valide.", $crawler->filter('#step3_form_endTime_error')->text());
 
+        // Other invalid cases are covered in unit tests.
         $form["step3_form[startDate]"] = "2022-12-07";
         $form["step3_form[startTime]"] = "";
         $form["step3_form[endDate]"] = "2022-12-05";
@@ -105,24 +60,6 @@ final class Step3ControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(422);
         $this->assertCount(1, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
         $this->assertSame("La date de fin doit être après le 07/12/2022.", $crawler->filter('#step3_form_endDate_error')->text());
-
-        $form["step3_form[startDate]"] = "2022-12-07";
-        $form["step3_form[startTime]"] = "16:00";
-        $form["step3_form[endDate]"] = "2022-12-07";
-        $form["step3_form[endTime]"] = "15:59";
-        $crawler = $client->submit($form);
-        $this->assertResponseStatusCodeSame(422);
-        $this->assertCount(1, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
-        $this->assertSame("L'heure de fin doit être après 16h00.", $crawler->filter('#step3_form_endTime_error')->text());
-
-        $form["step3_form[startDate]"] = "2022-12-07";
-        $form["step3_form[startTime]"] = "";
-        $form["step3_form[endDate]"] = "";
-        $form["step3_form[endTime]"] = "15:59";
-        $crawler = $client->submit($form);
-        $this->assertResponseStatusCodeSame(422);
-        $this->assertCount(1, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
-        $this->assertSame("Veuillez indiquer une date de fin, ou retirer l'heure de fin.", $crawler->filter('#step3_form_endDate_error')->text());
     }
 
     public function testRegulationOrderRecordNotFound(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step3ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step3ControllerTest.php
@@ -20,8 +20,8 @@ final class Step3ControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Suivant');
         $form = $saveButton->form();
-        $form["step3_form[startPeriod]"] = "2022-12-07T00:00";
-        $form["step3_form[endPeriod]"] = "2022-12-17T23:59";
+        $form["step3_form[startDate]"] = "2022-12-07";
+        $form["step3_form[endDate]"] = "2022-12-17";
 
         $client->submit($form);
         $this->assertResponseStatusCodeSame(303);
@@ -39,22 +39,28 @@ final class Step3ControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Suivant');
         $form = $saveButton->form();
-        $form["step3_form[startPeriod]"] = "mauvais format";
-        $form["step3_form[endPeriod]"] = "mauvais format";
+        $form["step3_form[startDate]"] = "mauvais format";
+        $form["step3_form[startTime]"] = "mauvais format";
+        $form["step3_form[endDate]"] = "mauvais format";
+        $form["step3_form[endTime]"] = "mauvais format";
 
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
-        $this->assertCount(2, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
-        $this->assertSame("Veuillez saisir une date et une heure valides.", $crawler->filter('#step3_form_startPeriod_error')->text());
-        $this->assertSame("Veuillez saisir une date et une heure valides.", $crawler->filter('#step3_form_endPeriod_error')->text());
+        $this->assertCount(4, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
+        $this->assertSame("Veuillez entrer une date valide.", $crawler->filter('#step3_form_startDate_error')->text());
+        $this->assertSame("Veuillez saisir une heure valide.", $crawler->filter('#step3_form_startTime_error')->text());
+        $this->assertSame("Veuillez entrer une date valide.", $crawler->filter('#step3_form_endDate_error')->text());
+        $this->assertSame("Veuillez saisir une heure valide.", $crawler->filter('#step3_form_endTime_error')->text());
 
-        $form["step3_form[startPeriod]"] = "2022-12-07T00:00";
-        $form["step3_form[endPeriod]"] = "2022-12-05T23:59";
+        $form["step3_form[startDate]"] = "2022-12-07";
+        $form["step3_form[startTime]"] = "";
+        $form["step3_form[endDate]"] = "2022-12-05";
+        $form["step3_form[endTime]"] = "";
 
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
         $this->assertCount(1, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
-        $this->assertCount(1, $crawler->filter('#step3_form_endPeriod_error')); // Cette valeur doit être supérieure à 7 déc. 2022.
+        $this->assertCount(1, $crawler->filter('#step3_form_endDate_error')); // Cette valeur doit être supérieure à 7 déc. 2022.
     }
 
     public function testRegulationOrderRecordNotFound(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step3ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step3ControllerTest.php
@@ -20,8 +20,8 @@ final class Step3ControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Suivant');
         $form = $saveButton->form();
-        $form["step3_form[startPeriod]"] = "2022-12-07";
-        $form["step3_form[endPeriod]"] = "2022-12-17";
+        $form["step3_form[startPeriod]"] = "2022-12-07T00:00";
+        $form["step3_form[endPeriod]"] = "2022-12-17T23:59";
 
         $client->submit($form);
         $this->assertResponseStatusCodeSame(303);
@@ -45,11 +45,11 @@ final class Step3ControllerTest extends AbstractWebTestCase
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
         $this->assertCount(2, $crawler->filter('[id^="step3_form_"][id$="_error"]'));
-        $this->assertSame("Veuillez entrer une date valide.", $crawler->filter('#step3_form_startPeriod_error')->text());
-        $this->assertSame("Veuillez entrer une date valide.", $crawler->filter('#step3_form_endPeriod_error')->text());
+        $this->assertSame("Veuillez saisir une date et une heure valides.", $crawler->filter('#step3_form_startPeriod_error')->text());
+        $this->assertSame("Veuillez saisir une date et une heure valides.", $crawler->filter('#step3_form_endPeriod_error')->text());
 
-        $form["step3_form[startPeriod]"] = "2022-12-07";
-        $form["step3_form[endPeriod]"] = "2022-12-05";
+        $form["step3_form[startPeriod]"] = "2022-12-07T00:00";
+        $form["step3_form[endPeriod]"] = "2022-12-05T23:59";
 
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);

--- a/tests/TimezoneHelper.php
+++ b/tests/TimezoneHelper.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests;
+
+trait TimezoneHelper
+{
+    protected function setDefaultTimezone(?string $timezone)
+    {
+        date_default_timezone_set($timezone);
+    }
+}

--- a/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
@@ -203,22 +203,34 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
             );
 
         // OverallPeriod
-        $start = new \DateTime('2023-02-10');
-        $end = new \DateTime('2023-02-12');
+        $startDate = new \DateTime('2023-02-10');
+        $startTime = new \DateTime('22:00:00');
+        $endDate = new \DateTime('2023-02-12');
+        $endTime = new \DateTime('08:00:00');
 
         $overallPeriod = $this->createMock(OverallPeriod::class);
         $overallPeriod
             ->expects(self::once())
             ->method('getStartDate')
-            ->willReturn($start);
+            ->willReturn($startDate);
+        $overallPeriod
+            ->expects(self::once())
+            ->method('getStartTime')
+            ->willReturn($startTime);
         $overallPeriod
             ->expects(self::once())
             ->method('getEndDate')
-            ->willReturn($end);
+            ->willReturn($endDate);
+        $overallPeriod
+            ->expects(self::once())
+            ->method('getEndTime')
+            ->willReturn($endTime);
 
         $step3Command = new SaveRegulationStep3Command($duplicatedRegulationOrderRecord);
-        $step3Command->startDate = $start;
-        $step3Command->endDate = $end;
+        $step3Command->startDate = $startDate;
+        $step3Command->startTime = $startTime;
+        $step3Command->endDate = $endDate;
+        $step3Command->endTime = $endTime;
 
         // VehicleCharacteristics
         $vehicleCharacteristics = $this->createMock(VehicleCharacteristics::class);

--- a/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
@@ -209,16 +209,16 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
         $overallPeriod = $this->createMock(OverallPeriod::class);
         $overallPeriod
             ->expects(self::once())
-            ->method('getStartPeriod')
+            ->method('getStartDate')
             ->willReturn($start);
         $overallPeriod
             ->expects(self::once())
-            ->method('getEndPeriod')
+            ->method('getEndDate')
             ->willReturn($end);
 
         $step3Command = new SaveRegulationStep3Command($duplicatedRegulationOrderRecord);
-        $step3Command->startPeriod = $start;
-        $step3Command->endPeriod = $end;
+        $step3Command->startDate = $start;
+        $step3Command->endDate = $end;
 
         // VehicleCharacteristics
         $vehicleCharacteristics = $this->createMock(VehicleCharacteristics::class);

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep3CommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep3CommandHandlerTest.php
@@ -16,16 +16,20 @@ use PHPUnit\Framework\TestCase;
 
 final class SaveRegulationStep3CommandHandlerTest extends TestCase
 {
-    private $startPeriod;
-    private $endPeriod;
+    private $startDate;
+    private $startTime;
+    private $endDate;
+    private $endTime;
     private $regulationCondition;
     private $regulationOrder;
     private $regulationOrderRecord;
 
     protected function setUp(): void
     {
-        $this->startPeriod = new \DateTime('2022-12-07 15:00');
-        $this->endPeriod = new \DateTime('2022-12-17 16:00');
+        $this->startDate = new \DateTime('2022-12-07');
+        $this->startTime = new \DateTime('15:00');
+        $this->endDate = new \DateTime('2022-12-17');
+        $this->endTime = new \DateTime('16:00');
 
         $this->regulationCondition = $this->createMock(RegulationCondition::class);
         $this->regulationOrder = $this->createMock(RegulationOrder::class);
@@ -58,8 +62,10 @@ final class SaveRegulationStep3CommandHandlerTest extends TestCase
                     new OverallPeriod(
                         uuid: '98d3d3c6-83cd-49ab-b94a-4d4373a31114',
                         regulationCondition: $this->regulationCondition,
-                        startPeriod: $this->startPeriod,
-                        endPeriod: $this->endPeriod,
+                        startDate: $this->startDate,
+                        startTime: $this->startTime,
+                        endDate: $this->endDate,
+                        endTime: $this->endTime,
                     )
                 )
             );
@@ -70,8 +76,10 @@ final class SaveRegulationStep3CommandHandlerTest extends TestCase
         );
 
         $command = new SaveRegulationStep3Command($this->regulationOrderRecord);
-        $command->startPeriod = $this->startPeriod;
-        $command->endPeriod = $this->endPeriod;
+        $command->startDate = $this->startDate;
+        $command->startTime = $this->startTime;
+        $command->endDate = $this->endDate;
+        $command->endTime = $this->endTime;
 
         $this->assertEmpty($handler($command, null));
     }
@@ -82,7 +90,7 @@ final class SaveRegulationStep3CommandHandlerTest extends TestCase
         $overallPeriod
             ->expects(self::once())
             ->method('update')
-            ->with($this->startPeriod, $this->endPeriod);
+            ->with($this->startDate, $this->startTime, $this->endDate, $this->endTime);
 
         $idFactory = $this->createMock(IdFactoryInterface::class);
         $idFactory
@@ -100,8 +108,10 @@ final class SaveRegulationStep3CommandHandlerTest extends TestCase
         );
 
         $command = new SaveRegulationStep3Command($this->regulationOrderRecord, $overallPeriod);
-        $command->startPeriod = $this->startPeriod;
-        $command->endPeriod = $this->endPeriod;
+        $command->startDate = $this->startDate;
+        $command->startTime = $this->startTime;
+        $command->endDate = $this->endDate;
+        $command->endTime = $this->endTime;
 
         $this->assertEmpty($handler($command));
     }

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep3CommandTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep3CommandTest.php
@@ -16,29 +16,43 @@ final class SaveRegulationStep3CommandTest extends TestCase
         $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
         $command = SaveRegulationStep3Command::create($regulationOrderRecord);
 
-        $this->assertEmpty($command->startPeriod);
-        $this->assertEmpty($command->endPeriod);
+        $this->assertEmpty($command->startDate);
+        $this->assertEmpty($command->startTime);
+        $this->assertEmpty($command->endDate);
+        $this->assertEmpty($command->endTime);
     }
 
     public function testWithOverallPeriod(): void
     {
-        $start = new \DateTime('2022-01-11');
-        $end = new \DateTime('2022-01-12');
+        $startDate = new \DateTime('2022-01-11');
+        $startTime = new \DateTime('08:00:00');
+        $endDate = new \DateTime('2022-01-12');
+        $endTime = new \DateTime('01:00:00');
 
         $overallPeriod = $this->createMock(OverallPeriod::class);
         $overallPeriod
             ->expects(self::once())
-            ->method('getStartPeriod')
-            ->willReturn($start);
+            ->method('getStartDate')
+            ->willReturn($startDate);
         $overallPeriod
             ->expects(self::once())
-            ->method('getEndPeriod')
-            ->willReturn($end);
+            ->method('getStartTime')
+            ->willReturn($startTime);
+        $overallPeriod
+            ->expects(self::once())
+            ->method('getEndDate')
+            ->willReturn($endDate);
+        $overallPeriod
+            ->expects(self::once())
+            ->method('getEndTime')
+            ->willReturn($endTime);
 
         $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
         $command = SaveRegulationStep3Command::create($regulationOrderRecord, $overallPeriod);
 
-        $this->assertSame($command->startPeriod, $start);
-        $this->assertSame($command->endPeriod, $end);
+        $this->assertSame($command->startDate, $startDate);
+        $this->assertSame($command->startTime, $startTime);
+        $this->assertSame($command->endDate, $endDate);
+        $this->assertSame($command->endTime, $endTime);
     }
 }

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandlerTest.php
@@ -26,8 +26,8 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
             toHouseNumber: '253',
         );
 
-        $startPeriod = new \DateTime('2022-12-07');
-        $endPeriod = new \DateTime('2022-12-17');
+        $startDate = new \DateTime('2022-12-07');
+        $endDate = new \DateTime('2022-12-17');
 
         $regulationOrderRecordRepository = $this->createMock(RegulationOrderRecordRepositoryInterface::class);
 
@@ -36,8 +36,10 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
             'organizationUuid' => 'a8439603-40f7-4b1e-8a35-cee9e53b98d4',
             'status' => 'draft',
             'description' => 'Description 1',
-            'startPeriod' => $startPeriod,
-            'endPeriod' => $endPeriod,
+            'startDate' => $startDate,
+            'startTime' => null,
+            'endDate' => $endDate,
+            'endTime' => null,
             'postalCode' => $location->postalCode,
             'city' => $location->city,
             'roadName' => $location->roadName,
@@ -63,7 +65,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'a8439603-40f7-4b1e-8a35-cee9e53b98d4',
                 'draft',
                 'Description 1',
-                new PeriodView($startPeriod, $endPeriod),
+                new PeriodView($startDate, null, $endDate, null),
                 new DetailLocationView(
                     $location->postalCode,
                     $location->city,
@@ -86,8 +88,10 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
             'organizationUuid' => 'a8439603-40f7-4b1e-8a35-cee9e53b98d4',
             'status' => 'draft',
             'description' => 'Description 1',
-            'startPeriod' => null,
-            'endPeriod' => null,
+            'startDate' => null,
+            'startTime' => null,
+            'endDate' => null,
+            'endTime' => null,
             'postalCode' => null,
             'city' => null,
             'roadName' => null,

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
@@ -41,17 +41,19 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
             toLongitude :'-1.930973',
         );
 
-        $startPeriod1 = new \DateTime('2022-12-07');
-        $endPeriod1 = new \DateTime('2022-12-17');
-        $startPeriod2 = new \DateTime('2022-12-10');
+        $startDate1 = new \DateTime('2022-12-07');
+        $endDate1 = new \DateTime('2022-12-17');
+        $startDate2 = new \DateTime('2022-12-10');
 
         $regulationOrderRecordRepository = $this->createMock(RegulationOrderRecordRepositoryInterface::class);
         $regulationOrder1 = [
             'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
             'issuingAuthority' => 'Autorité 1',
             'description' => 'Description 1',
-            'startPeriod' => $startPeriod1,
-            'endPeriod' => $endPeriod1,
+            'startDate' => $startDate1,
+            'startTime' => null,
+            'endDate' => $endDate1,
+            'endTime' => null,
             'postalCode' => $location1->postalCode,
             'city' => $location1->city,
             'roadName' => $location1->roadName,
@@ -70,8 +72,10 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
             'uuid' => '247edaa2-58d1-43de-9d33-9753bf6f4d30',
             'issuingAuthority' => 'Autorité 2',
             'description' => 'Description 2',
-            'startPeriod' => $startPeriod2,
-            'endPeriod' => null,
+            'startDate' => $startDate2,
+            'startTime' => null,
+            'endDate' => null,
+            'endTime' => null,
             'postalCode' => $location2->postalCode,
             'city' => $location2->city,
             'roadName' => $location2->roadName,
@@ -101,7 +105,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
                     uuid: '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
                     issuingAuthority: 'Autorité 1',
                     description: 'Description 1',
-                    period: new PeriodView($startPeriod1, $endPeriod1),
+                    period: new PeriodView($startDate1, null, $endDate1, null),
                     location: $location1,
                     vehicleCharacteristics: new VehicleCharacteristicsView(3.5, 3, 2, 10),
                 ),
@@ -109,7 +113,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
                     uuid: '247edaa2-58d1-43de-9d33-9753bf6f4d30',
                     issuingAuthority: 'Autorité 2',
                     description: 'Description 2',
-                    period: new PeriodView($startPeriod2),
+                    period: new PeriodView($startDate2, null, null, null),
                     location: $location2,
                     vehicleCharacteristics: null,
                 ),

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
@@ -42,7 +42,9 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
         );
 
         $startDate1 = new \DateTime('2022-12-07');
+        $startTime1 = new \DateTime('22:00');
         $endDate1 = new \DateTime('2022-12-17');
+        $endTime1 = new \DateTime('06:00');
         $startDate2 = new \DateTime('2022-12-10');
 
         $regulationOrderRecordRepository = $this->createMock(RegulationOrderRecordRepositoryInterface::class);
@@ -51,9 +53,9 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
             'issuingAuthority' => 'Autorité 1',
             'description' => 'Description 1',
             'startDate' => $startDate1,
-            'startTime' => null,
+            'startTime' => $startTime1,
             'endDate' => $endDate1,
-            'endTime' => null,
+            'endTime' => $endTime1,
             'postalCode' => $location1->postalCode,
             'city' => $location1->city,
             'roadName' => $location1->roadName,
@@ -105,7 +107,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
                     uuid: '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
                     issuingAuthority: 'Autorité 1',
                     description: 'Description 1',
-                    period: new PeriodView($startDate1, null, $endDate1, null),
+                    period: new PeriodView($startDate1, $startTime1, $endDate1, $endTime1),
                     location: $location1,
                     vehicleCharacteristics: new VehicleCharacteristicsView(3.5, 3, 2, 10),
                 ),

--- a/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
@@ -18,32 +18,38 @@ final class GetRegulationsQueryHandlerTest extends TestCase
 {
     public function testGetAll(): void
     {
-        $startPeriod1 = new \DateTime('2022-12-07');
-        $endPeriod1 = new \DateTime('2022-12-17');
-        $startPeriod2 = new \DateTime('2022-12-10');
+        $startDate1 = new \DateTime('2022-12-07');
+        $endDate1 = new \DateTime('2022-12-17');
+        $startDate2 = new \DateTime('2022-12-10');
         $organization = $this->createMock(Organization::class);
 
         $regulationOrderRecordRepository = $this->createMock(RegulationOrderRecordRepositoryInterface::class);
         $regulationOrder1 = [
             'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
-            'startPeriod' => $startPeriod1,
-            'endPeriod' => $endPeriod1,
+            'startDate' => $startDate1,
+            'startTime' => null,
+            'endDate' => $endDate1,
+            'endTime' => null,
             'status' => 'draft',
             'city' => 'Savenay',
             'roadName' => 'Rue de Prince Bois',
         ];
         $regulationOrder2 = [
             'uuid' => '247edaa2-58d1-43de-9d33-9753bf6f4d30',
-            'startPeriod' => $startPeriod2,
-            'endPeriod' => null,
+            'startDate' => $startDate2,
+            'startTime' => null,
+            'endDate' => null,
+            'endTime' => null,
             'status' => 'draft',
             'city' => 'Savenay',
             'roadName' => 'Rue du Lac',
         ];
         $regulationOrder3 = [
             'uuid' => 'c421193a-5437-431a-9228-db6288d36a16',
-            'startPeriod' => null,
-            'endPeriod' => null,
+            'startDate' => null,
+            'startTime' => null,
+            'endDate' => null,
+            'endTime' => null,
             'status' => 'draft',
             'city' => null,
             'roadName' => null,
@@ -70,13 +76,13 @@ final class GetRegulationsQueryHandlerTest extends TestCase
                     '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
                     'draft',
                     new ListItemLocationView('Rue de Prince Bois', 'Savenay'),
-                    new PeriodView($startPeriod1, $endPeriod1),
+                    new PeriodView($startDate1, null, $endDate1, null),
                 ),
                 new RegulationOrderListItemView(
                     '247edaa2-58d1-43de-9d33-9753bf6f4d30',
                     'draft',
                     new ListItemLocationView('Rue du Lac', 'Savenay'),
-                    new PeriodView($startPeriod2),
+                    new PeriodView($startDate2, null, null, null),
                 ),
                 new RegulationOrderListItemView(
                     'c421193a-5437-431a-9228-db6288d36a16',

--- a/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
@@ -19,7 +19,9 @@ final class GetRegulationsQueryHandlerTest extends TestCase
     public function testGetAll(): void
     {
         $startDate1 = new \DateTime('2022-12-07');
+        $startTime1 = new \DateTime('22:00');
         $endDate1 = new \DateTime('2022-12-17');
+        $endTime1 = new \DateTime('06:00');
         $startDate2 = new \DateTime('2022-12-10');
         $organization = $this->createMock(Organization::class);
 
@@ -27,9 +29,9 @@ final class GetRegulationsQueryHandlerTest extends TestCase
         $regulationOrder1 = [
             'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
             'startDate' => $startDate1,
-            'startTime' => null,
+            'startTime' => $startTime1,
             'endDate' => $endDate1,
-            'endTime' => null,
+            'endTime' => $endTime1,
             'status' => 'draft',
             'city' => 'Savenay',
             'roadName' => 'Rue de Prince Bois',
@@ -76,7 +78,7 @@ final class GetRegulationsQueryHandlerTest extends TestCase
                     '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
                     'draft',
                     new ListItemLocationView('Rue de Prince Bois', 'Savenay'),
-                    new PeriodView($startDate1, null, $endDate1, null),
+                    new PeriodView($startDate1, $startTime1, $endDate1, $endTime1),
                 ),
                 new RegulationOrderListItemView(
                     '247edaa2-58d1-43de-9d33-9753bf6f4d30',

--- a/tests/Unit/Domain/Condition/Period/OverallPeriodTest.php
+++ b/tests/Unit/Domain/Condition/Period/OverallPeriodTest.php
@@ -16,13 +16,15 @@ final class OverallPeriodTest extends TestCase
         $regulationCondition = $this->createMock(RegulationCondition::class);
         $validPeriod = $this->createMock(Period::class);
         $exceptionPeriod = $this->createMock(Period::class);
-        $start = new \DateTimeImmutable('2022-11-24');
-        $end = new \DateTimeImmutable('2022-11-26');
+        $startDate = new \DateTimeImmutable('2022-11-24');
+        $startTime = new \DateTimeImmutable('08:00:00');
+        $endDate = new \DateTimeImmutable('2022-11-26');
         $overallPeriod = new OverallPeriod(
             '9f3cbc01-8dbe-4306-9912-91c8d88e194f',
             $regulationCondition,
-            $start,
-            $end,
+            startDate: $startDate,
+            startTime: $startTime,
+            endDate: $endDate,
         );
         $overallPeriod->addValidPeriod($validPeriod);
         $overallPeriod->addValidPeriod($validPeriod); // Test deduplication
@@ -30,8 +32,10 @@ final class OverallPeriodTest extends TestCase
         $overallPeriod->addExceptionPeriod($exceptionPeriod); // Test deduplication
 
         $this->assertSame('9f3cbc01-8dbe-4306-9912-91c8d88e194f', $overallPeriod->getUuid());
-        $this->assertSame($start, $overallPeriod->getStartPeriod());
-        $this->assertSame($end, $overallPeriod->getEndPeriod());
+        $this->assertSame($startDate, $overallPeriod->getStartDate());
+        $this->assertSame($startTime, $overallPeriod->getStartTime());
+        $this->assertSame($endDate, $overallPeriod->getEndDate());
+        $this->assertSame(null, $overallPeriod->getEndTime());
         $this->assertSame($regulationCondition, $overallPeriod->getRegulationCondition());
         $this->assertSame([$validPeriod], $overallPeriod->getValidPeriods());
         $this->assertSame([$exceptionPeriod], $overallPeriod->getExceptionPeriods());
@@ -49,13 +53,17 @@ final class OverallPeriodTest extends TestCase
             $end,
         );
 
-        $start2 = new \DateTimeImmutable('2022-11-24');
-        $end2 = new \DateTimeImmutable('2022-11-26');
+        $startDate2 = new \DateTimeImmutable('2022-11-24');
+        $startTime2 = new \DateTimeImmutable('08:00:00');
+        $endDate2 = new \DateTimeImmutable('2022-11-26');
+        $endTime2 = new \DateTimeImmutable('16:00:00');
 
-        $overallPeriod->update($start2, $end2);
+        $overallPeriod->update($startDate2, $startTime2, $endDate2, $endTime2);
 
         $this->assertSame('9f3cbc01-8dbe-4306-9912-91c8d88e194f', $overallPeriod->getUuid());
-        $this->assertSame($start2, $overallPeriod->getStartPeriod());
-        $this->assertSame($end2, $overallPeriod->getEndPeriod());
+        $this->assertSame($startDate2, $overallPeriod->getStartDate());
+        $this->assertSame($startTime2, $overallPeriod->getStartTime());
+        $this->assertSame($endDate2, $overallPeriod->getEndDate());
+        $this->assertSame($endTime2, $overallPeriod->getEndTime());
     }
 }

--- a/tests/Unit/Infrastructure/Symfony/DependencyInjectionTest.php
+++ b/tests/Unit/Infrastructure/Symfony/DependencyInjectionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\Unit\Infrastructure\Symfony;
+
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class DependencyInjectionTest extends KernelTestCase
+{
+    public function testTimezoneParameters(): void
+    {
+        $this->assertSame('UTC', $this->getContainer()->getParameter('server_timezone'));
+        $this->assertSame('Europe/Paris', $this->getContainer()->getParameter('client_timezone'));
+    }
+}

--- a/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
+++ b/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\Unit\Infrastructure\Symfony\Command;
+
+use App\Infrastructure\Twig\AppExtension;
+use PHPUnit\Framework\TestCase;
+
+class AppExtensionTest extends TestCase
+{
+    private AppExtension $extension;
+
+    protected function setUp(): void
+    {
+        $this->extension = new AppExtension();
+    }
+
+    public function testGetFunctions(): void
+    {
+        $this->assertCount(2, $this->extension->getFunctions());
+    }
+
+    public function testFormatDateTimeDateOnly(): void
+    {
+        $this->assertSame('06/01/2023', $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06')));
+        // Time in $date is ignored
+        $this->assertSame('06/01/2023', $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06T08:30:00+00:00')));
+    }
+
+    public function testFormatDateTimeWithTime(): void
+    {
+        $this->assertSame(
+            '06/01/2023 à 09h30',
+            $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06'), new \DateTimeImmutable('08:30:00'))
+        );
+        // Time in $date is ignored
+        $this->assertSame(
+            '06/01/2023 à 11h30',
+            $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06T08:30:00+00:00'), new \DateTimeImmutable('10:30:00'))
+        );
+    }
+
+    private function provideIsFuture(): array
+    {
+        return [
+            // Day after
+            [
+                'date' => new \DateTimeImmutable('2023-01-07'),
+                'time' => null,
+                'now' => new \DateTimeImmutable('2023-01-06 10:30:00'),
+                'result' => true,
+            ],
+            [
+                'date' => new \DateTimeImmutable('2023-01-07'),
+                'time' => new \DateTimeImmutable('09:00:00'),
+                'now' => new \DateTimeImmutable('2023-01-06 10:30:00 '),
+                'result' => true,
+            ],
+            [
+                'date' => new \DateTimeImmutable('2023-01-07'),
+                'time' => new \DateTimeImmutable('00:00:01'),
+                'now' => new \DateTimeImmutable('2023-01-06'),
+                'result' => true,
+            ],
+            // Day before
+            [
+                'date' => new \DateTimeImmutable('2023-01-05'),
+                'time' => null,
+                'now' => new \DateTimeImmutable('2023-01-06 10:30:00'),
+                'result' => false,
+            ],
+            [
+                'date' => new \DateTimeImmutable('2023-01-05'),
+                'time' => new \DateTimeImmutable('23:59:59'),
+                'now' => new \DateTimeImmutable('2023-01-06'),
+                'result' => false,
+            ],
+            // Same day
+            [
+                'date' => new \DateTimeImmutable('2023-01-06'),
+                'time' => new \DateTimeImmutable('10:29:59'),
+                'now' => new \DateTimeImmutable('2023-01-06 10:30:00'),
+                'result' => false,
+            ],
+            [
+                'date' => new \DateTimeImmutable('2023-01-06'),
+                'time' => new \DateTimeImmutable('10:30:00'),
+                'now' => new \DateTimeImmutable('2023-01-06 10:30:00'),
+                'result' => false,
+            ],
+            [
+                'date' => new \DateTimeImmutable('2023-01-06'),
+                'time' => new \DateTimeImmutable('10:30:01'),
+                'now' => new \DateTimeImmutable('2023-01-06 10:30:00'),
+                'result' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideIsFuture
+     */
+    public function testIsFuture($date, $time, $now, $result): void
+    {
+        $this->assertSame($result, $this->extension->isFuture($date, $time, $now));
+    }
+}

--- a/tests/Unit/Infrastructure/Validation/IsValidSaveRegulationStep3CommandValidatorTest.php
+++ b/tests/Unit/Infrastructure/Validation/IsValidSaveRegulationStep3CommandValidatorTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\Unit\Infrastructure\Validator;
+
+use App\Application\Regulation\Command\Steps\SaveRegulationStep3Command;
+use App\Domain\Regulation\RegulationOrderRecord;
+use App\Infrastructure\Validator\SaveRegulationStep3CommandConstraint;
+use App\Infrastructure\Validator\SaveRegulationStep3CommandConstraintValidator;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class IsValidSaveRegulationStep3CommandValidatorTest extends ConstraintValidatorTestCase
+{
+    private $constraintObj;
+    private $regulationOrderRecord;
+
+    protected function setUp(): void
+    {
+        $this->defaultTimezone = 'UTC';
+        parent::setUp();
+        $this->constraintObj = new SaveRegulationStep3CommandConstraint();
+        $this->regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
+    }
+
+    protected function createValidator(): ConstraintValidatorInterface
+    {
+        return new SaveRegulationStep3CommandConstraintValidator(clientTimezone: 'Europe/Paris');
+    }
+
+    public function testUnexpectedValue(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->validator->validate('not a command instance', $this->constraintObj);
+    }
+
+    public function provideValidCases(): array
+    {
+        return [
+            [
+                // Start date only
+                'startDate' => '2022-12-07',
+                'startTime' => '',
+                'endDate' => '',
+                'endTime' => '',
+            ],
+            [
+                // Start date, and end date in the future
+                'startDate' => '2022-12-07',
+                'startTime' => '',
+                'endDate' => '2022-12-17',
+                'endTime' => '',
+            ],
+            [
+                // Same date, with start time only
+                'startDate' => '2022-12-07',
+                'startTime' => '09:00',
+                'endDate' => '2022-12-07',
+                'endTime' => '',
+            ],
+            [
+                // Same date, with end time only
+                'startDate' => '2022-12-07',
+                'startTime' => '',
+                'endDate' => '2022-12-07',
+                'endTime' => '06:00',
+            ],
+            [
+                // Same date, with end time in the future
+                'startDate' => '2022-12-07',
+                'startTime' => '09:00',
+                'endDate' => '2022-12-07',
+                'endTime' => '10:00',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideValidCases
+     */
+    public function testValid(string $startDate, string $startTime, string $endDate, string $endTime): void
+    {
+        $command = new SaveRegulationStep3Command($this->regulationOrderRecord);
+        $command->startDate = new \DateTimeImmutable($startDate);
+        $command->startTime = $startTime ? new \DateTimeImmutable($startTime) : null;
+        $command->endDate = $endDate ? new \DateTimeImmutable($endDate) : null;
+        $command->endTime = $endTime ? new \DateTimeImmutable($endTime) : null;
+
+        $this->validator->validate($command, $this->constraintObj);
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidEndTimeWithoutEndDate(): void
+    {
+        $command = new SaveRegulationStep3Command($this->regulationOrderRecord);
+        $command->startDate = new \DateTimeImmutable('2022-12-17');
+        $command->endTime = new \DateTimeImmutable('10:30:00');
+
+        $this->validator->validate($command, $this->constraintObj);
+        $this->buildViolation('regulation.step3.error.end_time_without_end_date')
+            ->atPath('property.path.endDate')
+            ->assertRaised();
+    }
+
+    public function testInvalidEndDateBeforeStartDate(): void
+    {
+        $command = new SaveRegulationStep3Command($this->regulationOrderRecord);
+        $command->startDate = new \DateTimeImmutable('2022-12-17');
+        $command->endDate = new \DateTimeImmutable('2022-12-16');
+
+        $this->validator->validate($command, $this->constraintObj);
+        $this->buildViolation('regulation.step3.error.end_date_before_start_date')
+            ->setParameter('{{ compared_value }}', '17/12/2022')
+            ->atPath('property.path.endDate')
+            ->assertRaised();
+    }
+
+    public function testInvalidEndTimeBeforeStartTime(): void
+    {
+        $command = new SaveRegulationStep3Command($this->regulationOrderRecord);
+        $command->startDate = new \DateTimeImmutable('2022-12-17');
+        $command->startTime = new \DateTimeImmutable('10:30:00');
+        $command->endDate = new \DateTimeImmutable('2022-12-17');
+        $command->endTime = new \DateTimeImmutable('09:30:00');
+
+        $this->validator->validate($command, $this->constraintObj);
+        $this->buildViolation('regulation.step3.error.end_time_before_start_time')
+            ->setParameter('{{ compared_value }}', '11h30')
+            ->atPath('property.path.endTime')
+            ->assertRaised();
+    }
+}

--- a/tests/Unit/Infrastructure/Validation/SaveRegulationStep3CommandConstraintValidatorTest.php
+++ b/tests/Unit/Infrastructure/Validation/SaveRegulationStep3CommandConstraintValidatorTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\Validator\ConstraintValidatorInterface;
 use Symfony\Component\Validator\Exception\UnexpectedValueException;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
-class IsValidSaveRegulationStep3CommandValidatorTest extends ConstraintValidatorTestCase
+class SaveRegulationStep3CommandConstraintValidatorTest extends ConstraintValidatorTestCase
 {
     private $constraintObj;
     private $regulationOrderRecord;

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -110,10 +110,6 @@
                 <source>common.form.next</source>
                 <target>Suivant</target>
             </trans-unit>
-            <trans-unit id="common.time">
-                <source>common.time</source>
-                <target>à %time%</target>
-            </trans-unit>
             <trans-unit id="common.date.from">
                 <source>common.date.from</source>
                 <target>du %date%</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -220,7 +220,7 @@
             </trans-unit>
             <trans-unit id="regulation.step3.end_period.help">
                 <source>regulation.step3.end_period.help</source>
-                <target>Laisser vide si la restriction est permanente</target>
+                <target>Laisser vide si la restriction est permanente.</target>
             </trans-unit>
             <trans-unit id="regulation.step4.vehicle_characteristics">
                 <source>regulation.step4.vehicle_characteristics</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -110,6 +110,26 @@
                 <source>common.form.next</source>
                 <target>Suivant</target>
             </trans-unit>
+            <trans-unit id="common.time">
+                <source>common.time</source>
+                <target>à %time%</target>
+            </trans-unit>
+            <trans-unit id="common.date.from">
+                <source>common.date.from</source>
+                <target>du %date%</target>
+            </trans-unit>
+            <trans-unit id="common.date.to">
+                <source>common.date.to</source>
+                <target>au %date%</target>
+            </trans-unit>
+            <trans-unit id="common.date.since">
+                <source>common.date.since</source>
+                <target>depuis le %date%</target>
+            </trans-unit>
+            <trans-unit id="common.date.starting">
+                <source>common.date.starting</source>
+                <target>à partir du %date%</target>
+            </trans-unit>
             <trans-unit id="regulation.list.title">
                 <source>regulation.list.title</source>
                 <target>Réglementations</target>
@@ -333,14 +353,6 @@
                 <source>regulation.period</source>
                 <target>Période</target>
             </trans-unit>
-            <trans-unit id="regulation.period.temporary">
-                <source>regulation.period.temporary</source>
-                <target>du %startDate% au %endDate%</target>
-            </trans-unit>
-            <trans-unit id="regulation.period.permanent.present">
-                <source>regulation.period.permanent.present</source>
-                <target>depuis le %date%</target>
-            </trans-unit>
             <trans-unit id="regulation.present">
                 <source>regulation.present</source>
                 <target>Réglementation en cours</target>
@@ -352,10 +364,6 @@
             <trans-unit id="regulation.future">
                 <source>regulation.future</source>
                 <target>Réglementation à venir</target>
-            </trans-unit>
-            <trans-unit id="regulation.period.permanent.future">
-                <source>regulation.period.permanent.future</source>
-                <target>à partir du %date%</target>
             </trans-unit>
             <trans-unit id="regulation.stepper.steps">
                 <source>regulation.stepper.steps</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -206,21 +206,33 @@
                 <source>regulation.step3.help</source>
                 <target>Pendant quelle période la circulation est-elle réglementée ? Si la restriction est permanente, une date de début suffit.</target>
             </trans-unit>
-            <trans-unit id="regulation.step3.start_period">
-                <source>regulation.step3.start_period</source>
+            <trans-unit id="regulation.step3.start_date">
+                <source>regulation.step3.start_date</source>
                 <target>Date de début</target>
             </trans-unit>
-            <trans-unit id="regulation.step3.start_period.help">
-                <source>regulation.step3.start_period.help</source>
+            <trans-unit id="regulation.step3.start_date.help">
+                <source>regulation.step3.start_date.help</source>
                 <target>Début d'effet de la restriction</target>
             </trans-unit>
-            <trans-unit id="regulation.step3.end_period">
-                <source>regulation.step3.end_period</source>
+            <trans-unit id="regulation.step3.start_time">
+                <source>regulation.step3.start_time</source>
+                <target>Heure de début</target>
+            </trans-unit>
+            <trans-unit id="regulation.step3.start_time.help">
+                <source>regulation.step3.start_time.help</source>
+                <target>Heure d'effet de la restriction</target>
+            </trans-unit>
+            <trans-unit id="regulation.step3.end_date">
+                <source>regulation.step3.end_date</source>
                 <target>Date de fin</target>
             </trans-unit>
-            <trans-unit id="regulation.step3.end_period.help">
-                <source>regulation.step3.end_period.help</source>
+            <trans-unit id="regulation.step3.end_date.help">
+                <source>regulation.step3.end_date.help</source>
                 <target>Laisser vide si la restriction est permanente.</target>
+            </trans-unit>
+            <trans-unit id="regulation.step3.end_time">
+                <source>regulation.step3.end_time</source>
+                <target>Heure de fin</target>
             </trans-unit>
             <trans-unit id="regulation.step4.vehicle_characteristics">
                 <source>regulation.step4.vehicle_characteristics</source>
@@ -323,7 +335,7 @@
             </trans-unit>
             <trans-unit id="regulation.period.temporary">
                 <source>regulation.period.temporary</source>
-                <target>du %startPeriod% au %endPeriod%</target>
+                <target>du %startDate% au %endDate%</target>
             </trans-unit>
             <trans-unit id="regulation.period.permanent.present">
                 <source>regulation.period.permanent.present</source>

--- a/translations/validators.fr.xlf
+++ b/translations/validators.fr.xlf
@@ -18,6 +18,18 @@
                 <source>regulation.detail.regulation_cant_be_published</source>
                 <target><![CDATA[<h3 class="fr-alert__title">]]>La réglementation ne peut pas être publiée. Vérifiez qu'elle a correctement été créée.<![CDATA[</h3>]]></target>
             </trans-unit>
+            <trans-unit id="regulation.step3.error.end_time_without_end_date">
+                <source>regulation.step3.error.end_time_without_end_date</source>
+                <target>Veuillez indiquer une date de fin, ou retirer l'heure de fin.</target>
+            </trans-unit>
+            <trans-unit id="regulation.step3.error.end_date_before_start_date">
+                <source>regulation.step3.error.end_date_before_start_date</source>
+                <target>La date de fin doit être après le {{ compared_value }}.</target>
+            </trans-unit>
+            <trans-unit id="regulation.step3.error.end_time_before_start_time">
+                <source>regulation.step3.error.end_time_before_start_time</source>
+                <target>L'heure de fin doit être après {{ compared_value }}.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Closes #124 

Cette PR ajoute la possibilité de définir une heure de début et/ou de fin

Pour tester : https://dialog-staging-pr127.osc-fr1.scalingo.io/

Il a fallu pour cela séparer les colonnes `startPeriod` et `endPeriod` en deux : `startDate`, `startTime`, `endDate`, `endTime`.

![Screenshot 2023-02-21 at 15-47-22 DiaLog](https://user-images.githubusercontent.com/15911462/220377211-192049f2-d0f3-4d37-b962-44cbbcf39324.png)
