### PR TITLE
Add missing cascades for RegulationCondition children

### DIFF
--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Condition.Location.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Condition.Location.orm.xml
@@ -22,7 +22,7 @@
       </options>
     </field>
     <one-to-one field="regulationCondition" target-entity="App\Domain\Condition\RegulationCondition" inversed-by="location">
-        <join-column name="regulation_condition_uuid" referenced-column-name="uuid" nullable="false"/>
+        <join-column name="regulation_condition_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE"/>
     </one-to-one>
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Condition.Period.OverallPeriod.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Condition.Period.OverallPeriod.orm.xml
@@ -9,7 +9,7 @@
     <one-to-many field="validPeriods" target-entity="App\Domain\Condition\Period\Period" mapped-by="overallValidPeriod"/>
     <one-to-many field="exceptionPeriods" target-entity="App\Domain\Condition\Period\Period" mapped-by="overallExceptionPeriod"/>
     <one-to-one field="regulationCondition" target-entity="App\Domain\Condition\RegulationCondition" inversed-by="overallPeriod">
-        <join-column name="regulation_condition_uuid" referenced-column-name="uuid" nullable="false"/>
+        <join-column name="regulation_condition_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE"/>
     </one-to-one>
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Condition.VehicleCharacteristics.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Condition.VehicleCharacteristics.orm.xml
@@ -28,7 +28,7 @@
         </options>
     </field>
     <one-to-one field="regulationCondition" target-entity="App\Domain\Condition\RegulationCondition" inversed-by="vehicleCharacteristics">
-        <join-column name="regulation_condition_uuid" referenced-column-name="uuid" nullable="false"/>
+        <join-column name="regulation_condition_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE" />
     </one-to-one>
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230214084610.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230214084610.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230214084610 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add ON DELETE CASCADE to FKs between regulation_condition and location, overallPeriod and vehicle_characteristics';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE location DROP CONSTRAINT FK_5E9E89CB9F073263');
+        $this->addSql('ALTER TABLE location ADD CONSTRAINT FK_5E9E89CB9F073263 FOREIGN KEY (regulation_condition_uuid) REFERENCES regulation_condition (uuid) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE overall_period DROP CONSTRAINT FK_A58D9F529F073263');
+        $this->addSql('ALTER TABLE overall_period ADD CONSTRAINT FK_A58D9F529F073263 FOREIGN KEY (regulation_condition_uuid) REFERENCES regulation_condition (uuid) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE vehicle_characteristics DROP CONSTRAINT FK_54F8F40A9F073263');
+        $this->addSql('ALTER TABLE vehicle_characteristics ADD CONSTRAINT FK_54F8F40A9F073263 FOREIGN KEY (regulation_condition_uuid) REFERENCES regulation_condition (uuid) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('CREATE SCHEMA public');
+        $this->addSql('ALTER TABLE overall_period DROP CONSTRAINT fk_a58d9f529f073263');
+        $this->addSql('ALTER TABLE overall_period ADD CONSTRAINT fk_a58d9f529f073263 FOREIGN KEY (regulation_condition_uuid) REFERENCES regulation_condition (uuid) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE vehicle_characteristics DROP CONSTRAINT fk_54f8f40a9f073263');
+        $this->addSql('ALTER TABLE vehicle_characteristics ADD CONSTRAINT fk_54f8f40a9f073263 FOREIGN KEY (regulation_condition_uuid) REFERENCES regulation_condition (uuid) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE location DROP CONSTRAINT fk_5e9e89cb9f073263');
+        $this->addSql('ALTER TABLE location ADD CONSTRAINT fk_5e9e89cb9f073263 FOREIGN KEY (regulation_condition_uuid) REFERENCES regulation_condition (uuid) NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+}


### PR DESCRIPTION
* Prérequis à #142 
* Suite à https://github.com/MTES-MCT/dialog/pull/142#discussion_r1100265166

Cette PR fait en sorte que OverallPeriod, Location et VehicleCharacteristics sont supprimés quand leur RegulationCondition parente est supprimée.
