### PR TITLE
Try symfony/security-bundle patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "prefer-stable": true,
     "repositories": [
         {
-            "type": "git",
-            "url": "git@github.com:MatTheCat/symfony.git"
+            "type": "vcs",
+            "url": "https://github.com/MatTheCat/symfony.git"
         }
     ],
     "require": {
@@ -28,7 +28,7 @@
         "symfony/messenger": "6.2.*",
         "symfony/proxy-manager-bridge": "6.2.*",
         "symfony/runtime": "6.2.*",
-        "symfony/security-bundle": "dev-ticket_49194 as 6.2.5",
+        "symfony/security-bundle": "dev-ticket_49194#691609c3b3f90aa765282a776487bf2de3c3a456",
         "symfony/translation": "6.2.*",
         "symfony/twig-bundle": "6.2.*",
         "symfony/uid": "6.2.*",

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,12 @@
     "type": "project",
     "minimum-stability": "stable",
     "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "git",
+            "url": "git@github.com:MatTheCat/symfony.git"
+        }
+    ],
     "require": {
         "php": ">=8.1",
         "ext-ctype": "*",
@@ -22,7 +28,7 @@
         "symfony/messenger": "6.2.*",
         "symfony/proxy-manager-bridge": "6.2.*",
         "symfony/runtime": "6.2.*",
-        "symfony/security-bundle": "6.2.*",
+        "symfony/security-bundle": "dev-ticket_49194 as 6.2.5",
         "symfony/translation": "6.2.*",
         "symfony/twig-bundle": "6.2.*",
         "symfony/uid": "6.2.*",

--- a/composer.lock
+++ b/composer.lock
@@ -6066,13 +6066,13 @@
             "version": "v6.2.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/security-bundle.git",
-                "reference": "2f7f0b79b2acb6f497e8a8f24ff86a5d7e36170f"
+                "url": "https://github.com/MatTheCat/symfony.git",
+                "reference": "691609c3b3f90aa765282a776487bf2de3c3a456"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-bundle/zipball/2f7f0b79b2acb6f497e8a8f24ff86a5d7e36170f",
-                "reference": "2f7f0b79b2acb6f497e8a8f24ff86a5d7e36170f",
+                "url": "https://api.github.com/repos/MatTheCat/symfony/zipball/691609c3b3f90aa765282a776487bf2de3c3a456",
+                "reference": "691609c3b3f90aa765282a776487bf2de3c3a456",
                 "shasum": ""
             },
             "require": {
@@ -6328,13 +6328,13 @@
             "version": "v6.2.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/security-http.git",
-                "reference": "5c8f064e34f3a320ab02874bdc4591197ba05b20"
+                "url": "https://github.com/MatTheCat/symfony.git",
+                "reference": "691609c3b3f90aa765282a776487bf2de3c3a456"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/security-http/zipball/5c8f064e34f3a320ab02874bdc4591197ba05b20",
-                "reference": "5c8f064e34f3a320ab02874bdc4591197ba05b20",
+                "url": "https://api.github.com/repos/MatTheCat/symfony/zipball/691609c3b3f90aa765282a776487bf2de3c3a456",
+                "reference": "691609c3b3f90aa765282a776487bf2de3c3a456",
                 "shasum": ""
             },
             "require": {


### PR DESCRIPTION
* Refs #128 

On n'avait pas pu mettre à jour `symfony/security-bundle` vers 6.2.6 car ça empêchait le CSRF de fonctionner.

C'est apparemment un bug dans Symfony et un patch est proposé : https://github.com/symfony/symfony/pull/49319

J'ouvre cette PR pour déployer sur Scalingo afin qu'on puisse tester "en live" et faire un retour sur la PR du patch