### PR TITLE
Fix CASCADE on RegulationCondition

### DIFF
--- a/src/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandler.php
+++ b/src/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandler.php
@@ -26,23 +26,25 @@ final class SaveRegulationStep1CommandHandler
 
     public function __invoke(SaveRegulationStep1Command $command): RegulationOrderRecord
     {
-        // If submitting step 1 for the first time, we create the regulationCondition, regulationOrder and regulationOrderRecord
+        // If submitting step 1 for the first time, we create the regulationOrder, regulationCondition and regulationOrderRecord
         if (!$command->regulationOrderRecord instanceof RegulationOrderRecord) {
-            $regulationCondition = $this->regulationConditionRepository->save(
-                new RegulationCondition(
-                    uuid: $this->idFactory->make(),
-                    negate: false,
-                ),
-            );
-
             $regulationOrder = $this->regulationOrderRepository->save(
                 new RegulationOrder(
                     uuid: $this->idFactory->make(),
                     issuingAuthority: $command->issuingAuthority,
                     description: $command->description,
-                    regulationCondition: $regulationCondition,
                 ),
             );
+
+            $regulationCondition = $this->regulationConditionRepository->save(
+                new RegulationCondition(
+                    uuid: $this->idFactory->make(),
+                    negate: false,
+                    regulationOrder: $regulationOrder,
+                ),
+            );
+
+            $regulationOrder->setRegulationCondition($regulationCondition);
 
             $regulationOrderRecord = $this->regulationOrderRecordRepository->save(
                 new RegulationOrderRecord(

--- a/src/Domain/Condition/RegulationCondition.php
+++ b/src/Domain/Condition/RegulationCondition.php
@@ -9,7 +9,6 @@ use App\Domain\Regulation\RegulationOrder;
 
 class RegulationCondition
 {
-    private ?RegulationOrder $regulationOrder = null;
     private ?VehicleCharacteristics $vehicleCharacteristics = null;
     private ?ConditionSet $conditionSet = null;
     private ?Location $location = null;
@@ -18,6 +17,7 @@ class RegulationCondition
     public function __construct(
         private string $uuid,
         private bool $negate,
+        private RegulationOrder $regulationOrder,
         private ?ConditionSet $parentConditionSet = null,
     ) {
     }
@@ -32,7 +32,7 @@ class RegulationCondition
         return $this->negate;
     }
 
-    public function getRegulationOrder(): ?RegulationOrder
+    public function getRegulationOrder(): RegulationOrder
     {
         return $this->regulationOrder;
     }

--- a/src/Domain/Regulation/RegulationOrder.php
+++ b/src/Domain/Regulation/RegulationOrder.php
@@ -8,11 +8,12 @@ use App\Domain\Condition\RegulationCondition;
 
 class RegulationOrder
 {
+    private ?RegulationCondition $regulationCondition = null;
+
     public function __construct(
         private string $uuid,
         private string $issuingAuthority,
         private string $description,
-        private RegulationCondition $regulationCondition,
     ) {
     }
 
@@ -31,9 +32,14 @@ class RegulationOrder
         return $this->description;
     }
 
-    public function getRegulationCondition(): RegulationCondition
+    public function getRegulationCondition(): ?RegulationCondition
     {
         return $this->regulationCondition;
+    }
+
+    public function setRegulationCondition(RegulationCondition $regulationCondition): void
+    {
+        $this->regulationCondition = $regulationCondition;
     }
 
     public function update(

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationConditionFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationConditionFixture.php
@@ -6,30 +6,35 @@ namespace App\Infrastructure\Persistence\Doctrine\Fixtures;
 
 use App\Domain\Condition\RegulationCondition;
 use Doctrine\Bundle\FixturesBundle\Fixture;
+use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-final class RegulationConditionFixture extends Fixture
+final class RegulationConditionFixture extends Fixture implements DependentFixtureInterface
 {
     public function load(ObjectManager $manager): void
     {
         $regulationCondition = new RegulationCondition(
             'a7920ccc-ceef-40ef-b62c-8a925ff5e43b',
             false,
+            $this->getReference('regulationOrder'),
         );
 
         $regulationCondition2 = new RegulationCondition(
             '945332d9-d649-44bd-b530-fb574fe849da',
             false,
+            $this->getReference('regulationOrder2'),
         );
 
         $regulationCondition3 = new RegulationCondition(
             'f171375d-343e-4373-8848-39d4370d92f8',
             false,
+            $this->getReference('regulationOrder3'),
         );
 
         $regulationCondition4 = new RegulationCondition(
             '4e43c2d3-788c-404e-b741-e3a501d0ce9f',
             false,
+            $this->getReference('regulationOrder4'),
         );
 
         $manager->persist($regulationCondition);
@@ -42,5 +47,12 @@ final class RegulationConditionFixture extends Fixture
         $this->addReference('regulationCondition2', $regulationCondition2);
         $this->addReference('regulationCondition3', $regulationCondition3);
         $this->addReference('regulationCondition4', $regulationCondition4);
+    }
+
+    public function getDependencies(): array
+    {
+        return [
+            RegulationOrderFixture::class,
+        ];
     }
 }

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
@@ -6,10 +6,9 @@ namespace App\Infrastructure\Persistence\Doctrine\Fixtures;
 
 use App\Domain\Regulation\RegulationOrder;
 use Doctrine\Bundle\FixturesBundle\Fixture;
-use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 
-final class RegulationOrderFixture extends Fixture implements DependentFixtureInterface
+final class RegulationOrderFixture extends Fixture
 {
     public function load(ObjectManager $manager): void
     {
@@ -17,28 +16,24 @@ final class RegulationOrderFixture extends Fixture implements DependentFixtureIn
             uuid: '54eacea0-e1e0-4823-828d-3eae72b76da8',
             issuingAuthority: 'Autorité 1',
             description: 'Description 1',
-            regulationCondition: $this->getReference('regulationCondition1'),
         );
 
         $regulationOrder2 = new RegulationOrder(
             uuid: '2e5eb289-90c8-4c3f-8e7c-2e9e7de8948c',
             issuingAuthority: 'Autorité 2',
             description: 'Description 2',
-            regulationCondition: $this->getReference('regulationCondition2'),
         );
 
         $regulationOrder3 = new RegulationOrder(
             uuid: 'c147cc20-ed02-4bd9-9f6b-91b67df296bd',
             issuingAuthority: 'Description 3',
             description: 'Autorité 3',
-            regulationCondition: $this->getReference('regulationCondition3'),
         );
 
         $regulationOrder4 = new RegulationOrder(
             uuid: 'fd5d2e24-64e4-45c9-a8fc-097c7df796b2',
             issuingAuthority: 'Description 4',
             description: 'Autorité 4',
-            regulationCondition: $this->getReference('regulationCondition4'),
         );
 
         $manager->persist($regulationOrder);
@@ -51,12 +46,5 @@ final class RegulationOrderFixture extends Fixture implements DependentFixtureIn
         $this->addReference('regulationOrder2', $regulationOrder2);
         $this->addReference('regulationOrder3', $regulationOrder3);
         $this->addReference('regulationOrder4', $regulationOrder4);
-    }
-
-    public function getDependencies(): array
-    {
-        return [
-            RegulationConditionFixture::class,
-        ];
     }
 }

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Condition.RegulationCondition.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Condition.RegulationCondition.orm.xml
@@ -9,7 +9,9 @@
     <one-to-one field="location" target-entity="App\Domain\Condition\Location" mapped-by="regulationCondition"/>
     <one-to-one field="overallPeriod" target-entity="App\Domain\Condition\Period\OverallPeriod" mapped-by="regulationCondition"/>
     <one-to-one field="conditionSet" target-entity="App\Domain\Condition\ConditionSet" mapped-by="regulationCondition"/>
-    <one-to-one field="regulationOrder" target-entity="App\Domain\Regulation\RegulationOrder" mapped-by="regulationCondition"/>
+    <one-to-one field="regulationOrder" target-entity="App\Domain\Regulation\RegulationOrder" inversed-by="regulationCondition">
+      <join-column name="regulation_order_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE"/>
+    </one-to-one>
     <many-to-one
       field="parentConditionSet"
       target-entity="App\Domain\Condition\ConditionSet"

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.RegulationOrder.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.RegulationOrder.orm.xml
@@ -6,8 +6,6 @@
     <id name="uuid" type="guid" column="uuid"/>
     <field name="issuingAuthority" type="string" column="issuing_authority" nullable="false"/>
     <field name="description" type="text" column="description" nullable="false"/>
-    <one-to-one field="regulationCondition" target-entity="App\Domain\Condition\RegulationCondition" inversed-by="regulationOrder">
-        <join-column name="regulation_condition_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE"/>
-    </one-to-one>
+    <one-to-one field="regulationCondition" target-entity="App\Domain\Condition\RegulationCondition" mapped-by="regulationOrder" />
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230215135519.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230215135519.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20230215135519 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Swap FK in RegulationOrder <-> RegulationCondition relationship';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Drop old FK constraint
+        $this->addSql('ALTER TABLE regulation_order DROP CONSTRAINT fk_24feed5d9f073263');
+        $this->addSql('DROP INDEX uniq_24feed5d9f073263');
+
+        // Create new FK column
+        $this->addSql('ALTER TABLE regulation_condition ADD regulation_order_uuid UUID');
+        $this->addSql('CREATE UNIQUE INDEX UNIQ_9D8762B7267E0D5E ON regulation_condition (regulation_order_uuid)');
+
+        // Move FK column data
+        $this->addSql('UPDATE regulation_condition SET regulation_order_uuid = (SELECT uuid FROM regulation_order WHERE regulation_condition_uuid = regulation_condition.uuid)');
+        $this->addSql('DELETE FROM regulation_condition WHERE regulation_order_uuid IS NULL');
+
+        // Finalize new FK constraint
+        $this->addSql('ALTER TABLE regulation_condition ALTER regulation_order_uuid SET NOT NULL');
+        $this->addSql('ALTER TABLE regulation_condition ADD CONSTRAINT FK_9D8762B7267E0D5E FOREIGN KEY (regulation_order_uuid) REFERENCES regulation_order (uuid) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        // Drop old FK column
+        $this->addSql('ALTER TABLE regulation_order DROP regulation_condition_uuid');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // Drop new FK constraint
+        $this->addSql('ALTER TABLE regulation_condition DROP CONSTRAINT FK_9D8762B7267E0D5E');
+        $this->addSql('DROP INDEX UNIQ_9D8762B7267E0D5E');
+
+        // Create old FK column
+        $this->addSql('ALTER TABLE regulation_order ADD regulation_condition_uuid UUID');
+        $this->addSql('CREATE UNIQUE INDEX uniq_24feed5d9f073263 ON regulation_order (regulation_condition_uuid)');
+
+        // Move FK column data
+        $this->addSql('UPDATE regulation_order SET regulation_condition_uuid = (SELECT uuid FROM regulation_condition WHERE regulation_order_uuid = regulation_order.uuid)');
+        $this->addSql('DELETE FROM regulation_order WHERE regulation_condition_uuid IS NULL');
+
+        // Finalize old FK constraint
+        $this->addSql('ALTER TABLE regulation_order ALTER regulation_condition_uuid SET NOT NULL');
+        $this->addSql('ALTER TABLE regulation_order ADD CONSTRAINT fk_24feed5d9f073263 FOREIGN KEY (regulation_condition_uuid) REFERENCES regulation_condition (uuid) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+
+        // Drop new FK column
+        $this->addSql('ALTER TABLE regulation_condition DROP regulation_order_uuid');
+    }
+}

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandlerTest.php
@@ -32,20 +32,10 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
             ->expects(self::exactly(3))
             ->method('make')
             ->willReturn(
-                'f331d768-ed8b-496d-81ce-b97008f338d0',
                 'd035fec0-30f3-4134-95b9-d74c68eb53e3',
+                'f331d768-ed8b-496d-81ce-b97008f338d0',
                 'f40f95eb-a7dd-4232-9f03-2db10f04f37f',
             );
-
-        $regulationCondition = new RegulationCondition(
-            uuid: 'f331d768-ed8b-496d-81ce-b97008f338d0',
-            negate: false,
-        );
-        $regulationConditionRepository
-            ->expects(self::once())
-            ->method('save')
-            ->with($this->equalTo($regulationCondition))
-            ->willReturn($regulationCondition);
 
         $createdRegulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
         $createdRegulationOrder = $this->createMock(RegulationOrder::class);
@@ -59,11 +49,25 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
                         uuid: 'd035fec0-30f3-4134-95b9-d74c68eb53e3',
                         issuingAuthority: 'Ville de Paris',
                         description: 'Interdiction de circuler',
-                        regulationCondition: $regulationCondition,
                     )
                 )
             )
             ->willReturn($createdRegulationOrder);
+
+        $regulationCondition = new RegulationCondition(
+            uuid: 'f331d768-ed8b-496d-81ce-b97008f338d0',
+            negate: false,
+            regulationOrder: $createdRegulationOrder,
+        );
+        $regulationConditionRepository
+            ->expects(self::once())
+            ->method('save')
+            ->with($this->equalTo($regulationCondition))
+            ->willReturn($regulationCondition);
+        $createdRegulationOrder
+            ->expects(self::once())
+            ->method('setRegulationCondition')
+            ->with($regulationCondition);
 
         $regulationOrderRecordRepository
             ->expects(self::once())
@@ -88,7 +92,6 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
             $regulationOrderRecordRepository,
             $now,
         );
-
 
         $command = new SaveRegulationStep1Command($organization);
         $command->issuingAuthority = 'Ville de Paris';
@@ -151,7 +154,6 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
             $regulationOrderRecordRepository,
             $now,
         );
-
 
         $command = new SaveRegulationStep1Command($organization, $regulationOrderRecord);
         $command->issuingAuthority = 'Ville de Paris';

--- a/tests/Unit/Domain/Condition/RegulationConditionTest.php
+++ b/tests/Unit/Domain/Condition/RegulationConditionTest.php
@@ -6,23 +6,26 @@ namespace App\Tests\Domain\Condition;
 
 use App\Domain\Condition\ConditionSet;
 use App\Domain\Condition\RegulationCondition;
+use App\Domain\Regulation\RegulationOrder;
 use PHPUnit\Framework\TestCase;
 
 final class RegulationConditionTest extends TestCase
 {
     public function testGetters(): void
     {
+        $regulationOrder = $this->createMock(RegulationOrder::class);
         $parentConditionSet = $this->createMock(ConditionSet::class);
 
         $regulationCondition = new RegulationCondition(
             '9f3cbc01-8dbe-4306-9912-91c8d88e194f',
             false,
+            $regulationOrder,
             $parentConditionSet,
         );
 
         $this->assertSame('9f3cbc01-8dbe-4306-9912-91c8d88e194f', $regulationCondition->getUuid());
         $this->assertSame(false, $regulationCondition->isNegate());
-        $this->assertSame(null, $regulationCondition->getRegulationOrder()); // Automatically set by Doctrine
+        $this->assertSame($regulationOrder, $regulationCondition->getRegulationOrder());
         $this->assertSame($parentConditionSet, $regulationCondition->getParentConditionSet());
         $this->assertSame(null, $regulationCondition->getVehicleCharacteristics()); // Automatically set by Doctrine
         $this->assertSame(null, $regulationCondition->getLocation()); // Automatically set by Doctrine

--- a/tests/Unit/Domain/Regulation/RegulationOrderTest.php
+++ b/tests/Unit/Domain/Regulation/RegulationOrderTest.php
@@ -12,30 +12,24 @@ final class RegulationOrderTest extends TestCase
 {
     public function testGetters(): void
     {
-        $regulationCondition = $this->createMock(RegulationCondition::class);
-
         $regulationOrder = new RegulationOrder(
             uuid: '6598fd41-85cb-42a6-9693-1bc45f4dd392',
             issuingAuthority: 'Commune de Savenay',
             description: 'Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye',
-            regulationCondition: $regulationCondition,
         );
 
         $this->assertSame('6598fd41-85cb-42a6-9693-1bc45f4dd392', $regulationOrder->getUuid());
         $this->assertSame('Commune de Savenay', $regulationOrder->getIssuingAuthority());
         $this->assertSame('Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye', $regulationOrder->getDescription());
-        $this->assertSame($regulationCondition, $regulationOrder->getRegulationCondition());
+        $this->assertSame(null, $regulationOrder->getRegulationCondition()); // Automatically set by Doctrine
     }
 
     public function testUpdate(): void
     {
-        $regulationCondition = $this->createMock(RegulationCondition::class);
-
         $regulationOrder = new RegulationOrder(
             uuid: '6598fd41-85cb-42a6-9693-1bc45f4dd392',
             issuingAuthority: 'Commune de Savenay',
             description: 'Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye',
-            regulationCondition: $regulationCondition,
         );
 
         $regulationOrder->update(


### PR DESCRIPTION
Correctif suite à #150 

La cascade entre RegulationCondition et ses tables "enfant" (Location, etc) se faisait bien. Par contre, celle entre RegulationOrder et RegulationCondition était dans le mauvais sens, de sorte que la suppression d'une réglementation ne supprimait pas sa RegulationCondition.