### PR TITLE
Comply tests PSR-4 compliant

### DIFF
--- a/tests/Mock/APIAdresseMockClientTest.php
+++ b/tests/Mock/APIAdresseMockClientTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Integration\Tests\Mock;
+namespace App\Tests\Mock;
 
 use App\Tests\Mock\APIAdresseMockClient;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

--- a/tests/Unit/Application/Condition/Query/Location/GetLocationByRegulationConditionQueryHandlerTest.php
+++ b/tests/Unit/Application/Condition/Query/Location/GetLocationByRegulationConditionQueryHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Unit\Application\Condition\Query\Period;
+namespace App\Tests\Unit\Application\Condition\Query\Location;
 
 use App\Application\Condition\Query\Location\GetLocationByRegulationConditionQuery;
 use App\Application\Condition\Query\Location\GetLocationByRegulationConditionQueryHandler;

--- a/tests/Unit/Application/Regulation/Command/DeleteRegulationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/DeleteRegulationCommandHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command;
+namespace App\Tests\Unit\Application\Regulation\Command;
 
 use App\Application\Regulation\Command\DeleteRegulationCommandHandler;
 use App\Application\Regulation\Command\DeleteRegulationCommand;

--- a/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command;
+namespace App\Tests\Unit\Application\Regulation\Command;
 
 use App\Application\CommandBusInterface;
 use App\Application\Condition\Query\Location\GetLocationByRegulationConditionQuery;

--- a/tests/Unit/Application/Regulation/Command/PublishRegulationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/PublishRegulationCommandHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command;
+namespace App\Tests\Unit\Application\Regulation\Command;
 
 use App\Application\Regulation\Command\PublishRegulationCommand;
 use App\Application\Regulation\Command\PublishRegulationCommandHandler;
@@ -13,7 +13,7 @@ use App\Domain\Regulation\Repository\RegulationOrderRecordRepositoryInterface;
 use App\Domain\Regulation\Specification\CanRegulationOrderRecordBePublished;
 use PHPUnit\Framework\TestCase;
 
-final class SaveRegulationStep5CommandHandlerTest extends TestCase
+final class PublishRegulationCommandHandlerTest extends TestCase
 {
     private $canRegulationOrderRecordBePublished;
     private $regulationOrderRecordRepository;

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command\Steps;
+namespace App\Tests\Unit\Application\Regulation\Command\Steps;
 
 use App\Application\IdFactoryInterface;
 use App\Application\Regulation\Command\Steps\SaveRegulationStep1Command;

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command\Steps;
+namespace App\Tests\Unit\Application\Regulation\Command\Steps;
 
 use App\Application\Regulation\Command\Steps\SaveRegulationStep1Command;
 use App\Domain\Regulation\RegulationOrder;

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep2CommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep2CommandHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command\Steps;
+namespace App\Tests\Unit\Application\Regulation\Command\Steps;
 
 use App\Application\GeocoderInterface;
 use App\Domain\Geography\GeometryFormatter;
@@ -154,7 +154,7 @@ final class SaveRegulationStep2CommandHandlerTest extends TestCase
                 'POINT(-1.935836 47.347024)',
                 'POINT(-1.930973 47.347917)',
             );
-    
+
         $locationRepository = $this->createMock(LocationRepositoryInterface::class);
         $locationRepository
             ->expects(self::never())
@@ -236,7 +236,7 @@ final class SaveRegulationStep2CommandHandlerTest extends TestCase
         $geometryFormatter = $this->createMock(GeometryFormatter::class);
         $geometryFormatter
             ->expects(self::never())
-            ->method('formatPoint');    
+            ->method('formatPoint');
 
         $locationRepository = $this->createMock(LocationRepositoryInterface::class);
         $locationRepository

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep2CommandTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep2CommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command\Steps;
+namespace App\Tests\Unit\Application\Regulation\Command\Steps;
 
 use App\Application\Regulation\Command\Steps\SaveRegulationStep2Command;
 use App\Domain\Condition\Location;

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep3CommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep3CommandHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command\Steps;
+namespace App\Tests\Unit\Application\Regulation\Command\Steps;
 
 use App\Application\IdFactoryInterface;
 use App\Application\Regulation\Command\Steps\SaveRegulationStep3Command;

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep3CommandTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep3CommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command\Steps;
+namespace App\Tests\Unit\Application\Regulation\Command\Steps;
 
 use App\Application\Regulation\Command\Steps\SaveRegulationStep3Command;
 use App\Domain\Condition\Period\OverallPeriod;

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep4CommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep4CommandHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command\Steps;
+namespace App\Tests\Unit\Application\Regulation\Command\Steps;
 
 use App\Application\IdFactoryInterface;
 use App\Application\Regulation\Command\Steps\SaveRegulationStep4Command;

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep4CommandTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep4CommandTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Command\Steps\Factory;
+namespace App\Tests\Unit\Application\Regulation\Command\Steps;
 
 use App\Application\Regulation\Command\Steps\SaveRegulationStep4Command;
 use App\Domain\Condition\VehicleCharacteristics;

--- a/tests/Unit/Domain/Condition/ConditionSetTest.php
+++ b/tests/Unit/Domain/Condition/ConditionSetTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Condition;
+namespace App\Tests\Unit\Domain\Condition;
 
 use App\Domain\Condition\ConditionSet;
 use App\Domain\Condition\Enum\OperatorEnum;

--- a/tests/Unit/Domain/Condition/LocationTest.php
+++ b/tests/Unit/Domain/Condition/LocationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Condition;
+namespace App\Tests\Unit\Domain\Condition;
 
 use App\Domain\Condition\Location;
 use App\Domain\Condition\RegulationCondition;

--- a/tests/Unit/Domain/Condition/Period/DayWeekMonthTest.php
+++ b/tests/Unit/Domain/Condition/Period/DayWeekMonthTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Condition\Period;
+namespace App\Tests\Unit\Domain\Condition\Period;
 
 use App\Domain\Condition\Period\DayWeekMonth;
 use App\Domain\Condition\Period\Enum\ApplicableDayEnum;

--- a/tests/Unit/Domain/Condition/Period/OverallPeriodTest.php
+++ b/tests/Unit/Domain/Condition/Period/OverallPeriodTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Condition\Period;
+namespace App\Tests\Unit\Domain\Condition\Period;
 
 use App\Domain\Condition\Period\OverallPeriod;
 use App\Domain\Condition\Period\Period;

--- a/tests/Unit/Domain/Condition/Period/PeriodTest.php
+++ b/tests/Unit/Domain/Condition/Period/PeriodTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Condition\Period;
+namespace App\Tests\Unit\Domain\Condition\Period;
 
 use App\Domain\Condition\Period\Period;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Domain/Condition/Period/SpecialDayTest.php
+++ b/tests/Unit/Domain/Condition/Period/SpecialDayTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Condition\Period;
+namespace App\Tests\Unit\Domain\Condition\Period;
 
 use App\Domain\Condition\Period\Enum\SpecialDayTypeEnum;
 use App\Domain\Condition\Period\Period;

--- a/tests/Unit/Domain/Condition/Period/TimePeriodOfDayTest.php
+++ b/tests/Unit/Domain/Condition/Period/TimePeriodOfDayTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Condition\Period;
+namespace App\Tests\Unit\Domain\Condition\Period;
 
 use App\Domain\Condition\Period\Period;
 use App\Domain\Condition\Period\TimePeriodOfDay;

--- a/tests/Unit/Domain/Condition/RegulationConditionTest.php
+++ b/tests/Unit/Domain/Condition/RegulationConditionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Condition;
+namespace App\Tests\Unit\Domain\Condition;
 
 use App\Domain\Condition\ConditionSet;
 use App\Domain\Condition\RegulationCondition;

--- a/tests/Unit/Domain/Condition/VehicleCharacteristicsTest.php
+++ b/tests/Unit/Domain/Condition/VehicleCharacteristicsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Condition;
+namespace App\Tests\Unit\Domain\Condition;
 
 use App\Domain\Condition\Enum\VehicleCritairEnum;
 use App\Domain\Condition\Enum\VehicleTypeEnum;

--- a/tests/Unit/Domain/Geography/CoordinatesTest.php
+++ b/tests/Unit/Domain/Geography/CoordinatesTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Geography;
+namespace App\Tests\Unit\Domain\Geography;
 
 use PHPUnit\Framework\TestCase;
 use App\Domain\Geography\Coordinates;

--- a/tests/Unit/Domain/Geography/GeometryFormatterTest.php
+++ b/tests/Unit/Domain/Geography/GeometryFormatterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Geography;
+namespace App\Tests\Unit\Domain\Geography;
 
 use App\Domain\Geography\GeometryFormatter;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Domain/PaginationTest.php
+++ b/tests/Unit/Domain/PaginationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain;
+namespace App\Tests\Unit\Domain;
 
 use App\Domain\Pagination;
 use PHPUnit\Framework\TestCase;

--- a/tests/Unit/Domain/Regulation/RegulationOrderRecordTest.php
+++ b/tests/Unit/Domain/Regulation/RegulationOrderRecordTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation;
+namespace App\Tests\Unit\Domain\Regulation;
 
 use App\Domain\Regulation\Enum\RegulationOrderRecordStatusEnum;
 use App\Domain\Regulation\RegulationOrder;

--- a/tests/Unit/Domain/Regulation/RegulationOrderTest.php
+++ b/tests/Unit/Domain/Regulation/RegulationOrderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation;
+namespace App\Tests\Unit\Domain\Regulation;
 
 use App\Domain\Condition\RegulationCondition;
 use App\Domain\Regulation\RegulationOrder;

--- a/tests/Unit/Domain/Regulation/Specification/CanOrganizationAccessToRegulationTest.php
+++ b/tests/Unit/Domain/Regulation/Specification/CanOrganizationAccessToRegulationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Specification;
+namespace App\Tests\Unit\Domain\Regulation\Specification;
 
 use App\Domain\Regulation\Specification\CanOrganizationAccessToRegulation;
 use App\Domain\User\Organization;

--- a/tests/Unit/Domain/Regulation/Specification/CanRegulationOrderRecordBePublishedTest.php
+++ b/tests/Unit/Domain/Regulation/Specification/CanRegulationOrderRecordBePublishedTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\Regulation\Specification;
+namespace App\Tests\Unit\Domain\Regulation\Specification;
 
 use App\Application\Condition\Query\Location\GetLocationByRegulationConditionQuery;
 use App\Application\Condition\Query\Period\GetOverallPeriodByRegulationConditionQuery;

--- a/tests/Unit/Domain/User/OrganizationTest.php
+++ b/tests/Unit/Domain/User/OrganizationTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\User;
+namespace App\Tests\Unit\Domain\User;
 
 use PHPUnit\Framework\TestCase;
 use App\Domain\User\Organization;

--- a/tests/Unit/Domain/User/UserTest.php
+++ b/tests/Unit/Domain/User/UserTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Domain\User;
+namespace App\Tests\Unit\Domain\User;
 
 use App\Domain\User\Organization;
 use App\Domain\User\User;

--- a/tests/Unit/Infrastructure/Adapter/APIAdresseGeocoderTest.php
+++ b/tests/Unit/Infrastructure/Adapter/APIAdresseGeocoderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Infrastructure\Adapter;
+namespace App\Tests\Unit\Infrastructure\Adapter;
 
 use App\Application\Exception\GeocodingFailureException;
 use App\Infrastructure\Adapter\APIAdresseGeocoder;

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -44,7 +44,7 @@
             </trans-unit>
             <trans-unit id="common.baseline">
                 <source>common.baseline</source>
-                <target>Intégration de la réglementation poids lourd dans les solutions numériques</target>
+                <target>Intégration de la réglementation poids lourds dans les solutions numériques</target>
             </trans-unit>
             <trans-unit id="common.back_to_home">
                 <source>common.back_to_home</source>


### PR DESCRIPTION
Cette PR permet de fixer les erreurs liées à la compatibilité PSR-4 des tests.

```
Class App\Tests\Infrastructure\Adapter\APIAdresseGeocoderTest located in ./tests/Unit/Infrastructure/Adapter/APIAdresseGeocoderTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Condition\LocationTest located in ./tests/Unit/Domain/Condition/LocationTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Condition\VehicleCharacteristicsTest located in ./tests/Unit/Domain/Condition/VehicleCharacteristicsTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Condition\RegulationConditionTest located in ./tests/Unit/Domain/Condition/RegulationConditionTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Condition\Period\SpecialDayTest located in ./tests/Unit/Domain/Condition/Period/SpecialDayTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Condition\Period\PeriodTest located in ./tests/Unit/Domain/Condition/Period/PeriodTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Condition\Period\OverallPeriodTest located in ./tests/Unit/Domain/Condition/Period/OverallPeriodTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Condition\Period\TimePeriodOfDayTest located in ./tests/Unit/Domain/Condition/Period/TimePeriodOfDayTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Condition\Period\DayWeekMonthTest located in ./tests/Unit/Domain/Condition/Period/DayWeekMonthTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Condition\ConditionSetTest located in ./tests/Unit/Domain/Condition/ConditionSetTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\User\OrganizationTest located in ./tests/Unit/Domain/User/OrganizationTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\User\UserTest located in ./tests/Unit/Domain/User/UserTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\PaginationTest located in ./tests/Unit/Domain/PaginationTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Specification\CanRegulationOrderRecordBePublishedTest located in ./tests/Unit/Domain/Regulation/Specification/CanRegulationOrderRecordBePublishedTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Specification\CanOrganizationAccessToRegulationTest located in ./tests/Unit/Domain/Regulation/Specification/CanOrganizationAccessToRegulationTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\RegulationOrderRecordTest located in ./tests/Unit/Domain/Regulation/RegulationOrderRecordTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\RegulationOrderTest located in ./tests/Unit/Domain/Regulation/RegulationOrderTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Geography\CoordinatesTest located in ./tests/Unit/Domain/Geography/CoordinatesTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Geography\GeometryFormatterTest located in ./tests/Unit/Domain/Geography/GeometryFormatterTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Unit\Application\Condition\Query\Period\GetLocationByRegulationConditionQueryHandlerTest located in ./tests/Unit/Application/Condition/Query/Location/GetLocationByRegulationConditionQueryHandlerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\DeleteRegulationCommandHandlerTest located in ./tests/Unit/Application/Regulation/Command/DeleteRegulationCommandHandlerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\Steps\SaveRegulationStep1CommandTest located in ./tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\Steps\SaveRegulationStep3CommandTest located in ./tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep3CommandTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\Steps\Factory\SaveRegulationStep4CommandTest located in ./tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep4CommandTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\Steps\SaveRegulationStep4CommandHandlerTest located in ./tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep4CommandHandlerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\Steps\SaveRegulationStep2CommandTest located in ./tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep2CommandTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\Steps\SaveRegulationStep1CommandHandlerTest located in ./tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandlerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\Steps\SaveRegulationStep2CommandHandlerTest located in ./tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep2CommandHandlerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\Steps\SaveRegulationStep3CommandHandlerTest located in ./tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep3CommandHandlerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\SaveRegulationStep5CommandHandlerTest located in ./tests/Unit/Application/Regulation/Command/PublishRegulationCommandHandlerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Domain\Regulation\Command\DuplicateRegulationCommandHandlerTest located in ./tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php does not comply with psr-4 autoloading standard. Skipping.
Class App\Tests\Integration\Tests\Mock\APIAdresseMockClientTest located in ./tests/Mock/APIAdresseMockClientTest.php does not comply with psr-4 autoloading standard. Skipping.
```