### PR TITLE
Remove test warnings

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -74,3 +74,6 @@ when@test:
             # See: https://symfony.com/doc/current/service_container/service_decoration.html
             decorates: 'api.adresse.client'
             decoration_inner_name: 'App\Tests\Mock\APIAdresseMockClient::api.adresse.client'
+
+        Psr\Log\NullLogger: ~
+        logger: '@Psr\Log\NullLogger'


### PR DESCRIPTION
Cette PR permet de supprimer les warnings des exceptions non catchés par phpunit.

![image](https://user-images.githubusercontent.com/2683379/221825902-80e79b17-2806-4b28-b359-f2c7ad6a3253.png)
