### PR TITLE
Désactive la vérification de la Content-Security-Policy en développement

### DIFF
--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -37,6 +37,11 @@ nelmio_security:
             img-src: ['self', 'data:']
             block-all-mixed-content: true
 
+when@dev:
+    nelmio_security:
+        csp:
+            hosts: ['example.org'] # Use any value so we don't enforce on localhost.
+
 when@prod:
     nelmio_security:
         # Require HTTPS


### PR DESCRIPTION
Closes #177 

Voir https://github.com/MTES-MCT/dialog/issues/177#issuecomment-1448521500

L'objectif est de faire fonctionner les pages d'erreur (contourner un bug dans Symfony : absence de nonces dans ces pages d'erreur) pour une meilleure expérience de développement.

L'inconvénient est qu'on ne verra pas les éventuels problèmes de CSP avant un déploiement (sur une branche de PR par exemple).

Mais ça résout aussi les problèmes de CSP intempestives liées à Turbo (en partie résolues ici #148) car elles ne se présentaient qu'en local.