### PR TITLE
Custom error pages

### DIFF
--- a/templates/bundles/TwigBundle/Exception/error.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error.html.twig
@@ -1,0 +1,29 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    {{ 'error.status_code.title'|trans }} - {{ parent() }}
+{% endblock %}
+
+{% block body %}
+     <div class="fr-container">
+        <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
+            <div class="fr-py-0 fr-col-12 fr-col-md-6">
+                <h1>{{ 'error.status_code.title'|trans }}</h1>
+                <p class="fr-text--sm fr-mb-3w">{{ 'error.status_code.detail'|trans({ '%status%': status_code }) }}</p>
+                <p class="fr-text--lead fr-mb-3w">{{ 'error.status_code.description'|trans }}</p>
+                <ul class="fr-btns-group fr-btns-group--inline-md">
+                    <li>
+                        <a class="fr-btn" href="{{ path('app_landing') }}">
+                            {{ 'error.home_link'|trans }}
+                        </a>
+                    </li>
+                    <li>
+                        <a href="mailto:dialog@beta.gouv.fr" class="fr-btn fr-btn--secondary" data-testid="contact-link">
+                            {{ 'landing.jumbotron.contact'|trans }}
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error403.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error403.html.twig
@@ -1,0 +1,28 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    {{ 'error.403.title'|trans }} - {{ parent() }}
+{% endblock %}
+
+{% block body %}
+     <div class="fr-container">
+        <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
+            <div class="fr-py-0 fr-col-12 fr-col-md-6">
+                <h1>{{ 'error.403.title'|trans }}</h1>
+                <p class="fr-text--sm fr-mb-3w">{{ 'error.status_code.detail'|trans({'%status%': 403})}}</p>
+                <ul class="fr-btns-group fr-btns-group--inline-md">
+                    <li>
+                        <a class="fr-btn" href="{{ path('app_landing') }}">
+                            {{ 'error.home_link'|trans }}
+                        </a>
+                    </li>
+                    <li>
+                        <a href="mailto:dialog@beta.gouv.fr" class="fr-btn fr-btn--secondary" data-testid="contact-link">
+                            {{ 'landing.jumbotron.contact'|trans }}
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -1,0 +1,34 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}
+    {{ 'error.404.title'|trans }} - {{ parent() }}
+{% endblock %}
+
+{% block body %}
+     <div class="fr-container">
+        <div class="fr-my-7w fr-mt-md-12w fr-mb-md-10w fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-grid-row--center">
+            <div class="fr-py-0 fr-col-12 fr-col-md-6">
+                <h1>{{ 'error.404.title'|trans }}</h1>
+                <p class="fr-text--sm fr-mb-3w">{{ 'error.status_code.detail'|trans({'%status%': 404})}}</p>
+                <p class="fr-text--lead fr-mb-3w">
+                    {{ 'error.404.description'|trans }}
+                </p>
+                <p class="fr-text--sm fr-mb-5w">
+                    {{ 'error.404.more_description'|trans }}
+                </p>
+                <ul class="fr-btns-group fr-btns-group--inline-md">
+                    <li>
+                        <a class="fr-btn" href="{{ path('app_landing') }}">
+                            {{ 'error.home_link'|trans }}
+                        </a>
+                    </li>
+                    <li>
+                        <a href="mailto:dialog@beta.gouv.fr" class="fr-btn fr-btn--secondary" data-testid="contact-link">
+                            {{ 'landing.jumbotron.contact'|trans }}
+                        </a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -560,6 +560,38 @@
                 <source>login.legend</source>
                 <target>Se connecter avec son compte</target>
             </trans-unit>
+            <trans-unit id="error.home_link">
+                <source>error.home_link</source>
+                <target>Page d'accueil</target>
+            </trans-unit>
+            <trans-unit id="error.404.title">
+                <source>error.404.title</source>
+                <target>Page non trouvée</target>
+            </trans-unit>
+            <trans-unit id="error.404.description">
+                <source>error.404.description</source>
+                <target>La page que vous cherchez est introuvable. Excusez-nous pour la gène occasionnée.</target>
+            </trans-unit>
+            <trans-unit id="error.404.more_description">
+                <source>error.404.more_description</source>
+                <target>Si vous avez tapé l'adresse web dans le navigateur, vérifiez qu'elle est correcte. La page n’est peut-être plus disponible. Dans ce cas, pour continuer votre visite vous pouvez consulter notre page d’accueil. Sinon contactez-nous pour que l’on puisse vous rediriger vers la bonne information.</target>
+            </trans-unit>
+            <trans-unit id="error.status_code.title">
+                <source>error.status_code.title</source>
+                <target>Une erreur est survenue</target>
+            </trans-unit>
+            <trans-unit id="error.status_code.description">
+                <source>error.status_code.description</source>
+                <target>La page que vous cherchez est inaccessible. Excusez-nous pour la gène occasionnée.</target>
+            </trans-unit>
+            <trans-unit id="error.status_code.detail">
+                <source>error.status_code.detail</source>
+                <target>Erreur %status%</target>
+            </trans-unit>
+            <trans-unit id="error.403.title">
+                <source>error.403.title</source>
+                <target>Vous n'avez pas les droits requis pour accéder à cette page</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Cette PR permet de customiser les pages d'erreurs et de les rendre compatible avec le DSRF.

Pour tester en local : 
- http://localhost:8000/_error/404
- http://localhost:8000/_error/403
- http://localhost:8000/_error/500

Page 5xx :
![image](https://user-images.githubusercontent.com/2683379/222177599-22e18900-4b68-4626-ba62-bbdfba7ed5f3.png)

Page 404 :
![image](https://user-images.githubusercontent.com/2683379/222177710-4b50fa13-f24b-42eb-b75a-837343397e45.png)

Page 403 :
![image](https://user-images.githubusercontent.com/2683379/222178017-7bc65bee-38d1-4e70-8ca6-37f01c7081d3.png)
