### PR TITLE
Add startDate and endDate to RegulationOrder

### DIFF
--- a/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep1Command.xml
+++ b/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep1Command.xml
@@ -25,6 +25,10 @@
             <constraint name="Type">
                 <option name="type">\DateTimeInterface</option>
             </constraint>
+            <constraint name="GreaterThan">
+                <!-- TODO: ensure error message contains date using $clientTimezone -->
+                <option name="propertyPath">startDate</option>
+            </constraint>
         </property>
     </class>
 </constraint-mapping>

--- a/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep1Command.xml
+++ b/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep1Command.xml
@@ -22,7 +22,9 @@
             </constraint>
         </property>
         <property name="endDate">
-
+            <constraint name="Type">
+                <option name="type">\DateTimeInterface</option>
+            </constraint>
         </property>
     </class>
 </constraint-mapping>

--- a/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep1Command.xml
+++ b/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep1Command.xml
@@ -25,10 +25,7 @@
             <constraint name="Type">
                 <option name="type">\DateTimeInterface</option>
             </constraint>
-            <constraint name="GreaterThan">
-                <!-- TODO: ensure error message contains date using $clientTimezone -->
-                <option name="propertyPath">startDate</option>
-            </constraint>
         </property>
+        <constraint name="App\Infrastructure\Validator\SaveRegulationStep1CommandConstraint" />
     </class>
 </constraint-mapping>

--- a/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep1Command.xml
+++ b/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep1Command.xml
@@ -15,5 +15,14 @@
                 <option name="max">255</option>
             </constraint>
         </property>
+        <property name="startDate">
+            <constraint name="NotBlank" />
+            <constraint name="Type">
+                <option name="type">\DateTimeInterface</option>
+            </constraint>
+        </property>
+        <property name="endDate">
+
+        </property>
     </class>
 </constraint-mapping>

--- a/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
+++ b/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
@@ -68,6 +68,8 @@ final class DuplicateRegulationCommandHandler
         $step1Command->description = $this->translator->trans('regulation.description.copy', [
             '%description%' => $originalRegulationOrder->getDescription(),
         ]);
+        $step1Command->startDate = $originalRegulationOrder->getStartDate();
+        $step1Command->endDate = $originalRegulationOrder->getEndDate();
 
         return $this->commandBus->handle($step1Command);
     }

--- a/src/Application/Regulation/Command/Steps/SaveRegulationStep1Command.php
+++ b/src/Application/Regulation/Command/Steps/SaveRegulationStep1Command.php
@@ -12,6 +12,8 @@ final class SaveRegulationStep1Command implements CommandInterface
 {
     public ?string $issuingAuthority;
     public ?string $description;
+    public ?\DateTimeInterface $startDate;
+    public ?\DateTimeInterface $endDate = null;
 
     public function __construct(
         public readonly Organization $organization,
@@ -28,6 +30,8 @@ final class SaveRegulationStep1Command implements CommandInterface
         $command->issuingAuthority = $regulationOrder?->getIssuingAuthority()
             ?? $organization->getName();
         $command->description = $regulationOrder?->getDescription();
+        $command->startDate = $regulationOrder?->getStartDate();
+        $command->endDate = $regulationOrder?->getEndDate();
 
         return $command;
     }

--- a/src/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandler.php
+++ b/src/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandler.php
@@ -33,6 +33,8 @@ final class SaveRegulationStep1CommandHandler
                     uuid: $this->idFactory->make(),
                     issuingAuthority: $command->issuingAuthority,
                     description: $command->description,
+                    startDate: $command->startDate,
+                    endDate: $command->endDate,
                 ),
             );
 
@@ -62,6 +64,8 @@ final class SaveRegulationStep1CommandHandler
         $command->regulationOrderRecord->getRegulationOrder()->update(
             issuingAuthority: $command->issuingAuthority,
             description: $command->description,
+            startDate: $command->startDate,
+            endDate: $command->endDate,
         );
 
         return $command->regulationOrderRecord;

--- a/src/Domain/Regulation/RegulationOrder.php
+++ b/src/Domain/Regulation/RegulationOrder.php
@@ -14,6 +14,8 @@ class RegulationOrder
         private string $uuid,
         private string $issuingAuthority,
         private string $description,
+        private \DateTimeInterface $startDate,
+        private ?\DateTimeInterface $endDate = null,
     ) {
     }
 
@@ -30,6 +32,17 @@ class RegulationOrder
     public function getDescription(): string
     {
         return $this->description;
+    }
+
+    public function getStartDate(): \DateTimeInterface
+    {
+        return $this->startDate;
+    }
+
+
+    public function getEndDate(): ?\DateTimeInterface
+    {
+        return $this->endDate;
     }
 
     public function getRegulationCondition(): ?RegulationCondition

--- a/src/Domain/Regulation/RegulationOrder.php
+++ b/src/Domain/Regulation/RegulationOrder.php
@@ -39,7 +39,6 @@ class RegulationOrder
         return $this->startDate;
     }
 
-
     public function getEndDate(): ?\DateTimeInterface
     {
         return $this->endDate;

--- a/src/Domain/Regulation/RegulationOrder.php
+++ b/src/Domain/Regulation/RegulationOrder.php
@@ -57,8 +57,12 @@ class RegulationOrder
     public function update(
         string $issuingAuthority,
         string $description,
+        \DateTimeInterface $startDate,
+        ?\DateTimeInterface $endDate = null,
     ): void {
         $this->issuingAuthority = $issuingAuthority;
         $this->description = $description;
+        $this->startDate = $startDate;
+        $this->endDate = $endDate;
     }
 }

--- a/src/Domain/Regulation/RegulationOrder.php
+++ b/src/Domain/Regulation/RegulationOrder.php
@@ -14,7 +14,7 @@ class RegulationOrder
         private string $uuid,
         private string $issuingAuthority,
         private string $description,
-        private \DateTimeInterface $startDate,
+        private ?\DateTimeInterface $startDate,
         private ?\DateTimeInterface $endDate = null,
     ) {
     }
@@ -34,7 +34,7 @@ class RegulationOrder
         return $this->description;
     }
 
-    public function getStartDate(): \DateTimeInterface
+    public function getStartDate(): ?\DateTimeInterface
     {
         return $this->startDate;
     }

--- a/src/Infrastructure/Form/Regulation/Steps/Step1FormType.php
+++ b/src/Infrastructure/Form/Regulation/Steps/Step1FormType.php
@@ -28,6 +28,7 @@ final class Step1FormType extends AbstractType
                     'label' => 'regulation.step1.start_date',
                     'help' => 'regulation.step1.start_date.help',
                     'widget' => 'single_text',
+                    'view_timezone' => $this->clientTimezone,
                 ],
             )
             ->add(

--- a/src/Infrastructure/Form/Regulation/Steps/Step1FormType.php
+++ b/src/Infrastructure/Form/Regulation/Steps/Step1FormType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\Form\Regulation\Steps;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -12,9 +13,34 @@ use Symfony\Component\Form\FormBuilderInterface;
 
 final class Step1FormType extends AbstractType
 {
+    public function __construct(
+        private string $clientTimezone,
+    ) {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
+            ->add(
+                'startDate',
+                DateType::class,
+                options: [
+                    'label' => 'regulation.step1.start_date',
+                    'help' => 'regulation.step1.start_date.help',
+                    'widget' => 'single_text',
+                ],
+            )
+            ->add(
+                'endDate',
+                DateType::class,
+                options: [
+                    'label' => 'regulation.step1.end_date',
+                    'help' => 'regulation.step1.end_date.help',
+                    'widget' => 'single_text',
+                    'view_timezone' => $this->clientTimezone,
+                    'required' => false,
+                ],
+            )
             ->add(
                 'issuingAuthority',
                 TextType::class,

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
@@ -39,7 +39,7 @@ final class RegulationOrderFixture extends Fixture
             uuid: 'fd5d2e24-64e4-45c9-a8fc-097c7df796b2',
             issuingAuthority: 'Description 4',
             description: 'Autorité 4',
-            startDate: new \DateTimeImmutable('2023-03-12')
+            startDate: new \DateTimeImmutable('2023-03-12'),
         );
 
         $manager->persist($regulationOrder);

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
@@ -16,24 +16,30 @@ final class RegulationOrderFixture extends Fixture
             uuid: '54eacea0-e1e0-4823-828d-3eae72b76da8',
             issuingAuthority: 'Autorité 1',
             description: 'Description 1',
+            startDate: new \DateTimeImmutable('2023-03-13'),
+            endDate: new \DateTimeImmutable('2023-03-15'),
         );
 
         $regulationOrder2 = new RegulationOrder(
             uuid: '2e5eb289-90c8-4c3f-8e7c-2e9e7de8948c',
             issuingAuthority: 'Autorité 2',
             description: 'Description 2',
+            startDate: new \DateTimeImmutable('2023-03-10'),
+            endDate: new \DateTimeImmutable('2023-03-20'),
         );
 
         $regulationOrder3 = new RegulationOrder(
             uuid: 'c147cc20-ed02-4bd9-9f6b-91b67df296bd',
             issuingAuthority: 'Description 3',
             description: 'Autorité 3',
+            startDate: new \DateTimeImmutable('2023-03-11'),
         );
 
         $regulationOrder4 = new RegulationOrder(
             uuid: 'fd5d2e24-64e4-45c9-a8fc-097c7df796b2',
             issuingAuthority: 'Description 4',
             description: 'Autorité 4',
+            startDate: new \DateTimeImmutable('2023-03-12')
         );
 
         $manager->persist($regulationOrder);

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
@@ -39,7 +39,7 @@ final class RegulationOrderFixture extends Fixture
             uuid: 'fd5d2e24-64e4-45c9-a8fc-097c7df796b2',
             issuingAuthority: 'Description 4',
             description: 'Autorité 4',
-            startDate: new \DateTimeImmutable('2023-03-12'),
+            startDate: null, // Simulate a regulation order before migration
         );
 
         $manager->persist($regulationOrder);

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.RegulationOrder.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.RegulationOrder.orm.xml
@@ -6,6 +6,8 @@
     <id name="uuid" type="guid" column="uuid"/>
     <field name="issuingAuthority" type="string" column="issuing_authority" nullable="false"/>
     <field name="description" type="text" column="description" nullable="false"/>
+    <field name="startDate" type="datetimetz" column="start_date" nullable="true"/>
+    <field name="endDate" type="datetimetz" column="end_date" nullable="true"/>
     <one-to-one field="regulationCondition" target-entity="App\Domain\Condition\RegulationCondition" mapped-by="regulationOrder" />
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230313132443.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230313132443.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230313132443 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE regulation_order ADD start_date TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL');
+        $this->addSql('ALTER TABLE regulation_order ADD end_date TIMESTAMP(0) WITH TIME ZONE DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE regulation_order DROP start_date');
+        $this->addSql('ALTER TABLE regulation_order DROP end_date');
+    }
+}

--- a/src/Infrastructure/Validator/SaveRegulationStep1CommandConstraint.php
+++ b/src/Infrastructure/Validator/SaveRegulationStep1CommandConstraint.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Validator;
+
+use Symfony\Component\Validator\Constraint;
+
+final class SaveRegulationStep1CommandConstraint extends Constraint
+{
+    public function getTargets(): string
+    {
+        return self::CLASS_CONSTRAINT;
+    }
+}

--- a/src/Infrastructure/Validator/SaveRegulationStep1CommandConstraintValidator.php
+++ b/src/Infrastructure/Validator/SaveRegulationStep1CommandConstraintValidator.php
@@ -26,12 +26,11 @@ final class SaveRegulationStep1CommandConstraintValidator extends ConstraintVali
             $viewStartDate = \DateTimeImmutable::createFromInterface($command->startDate)
                 ->setTimezone(new \DateTimeZone($this->clientTimezone))
                 ->format('d/m/Y');
-    
+
             $this->context->buildViolation('regulation.step1.error.end_date_before_start_date')
                 ->setParameter('{{ compared_value }}', $viewStartDate)
                 ->atPath('endDate')
                 ->addViolation();
         }
-
     }
 }

--- a/src/Infrastructure/Validator/SaveRegulationStep1CommandConstraintValidator.php
+++ b/src/Infrastructure/Validator/SaveRegulationStep1CommandConstraintValidator.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Validator;
+
+use App\Application\Regulation\Command\Steps\SaveRegulationStep1Command;
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+final class SaveRegulationStep1CommandConstraintValidator extends ConstraintValidator
+{
+    public function __construct(
+        private string $clientTimezone,
+    ) {
+    }
+
+    public function validate(mixed $command, Constraint $constraint): void
+    {
+        if (!$command instanceof SaveRegulationStep1Command) {
+            throw new UnexpectedValueException($command, SaveRegulationStep1Command::class);
+        }
+
+        if ($command->endDate !== null && $command->endDate < $command->startDate) {
+            $viewStartDate = \DateTimeImmutable::createFromInterface($command->startDate)
+                ->setTimezone(new \DateTimeZone($this->clientTimezone))
+                ->format('d/m/Y');
+    
+            $this->context->buildViolation('regulation.step1.error.end_date_before_start_date')
+                ->setParameter('{{ compared_value }}', $viewStartDate)
+                ->atPath('endDate')
+                ->addViolation();
+        }
+
+    }
+}

--- a/templates/regulation/steps/step1.html.twig
+++ b/templates/regulation/steps/step1.html.twig
@@ -11,6 +11,8 @@
     {{ form_errors(form) }}
 
     {{ form_row(form.issuingAuthority, {group_class: 'fr-input-group', widget_class: 'fr-input', label_content_attr: {class: 'fr-text--bold'}}) }}
+    {{ form_row(form.startDate, {group_class: 'fr-input-group', widget_class: 'fr-input', label_content_attr: {class: 'fr-text--bold'}}) }}
+    {{ form_row(form.endDate, {group_class: 'fr-input-group', widget_class: 'fr-input', label_content_attr: {class: 'fr-text--bold'}}) }}
 
     <fieldset class="fr-fieldset">
         <legend class="fr-fieldset__legend">

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step1ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step1ControllerTest.php
@@ -71,6 +71,14 @@ final class Step1ControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
+    public function testRegulationOrderWithoutExistingStartDate(): void
+    {
+        $client = $this->login();
+        $client->request('GET', '/regulations/form/fd5d2e24-64e4-45c9-a8fc-097c7df796b2');
+        // TODO: why is this 404
+        $this->assertResponseStatusCodeSame(200);
+    }
+
     public function testBadUuid(): void
     {
         $client = $this->login();

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step1ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step1ControllerTest.php
@@ -71,12 +71,24 @@ final class Step1ControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testRegulationOrderWithoutExistingStartDate(): void
+    public function testEditRegulationOrderWithNoStartDateYet(): void
     {
         $client = $this->login();
-        $client->request('GET', '/regulations/form/fd5d2e24-64e4-45c9-a8fc-097c7df796b2');
-        // TODO: why is this 404
+        $crawler = $client->request('GET', '/regulations/form/867d2be6-0d80-41b5-b1ff-8452b30a95f5');
+
         $this->assertResponseStatusCodeSame(200);
+
+        $saveButton = $crawler->selectButton('Suivant');
+        $form = $saveButton->form();
+        $form["step1_form[issuingAuthority]"] = "Ville de Paris";
+        $form["step1_form[description]"] = "Interdiction de circuler dans Paris";
+        $form["step1_form[startDate]"] = "2023-02-14";
+        $client->submit($form);
+        $this->assertResponseStatusCodeSame(303);
+
+        $client->followRedirect();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertRouteSame('app_regulations_steps_2');
     }
 
     public function testBadUuid(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step1ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step1ControllerTest.php
@@ -60,8 +60,7 @@ final class Step1ControllerTest extends AbstractWebTestCase
         $form["step1_form[endDate]"] = "2023-02-11";
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
-        // TODO: ensure error message contains date using $clientTimezone
-        $this->assertSame("Cette valeur doit être supérieure à 11 févr. 2023 à 23:00.", $crawler->filter('#step1_form_endDate_error')->text());
+        $this->assertSame("La date de fin doit être après le 12/02/2023.", $crawler->filter('#step1_form_endDate_error')->text());
     }
 
     public function testRegulationOrderRecordNotFound(): void

--- a/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
@@ -102,6 +102,9 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
 
     public function testRegulationFullyDuplicated(): void
     {
+        $startDate = new \DateTimeImmutable('2023-03-13');
+        $endDate = new \DateTimeImmutable('2023-03-16');
+
         $this->canOrganizationAccessToRegulation
             ->expects(self::once())
             ->method('isSatisfiedBy')
@@ -117,6 +120,16 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
             ->expects(self::once())
             ->method('getDescription')
             ->willReturn('Description');
+
+        $this->originalRegulationOrder
+            ->expects(self::once())
+            ->method('getStartDate')
+            ->willReturn($startDate);
+
+        $this->originalRegulationOrder
+            ->expects(self::once())
+            ->method('getEndDate')
+            ->willReturn($endDate);
 
         $duplicatedRegulationCondition = $this->createMock(RegulationCondition::class);
         $duplicatedRegulationOrder = $this->createMock(RegulationOrder::class);
@@ -143,6 +156,8 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
         $step1command = new SaveRegulationStep1Command($this->organization);
         $step1command->issuingAuthority = 'Autorité compétente';
         $step1command->description = 'Description (copie)';
+        $step1command->startDate = $startDate;
+        $step1command->endDate = $endDate;
 
         $this->originalRegulationCondition
             ->expects(self::exactly(3))
@@ -288,6 +303,9 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
 
     public function testRegulationPartiallyDuplicated(): void
     {
+        $startDate = new \DateTimeImmutable('2023-03-13');
+        $endDate = new \DateTimeImmutable('2023-03-16');
+
         $this->canOrganizationAccessToRegulation
             ->expects(self::once())
             ->method('isSatisfiedBy')
@@ -303,6 +321,16 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
             ->expects(self::once())
             ->method('getDescription')
             ->willReturn('Description');
+
+        $this->originalRegulationOrder
+            ->expects(self::once())
+            ->method('getStartDate')
+            ->willReturn($startDate);
+
+        $this->originalRegulationOrder
+            ->expects(self::once())
+            ->method('getEndDate')
+            ->willReturn($endDate);
 
         $duplicatedRegulationCondition = $this->createMock(RegulationCondition::class);
         $duplicatedRegulationOrder = $this->createMock(RegulationOrder::class);
@@ -329,6 +357,8 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
         $step1command = new SaveRegulationStep1Command($this->organization);
         $step1command->issuingAuthority = 'Autorité compétente';
         $step1command->description = 'Description (copie)';
+        $step1command->startDate = $startDate;
+        $step1command->endDate = $endDate;
 
         $this->originalRegulationCondition
             ->expects(self::exactly(3))

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandHandlerTest.php
@@ -27,6 +27,8 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
         $regulationOrderRepository = $this->createMock(RegulationOrderRepositoryInterface::class);
         $organization = $this->createMock(Organization::class);
         $now = new \DateTimeImmutable('2022-01-09');
+        $start = new \DateTimeImmutable('2023-03-13');
+        $end = new \DateTimeImmutable('2023-03-15');
 
         $idFactory
             ->expects(self::exactly(3))
@@ -49,6 +51,8 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
                         uuid: 'd035fec0-30f3-4134-95b9-d74c68eb53e3',
                         issuingAuthority: 'Ville de Paris',
                         description: 'Interdiction de circuler',
+                        startDate: $start,
+                        endDate: $end,
                     )
                 )
             )
@@ -96,6 +100,8 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
         $command = new SaveRegulationStep1Command($organization);
         $command->issuingAuthority = 'Ville de Paris';
         $command->description = 'Interdiction de circuler';
+        $command->startDate = $start;
+        $command->endDate = $end;
 
         $result = $handler($command);
 
@@ -110,6 +116,9 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
         $regulationOrderRepository = $this->createMock(RegulationOrderRepositoryInterface::class);
         $now = new \DateTimeImmutable('2022-01-09');
         $organization = $this->createMock(Organization::class);
+
+        $start = new \DateTimeImmutable('2023-03-13');
+        $end = new \DateTimeImmutable('2023-03-15');
 
         $idFactory
             ->expects(self::never())
@@ -139,6 +148,9 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
             ->with(
                 'Ville de Paris',
                 'Interdiction de circuler',
+                new \DateTimeImmutable('2023-03-13'),
+                new \DateTimeImmutable('2023-03-15'),
+
             );
 
         $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
@@ -158,6 +170,8 @@ final class SaveRegulationStep1CommandHandlerTest extends TestCase
         $command = new SaveRegulationStep1Command($organization, $regulationOrderRecord);
         $command->issuingAuthority = 'Ville de Paris';
         $command->description = 'Interdiction de circuler';
+        $command->startDate = $start;
+        $command->endDate = $end;
 
         $result = $handler($command);
 

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep1CommandTest.php
@@ -23,12 +23,16 @@ final class SaveRegulationStep1CommandTest extends TestCase
 
         $this->assertSame('DiaLog', $command->issuingAuthority);
         $this->assertEmpty($command->description);
+        $this->assertEmpty($command->startDate);
+        $this->assertEmpty($command->endDate);
     }
 
     public function testWithRegulationOrderRecord(): void
     {
         $organization = $this->createMock(Organization::class);
         $regulationOrder = $this->createMock(RegulationOrder::class);
+        $start = new \DateTimeImmutable('2023-03-13');
+        $end = new \DateTimeImmutable('2023-03-15');
 
         $regulationOrder
             ->expects(self::once())
@@ -40,6 +44,16 @@ final class SaveRegulationStep1CommandTest extends TestCase
             ->method('getDescription')
             ->willReturn('Description');
 
+        $regulationOrder
+            ->expects(self::once())
+            ->method('getStartDate')
+            ->willReturn($start);
+
+        $regulationOrder
+            ->expects(self::once())
+            ->method('getEndDate')
+            ->willReturn($end);
+
         $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
         $regulationOrderRecord
             ->expects(self::once())
@@ -50,5 +64,7 @@ final class SaveRegulationStep1CommandTest extends TestCase
 
         $this->assertSame($command->issuingAuthority, 'Autorité');
         $this->assertSame($command->description, 'Description');
+        $this->assertSame($command->startDate, $start);
+        $this->assertSame($command->endDate, $end);
     }
 }

--- a/tests/Unit/Domain/Regulation/RegulationOrderTest.php
+++ b/tests/Unit/Domain/Regulation/RegulationOrderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Domain\Regulation;
 
-use App\Domain\Condition\RegulationCondition;
 use App\Domain\Regulation\RegulationOrder;
 use PHPUnit\Framework\TestCase;
 
@@ -12,24 +11,35 @@ final class RegulationOrderTest extends TestCase
 {
     public function testGetters(): void
     {
+        $start = new \DateTime('2023-03-13');
+        $end = new \DateTime('2023-03-15');
+
         $regulationOrder = new RegulationOrder(
             uuid: '6598fd41-85cb-42a6-9693-1bc45f4dd392',
             issuingAuthority: 'Commune de Savenay',
             description: 'Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye',
+            startDate: $start,
+            endDate: $end,
         );
 
         $this->assertSame('6598fd41-85cb-42a6-9693-1bc45f4dd392', $regulationOrder->getUuid());
         $this->assertSame('Commune de Savenay', $regulationOrder->getIssuingAuthority());
         $this->assertSame('Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye', $regulationOrder->getDescription());
+        $this->assertSame($start, $regulationOrder->getStartDate());
+        $this->assertSame($end, $regulationOrder->getEndDate());
         $this->assertSame(null, $regulationOrder->getRegulationCondition()); // Automatically set by Doctrine
     }
 
     public function testUpdate(): void
     {
+        $start = new \DateTime('2023-03-13');
+
         $regulationOrder = new RegulationOrder(
             uuid: '6598fd41-85cb-42a6-9693-1bc45f4dd392',
             issuingAuthority: 'Commune de Savenay',
             description: 'Arrêté temporaire portant réglementation de la circulation sur : Routes Départementales N° 3-93, Voie communautaire de la Colleraye',
+            startDate: $start,
+            endDate: null,
         );
 
         $regulationOrder->update(

--- a/tests/Unit/Domain/Regulation/RegulationOrderTest.php
+++ b/tests/Unit/Domain/Regulation/RegulationOrderTest.php
@@ -11,8 +11,8 @@ final class RegulationOrderTest extends TestCase
 {
     public function testGetters(): void
     {
-        $start = new \DateTime('2023-03-13');
-        $end = new \DateTime('2023-03-15');
+        $start = new \DateTimeImmutable('2023-03-13');
+        $end = new \DateTimeImmutable('2023-03-15');
 
         $regulationOrder = new RegulationOrder(
             uuid: '6598fd41-85cb-42a6-9693-1bc45f4dd392',

--- a/tests/Unit/Domain/Regulation/RegulationOrderTest.php
+++ b/tests/Unit/Domain/Regulation/RegulationOrderTest.php
@@ -33,6 +33,8 @@ final class RegulationOrderTest extends TestCase
     public function testUpdate(): void
     {
         $start = new \DateTime('2023-03-13');
+        $newStart = new \DateTime('2023-03-13');
+        $end = new \DateTimeImmutable('2023-03-15');
 
         $regulationOrder = new RegulationOrder(
             uuid: '6598fd41-85cb-42a6-9693-1bc45f4dd392',
@@ -45,9 +47,13 @@ final class RegulationOrderTest extends TestCase
         $regulationOrder->update(
             issuingAuthority: 'Commune de Paris',
             description: 'Arrêté temporaire',
+            startDate: $newStart,
+            endDate: $end,
         );
 
         $this->assertSame('Commune de Paris', $regulationOrder->getIssuingAuthority());
         $this->assertSame('Arrêté temporaire', $regulationOrder->getDescription());
+        $this->assertSame($newStart, $regulationOrder->getStartDate());
+        $this->assertSame($end, $regulationOrder->getEndDate());
     }
 }

--- a/tests/Unit/Infrastructure/Validation/SaveRegulationStep1CommandConstraintValidatorTest.php
+++ b/tests/Unit/Infrastructure/Validation/SaveRegulationStep1CommandConstraintValidatorTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\Unit\Infrastructure\Validator;
+
+use App\Application\Regulation\Command\Steps\SaveRegulationStep1Command;
+use App\Domain\Regulation\RegulationOrderRecord;
+use App\Domain\User\Organization;
+use App\Infrastructure\Validator\SaveRegulationStep1CommandConstraint;
+use App\Infrastructure\Validator\SaveRegulationStep1CommandConstraintValidator;
+use Symfony\Component\Validator\ConstraintValidatorInterface;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+class SaveRegulationStep1CommandConstraintValidatorTest extends ConstraintValidatorTestCase
+{
+    private $constraintObj;
+    private $organization;
+    private $regulationOrderRecord;
+
+    protected function setUp(): void
+    {
+        $this->defaultTimezone = 'UTC';
+        parent::setUp();
+        $this->constraintObj = new SaveRegulationStep1CommandConstraint();
+        $this->organization = $this->createMock(Organization::class);
+        $this->regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
+    }
+
+    protected function createValidator(): ConstraintValidatorInterface
+    {
+        return new SaveRegulationStep1CommandConstraintValidator(clientTimezone: 'Europe/Paris');
+    }
+
+    public function testUnexpectedValue(): void
+    {
+        $this->expectException(UnexpectedValueException::class);
+        $this->validator->validate('not a command instance', $this->constraintObj);
+    }
+
+    public function provideValidCases(): array
+    {
+        return [
+            [
+                // Start date only
+                'startDate' => '2023-03-12',
+                'endDate' => '',
+            ],
+            [
+                // End date after start date
+                'startDate' => '2023-03-12',
+                'endDate' => '2023-03-13',
+            ],
+            [
+                // Same day
+                'startDate' => '2023-03-12',
+                'endDate' => '2023-03-12',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideValidCases
+     */
+    public function testValid(string $startDate, string $endDate): void
+    {
+        $command = new SaveRegulationStep1Command($this->organization, $this->regulationOrderRecord);
+        $command->startDate = new \DateTimeImmutable($startDate);
+        $command->endDate = $endDate ? new \DateTimeImmutable($endDate) : null;
+
+        $this->validator->validate($command, $this->constraintObj);
+        $this->assertNoViolation();
+    }
+
+    public function testInvalidEndDateBeforeStartDate(): void
+    {
+        $command = new SaveRegulationStep1Command($this->organization, $this->regulationOrderRecord);
+        $command->startDate = new \DateTimeImmutable('2023-03-12');
+        $command->endDate = new \DateTimeImmutable('2023-03-11');
+
+        $this->validator->validate($command, $this->constraintObj);
+        $this->buildViolation('regulation.step1.error.end_date_before_start_date')
+            ->setParameter('{{ compared_value }}', '12/03/2023')
+            ->atPath('property.path.endDate')
+            ->assertRaised();
+    }
+}

--- a/tests/Unit/Infrastructure/Validation/SaveRegulationStep1CommandConstraintValidatorTest.php
+++ b/tests/Unit/Infrastructure/Validation/SaveRegulationStep1CommandConstraintValidatorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Test\Unit\Infrastructure\Validator;
+namespace App\Test\Unit\Infrastructure\Validation;
 
 use App\Application\Regulation\Command\Steps\SaveRegulationStep1Command;
 use App\Domain\Regulation\RegulationOrderRecord;

--- a/tests/Unit/Infrastructure/Validation/SaveRegulationStep3CommandConstraintValidatorTest.php
+++ b/tests/Unit/Infrastructure/Validation/SaveRegulationStep3CommandConstraintValidatorTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Test\Unit\Infrastructure\Validator;
+namespace App\Test\Unit\Infrastructure\Validation;
 
 use App\Application\Regulation\Command\Steps\SaveRegulationStep3Command;
 use App\Domain\Regulation\RegulationOrderRecord;

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -192,7 +192,7 @@
             </trans-unit>
             <trans-unit id="regulation.step1.end_date.help">
                 <source>regulation.step1.end_date.help</source>
-                <target>Laisser vide si l'arrếté est permanent.</target>
+                <target>Laisser vide si l'arrêté est permanent.</target>
             </trans-unit>
             <trans-unit id="regulation.step1.description.help">
                 <source>regulation.step1.description.help</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -178,6 +178,22 @@
                 <source>regulation.step1.description</source>
                 <target>Description</target>
             </trans-unit>
+            <trans-unit id="regulation.step1.start_date">
+                <source>regulation.step1.start_date</source>
+                <target>Date de début</target>
+            </trans-unit>
+            <trans-unit id="regulation.step1.start_date.help">
+                <source>regulation.step1.start_date.help</source>
+                <target>Début d'effet de l'arrêté</target>
+            </trans-unit>
+            <trans-unit id="regulation.step1.end_date">
+                <source>regulation.step1.end_date</source>
+                <target>Date de fin</target>
+            </trans-unit>
+            <trans-unit id="regulation.step1.end_date.help">
+                <source>regulation.step1.end_date.help</source>
+                <target>Laisser vide si l'arrếté est permanent.</target>
+            </trans-unit>
             <trans-unit id="regulation.step1.description.help">
                 <source>regulation.step1.description.help</source>
                 <target>Décrivez brièvement les raisons de la perturbation. (Exemple : "travaux sur la voie")</target>

--- a/translations/validators.fr.xlf
+++ b/translations/validators.fr.xlf
@@ -18,6 +18,10 @@
                 <source>regulation.detail.regulation_cant_be_published</source>
                 <target><![CDATA[<h3 class="fr-alert__title">]]>La réglementation ne peut pas être publiée. Vérifiez qu'elle a correctement été créée.<![CDATA[</h3>]]></target>
             </trans-unit>
+            <trans-unit id="regulation.step1.error.end_date_before_start_date">
+                <source>regulation.step1.error.end_date_before_start_date</source>
+                <target>La date de fin doit être après le {{ compared_value }}.</target>
+            </trans-unit>
             <trans-unit id="regulation.step3.error.end_time_without_end_date">
                 <source>regulation.step3.error.end_time_without_end_date</source>
                 <target>Veuillez indiquer une date de fin, ou retirer l'heure de fin.</target>


### PR DESCRIPTION
- Ref #215

Cette PR :

* Ajoute les colonnes `startDate` et `endDate` à `RegulationOrder`
* Ajoute les champs de formulaire "Date de début" et "Date de fin" correspondants
* Met à jour les tests

Les champs correspondant à l'étape 3 "Période de validité" restent inchangés à ce stade.