### PR TITLE
Fix formatDateTime timezone handling

### DIFF
--- a/src/Infrastructure/Twig/AppExtension.php
+++ b/src/Infrastructure/Twig/AppExtension.php
@@ -6,9 +6,12 @@ namespace App\Infrastructure\Twig;
 
 class AppExtension extends \Twig\Extension\AbstractExtension
 {
+    private \DateTimeZone $clientTimezone;
+
     public function __construct(
-        private string $clientTimezone,
+        string $clientTimezone,
     ) {
+        $this->clientTimezone = new \DateTimeZone($clientTimezone);
     }
 
     public function getFunctions(): array
@@ -24,15 +27,16 @@ class AppExtension extends \Twig\Extension\AbstractExtension
      */
     public function formatDateTime(\DateTimeInterface $date, ?\DateTimeInterface $time = null): string
     {
-        $dateTime = \DateTime::createFromInterface($date);
+        $dateTime = \DateTimeImmutable::createFromInterface($date)->setTimeZone($this->clientTimezone);
         $format = 'd/m/Y';
 
         if ($time) {
-            $dateTime->setTime((int) $time->format('H'), (int) $time->format('i'), (int) $time->format('s'));
+            $time = \DateTimeImmutable::createFromInterface($time)->setTimezone($this->clientTimezone);
+            $dateTime = $dateTime->setTime((int) $time->format('H'), (int) $time->format('i'), (int) $time->format('s'));
             $format = 'd/m/Y à H\hi';
         }
 
-        return $dateTime->setTimezone(new \DateTimeZone($this->clientTimezone))->format($format);
+        return $dateTime->format($format);
     }
 
     public function isFuture(\DateTimeInterface $date, \DateTimeInterface $time = null, \DateTimeInterface $reference = null): bool
@@ -41,10 +45,10 @@ class AppExtension extends \Twig\Extension\AbstractExtension
             $reference = new \DateTimeImmutable('now');
         }
 
-        $dateTime = \DateTime::createFromInterface($date);
+        $dateTime = \DateTimeImmutable::createFromInterface($date);
 
         if ($time) {
-            $dateTime->setTime((int) $time->format('H'), (int) $time->format('i'), (int) $time->format('s'));
+            $dateTime = $dateTime->setTime((int) $time->format('H'), (int) $time->format('i'), (int) $time->format('s'));
         }
 
         return $reference < $dateTime;

--- a/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
+++ b/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
@@ -38,10 +38,9 @@ class AppExtensionTest extends TestCase
             '06/01/2023 à 09h30',
             $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06 UTC'), new \DateTimeImmutable('08:30:00 UTC'))
         );
-        // Time in $date is ignored
         $this->assertSame(
-            '06/01/2023 à 11h30',
-            $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06T08:30:00'), new \DateTimeImmutable('10:30:00'))
+            '07/01/2023 à 11h30',
+            $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06 23:00 UTC'), new \DateTimeImmutable('10:30:00 UTC'))
         );
     }
 


### PR DESCRIPTION
Correctif suite à #127 

Quand une heure est spécifiée, on l'appliquait à la date _avant de convertir en Europe/Paris_. On avait donc 2023-01-06 23:00 UTC + 08:00 UTC qui devenait 2023-01-06 08:00 UTC et in fine "06/01/2023 à 09h00", au lieu de "07/01/2023 à 09h00".

Cette PR corrige ce pb : on convertit d'abord la date en Europe/Paris, les y-m-d sont donc corrects, et _ensuite_ on y applique l'heure d'abord convertie en Europe/Paris aussi.