### PR TITLE
Make AppExtensionTest independent of daylight saving time

### DIFF
--- a/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
+++ b/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
@@ -17,7 +17,7 @@ class AppExtensionTest extends TestCase
     protected function setUp(): void
     {
         $this->setDefaultTimezone('UTC');
-        $this->extension = new AppExtension('Europe/Paris');
+        $this->extension = new AppExtension('Etc/GMT-1'); // Independent of Daylight Saving Time (DST).
     }
 
     public function testGetFunctions(): void


### PR DESCRIPTION
* Motivé par https://github.com/MTES-MCT/dialog/pull/235#issuecomment-1485163228
* Motivé par https://github.com/MTES-MCT/dialog/pull/234#discussion_r1149197558

Le test échoue sur la CI car il utilise le fuseau horaire `Europe/Paris`. Or PHP gère automatiquement l'heure d'été sur les fuseaux horaires renseignés comme ça, ce qui est très bien.

Sauf que pour les tests, on ne peut pas les réécrire chaque fois que l'heure d'été change.

Le correctif est d'utiliser un fuseau horaire "fixe" : GMT-1.