### PR TITLE
Complete turbo drive config

### DIFF
--- a/config/packages/webpack_encore.yaml
+++ b/config/packages/webpack_encore.yaml
@@ -7,12 +7,9 @@ webpack_encore:
     # Set attributes that will be rendered on all script and link tags
     script_attributes:
         defer: true
-        # Uncomment (also under link_attributes) if using Turbo Drive
-        # https://turbo.hotwired.dev/handbook/drive#reloading-when-assets-change
-        # 'data-turbo-track': reload
-    # link_attributes:
-        # Uncomment if using Turbo Drive
-        # 'data-turbo-track': reload
+        'data-turbo-track': reload
+    link_attributes:
+        'data-turbo-track': reload
 
     # If using Encore.enableIntegrityHashes() and need the crossorigin attribute (default: false, or use 'anonymous' or 'use-credentials')
     # crossorigin: 'anonymous'


### PR DESCRIPTION
Cette PR est motivée par le fait que notre config Turbo était incomplète (cf https://symfony.com/bundles/ux-turbo/current/index.html#1-make-sure-your-javascript-is-turbo-ready)