### PR TITLE
Make house numbers optional

### DIFF
--- a/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep2Command.xml
+++ b/config/validator/Application/Regulation/Command/Steps/SaveRegulationStep2Command.xml
@@ -23,13 +23,11 @@
             </constraint>
         </property>
         <property name="fromHouseNumber">
-            <constraint name="NotBlank" />
             <constraint name="Length">
                 <option name="max">8</option>
             </constraint>
        </property>
        <property name="toHouseNumber">
-            <constraint name="NotBlank" />
             <constraint name="Length">
                 <option name="max">8</option>
             </constraint>

--- a/src/Application/Regulation/Command/Steps/SaveRegulationStep2CommandHandler.php
+++ b/src/Application/Regulation/Command/Steps/SaveRegulationStep2CommandHandler.php
@@ -34,8 +34,8 @@ final class SaveRegulationStep2CommandHandler
 
         // If submitting step 2 for the first time, we create the location
         if (!$command->location instanceof Location) {
-            $fromPoint = $this->computePoint($command->postalCode, $command->city, $command->roadName, $command->fromHouseNumber);
-            $toPoint = $this->computePoint($command->postalCode, $command->city, $command->roadName, $command->toHouseNumber);
+            $fromPoint = $command->fromHouseNumber ? $this->computePoint($command->postalCode, $command->city, $command->roadName, $command->fromHouseNumber) : null;
+            $toPoint = $command->toHouseNumber ? $this->computePoint($command->postalCode, $command->city, $command->roadName, $command->toHouseNumber) : null;
 
             $this->locationRepository->save(
                 new Location(
@@ -63,7 +63,7 @@ final class SaveRegulationStep2CommandHandler
         $fromPointNeedsUpdating = $hasRoadChanged || ($command->fromHouseNumber !== $command->location->getFromHouseNumber());
 
         if ($fromPointNeedsUpdating) {
-            $fromPoint = $this->computePoint($command->postalCode, $command->city, $command->roadName, $command->fromHouseNumber);
+            $fromPoint = $command->fromHouseNumber ? $this->computePoint($command->postalCode, $command->city, $command->roadName, $command->fromHouseNumber) : null;
         } else {
             $fromPoint = $command->location->getFromPoint();
         }
@@ -71,7 +71,7 @@ final class SaveRegulationStep2CommandHandler
         $toPointNeedsUpdating = $hasRoadChanged || ($command->toHouseNumber !== $command->location->getToHouseNumber());
 
         if ($toPointNeedsUpdating) {
-            $toPoint = $this->computePoint($command->postalCode, $command->city, $command->roadName, $command->toHouseNumber);
+            $toPoint = $command->toHouseNumber ? $this->computePoint($command->postalCode, $command->city, $command->roadName, $command->toHouseNumber) : null;
         } else {
             $toPoint = $command->location->getToPoint();
         }

--- a/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
@@ -28,9 +28,7 @@ final class GetRegulationOrderRecordSummaryQueryHandler
 
         $hasLocation = $row['postalCode']
             && $row['city']
-            && $row['roadName']
-            && $row['fromHouseNumber']
-            && $row['toHouseNumber'];
+            && $row['roadName'];
 
         return new RegulationOrderRecordSummaryView(
             $row['uuid'],

--- a/src/Application/Regulation/View/DetailLocationView.php
+++ b/src/Application/Regulation/View/DetailLocationView.php
@@ -10,8 +10,8 @@ class DetailLocationView
         public readonly string $postalCode,
         public readonly string $city,
         public readonly string $roadName,
-        public readonly string $fromHouseNumber,
-        public readonly string $toHouseNumber,
+        public readonly ?string $fromHouseNumber,
+        public readonly ?string $toHouseNumber,
     ) {
     }
 }

--- a/src/Domain/Regulation/Location.php
+++ b/src/Domain/Regulation/Location.php
@@ -14,10 +14,10 @@ class Location
         private string $postalCode,
         private string $city,
         private string $roadName,
-        private string $fromHouseNumber,
-        private string $fromPoint,
-        private string $toHouseNumber,
-        private string $toPoint,
+        private ?string $fromHouseNumber,
+        private ?string $fromPoint,
+        private ?string $toHouseNumber,
+        private ?string $toPoint,
     ) {
     }
 
@@ -46,22 +46,22 @@ class Location
         return $this->roadName;
     }
 
-    public function getFromHouseNumber(): string
+    public function getFromHouseNumber(): ?string
     {
         return $this->fromHouseNumber;
     }
 
-    public function getFromPoint(): string
+    public function getFromPoint(): ?string
     {
         return $this->fromPoint;
     }
 
-    public function getToHouseNumber(): string
+    public function getToHouseNumber(): ?string
     {
         return $this->toHouseNumber;
     }
 
-    public function getToPoint(): string
+    public function getToPoint(): ?string
     {
         return $this->toPoint;
     }
@@ -75,10 +75,10 @@ class Location
         string $postalCode,
         string $city,
         string $roadName,
-        string $fromHouseNumber,
-        string $fromPoint,
-        string $toHouseNumber,
-        string $toPoint,
+        ?string $fromHouseNumber,
+        ?string $fromPoint,
+        ?string $toHouseNumber,
+        ?string $toPoint,
     ): void {
         $this->postalCode = $postalCode;
         $this->city = $city;

--- a/src/Infrastructure/Form/Regulation/Steps/Step2FormType.php
+++ b/src/Infrastructure/Form/Regulation/Steps/Step2FormType.php
@@ -41,6 +41,7 @@ final class Step2FormType extends AbstractType
                 'fromHouseNumber',
                 TextType::class,
                 options: [
+                    'required' => false,
                     'label' => 'regulation.step2.from_house_number',
                 ],
             )
@@ -48,6 +49,7 @@ final class Step2FormType extends AbstractType
                 'toHouseNumber',
                 TextType::class,
                 options: [
+                    'required' => false,
                     'label' => 'regulation.step2.to_house_number',
                 ],
             )

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
@@ -7,15 +7,15 @@
     <field name="postalCode" type="string" column="postal_code" nullable="false" length="5" />
     <field name="city" type="string" column="city" nullable="false" length="255" />
     <field name="roadName" type="string" column="road_name" nullable="false" length="60" />
-    <field name="fromHouseNumber" type="string" column="from_house_number" nullable="false" length="8" />
-    <field name="fromPoint" type="geometry" column="from_point" nullable="false">
+    <field name="fromHouseNumber" type="string" column="from_house_number" nullable="true" length="8" />
+    <field name="fromPoint" type="geometry" column="from_point" nullable="true">
       <options>
         <option name="geometry_type">POINT</option>
         <option name="srid">2154</option>
       </options>
     </field>
-    <field name="toHouseNumber" type="string" column="to_house_number" nullable="false" length="8" />
-    <field name="toPoint" type="geometry" column="to_point" nullable="false">
+    <field name="toHouseNumber" type="string" column="to_house_number" nullable="true" length="8" />
+    <field name="toPoint" type="geometry" column="to_point" nullable="true">
       <options>
         <option name="geometry_type">POINT</option>
         <option name="srid">2154</option>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230329092116.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230329092116.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230329092116 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Location house numbers and points become nullable';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE location ALTER from_house_number DROP NOT NULL');
+        $this->addSql('ALTER TABLE location ALTER from_point DROP NOT NULL');
+        $this->addSql('ALTER TABLE location ALTER to_house_number DROP NOT NULL');
+        $this->addSql('ALTER TABLE location ALTER to_point DROP NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE location ALTER from_house_number SET NOT NULL');
+        $this->addSql('ALTER TABLE location ALTER from_point SET NOT NULL');
+        $this->addSql('ALTER TABLE location ALTER to_house_number SET NOT NULL');
+        $this->addSql('ALTER TABLE location ALTER to_point SET NOT NULL');
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230329092116.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20230329092116.php
@@ -27,6 +27,10 @@ final class Version20230329092116 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->addSql('UPDATE location SET from_house_number = \'N/C\' WHERE from_house_number IS NULL');
+        $this->addSql('UPDATE location SET from_point = POINT(0, 0)::geometry WHERE from_point IS NULL');
+        $this->addSql('UPDATE location SET to_house_number = \'N/C\' WHERE to_house_number IS NULL');
+        $this->addSql('UPDATE location SET to_point = POINT(0, 0)::geometry WHERE to_point IS NULL');
         $this->addSql('ALTER TABLE location ALTER from_house_number SET NOT NULL');
         $this->addSql('ALTER TABLE location ALTER from_point SET NOT NULL');
         $this->addSql('ALTER TABLE location ALTER to_house_number SET NOT NULL');

--- a/templates/api/regulations.xml.twig
+++ b/templates/api/regulations.xml.twig
@@ -59,44 +59,60 @@
                     <conditions xsi:type="LocationCondition">
                         <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
                             <loc:secondarySupplementaryDescription>
-                                <loc:locationDescription>
-                                    <com:values>
-                                        <com:value>{{ location.fromHouseNumber }} - {{ location.toHouseNumber }}, {{ location.roadName }}, {{ location.postalCode }} {{ location.city }}</com:value>
-                                    </com:values>
-                                </loc:locationDescription>
-                                <loc:roadInformation>
-                                    <loc:roadName>{{ location.roadName }}</loc:roadName>
-                                </loc:roadInformation>
+                                <loc:namedArea>
+                                    <loc:areaName>
+                                        <com:values>
+                                            <com:value>{{ location.postalCode }} {{ location.city }}</com:value>
+                                        </com:values>
+                                    </loc:areaName>
+                                    <loc:namedAreaType>municipality</loc:namedAreaType>
+                                    <loc:country>FR</loc:country>
+                                </loc:namedArea>
                             </loc:secondarySupplementaryDescription>
                             <loc:linearWithinLinearElement>
                                 <loc:directionRelativeOnLinearSection>both</loc:directionRelativeOnLinearSection>
                                 <loc:heightGradeOfLinearSection>atGrade</loc:heightGradeOfLinearSection>
-                                <loc:linearElement xsi:type="loc:LinearElementByPoints">
-                                    <loc:startPointOfLinearElement>
-                                        <loc:referentIdentifier>start</loc:referentIdentifier>
-                                        <loc:referentName>{{ location.fromHouseNumber }}</loc:referentName>
-                                        <loc:referentType>referenceMarker</loc:referentType>
-                                        <loc:pointCoordinates>
-                                            <loc:latitude>{{ location.fromLatitude }}</loc:latitude>
-                                            <loc:longitude>{{ location.fromLongitude }}</loc:longitude>
-                                        </loc:pointCoordinates>
-                                    </loc:startPointOfLinearElement>
-                                    <loc:endPointOfLinearElement>
-                                        <loc:referentIdentifier>end</loc:referentIdentifier>
-                                        <loc:referentName>{{ location.toHouseNumber }}</loc:referentName>
-                                        <loc:referentType>referenceMarker</loc:referentType>
-                                        <loc:pointCoordinates>
-                                            <loc:latitude>{{ location.toLatitude }}</loc:latitude>
-                                            <loc:longitude>{{ location.toLongitude }}</loc:longitude>
-                                        </loc:pointCoordinates>
-                                    </loc:endPointOfLinearElement>
-                                </loc:linearElement>
-                                <loc:fromPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
-                                    <loc:percentageDistanceAlong>0</loc:percentageDistanceAlong>
-                                </loc:fromPoint>
-                                <loc:toPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
-                                    <loc:percentageDistanceAlong>100</loc:percentageDistanceAlong>
-                                </loc:toPoint>
+                                {% if location.fromHouseNumber or location.toHouseNumber %}
+                                    <loc:linearElement xsi:type="loc:LinearElementByPoints">
+                                        <loc:roadName>
+                                            <com:values>
+                                                <com:value>{{ location.roadName }}</com:value>
+                                            </com:values>
+                                        </loc:roadName>
+                                        {% if location.fromHouseNumber %}
+                                            <loc:startPointOfLinearElement>
+                                                <loc:referentIdentifier>start</loc:referentIdentifier>
+                                                <loc:referentName>{{ location.fromHouseNumber }}</loc:referentName>
+                                                <loc:referentType>referenceMarker</loc:referentType>
+                                                <loc:pointCoordinates>
+                                                    <loc:latitude>{{ location.fromLatitude }}</loc:latitude>
+                                                    <loc:longitude>{{ location.fromLongitude }}</loc:longitude>
+                                                </loc:pointCoordinates>
+                                            </loc:startPointOfLinearElement>
+                                        {% endif %}
+                                        {% if location.toHouseNumber %}
+                                            <loc:endPointOfLinearElement>
+                                                <loc:referentIdentifier>end</loc:referentIdentifier>
+                                                <loc:referentName>{{ location.toHouseNumber }}</loc:referentName>
+                                                <loc:referentType>referenceMarker</loc:referentType>
+                                                <loc:pointCoordinates>
+                                                    <loc:latitude>{{ location.toLatitude }}</loc:latitude>
+                                                    <loc:longitude>{{ location.toLongitude }}</loc:longitude>
+                                                </loc:pointCoordinates>
+                                            </loc:endPointOfLinearElement>
+                                        {% endif %}
+                                    </loc:linearElement>
+                                    <loc:fromPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
+                                        <loc:percentageDistanceAlong>0</loc:percentageDistanceAlong>
+                                    </loc:fromPoint>
+                                    <loc:toPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
+                                        <loc:percentageDistanceAlong>100</loc:percentageDistanceAlong>
+                                    </loc:toPoint>
+                                {% else %}
+                                    <loc:linearElement xsi:type="loc:LinearElement">
+                                        <loc:roadName>{{ location.roadName }}</loc:roadName>
+                                    </loc:linearElement>
+                                {% endif %}
                             </loc:linearWithinLinearElement>
                         </locationByOrder>
                     </conditions>

--- a/templates/regulation/_summary.html.twig
+++ b/templates/regulation/_summary.html.twig
@@ -47,7 +47,13 @@
             {% set loc = regulationOrderRecord.location %}
             <ul class="fr-ml-1w fr-my-0">
                 <li>{{ 'regulation.detail.where.city'|trans({'%postalCode%': loc.postalCode, '%city%': loc.city}) }}</li>
-                <li>{{ 'regulation.detail.where.road_segment'|trans({'%roadName%': loc.roadName, '%from%': loc.fromHouseNumber, '%to%': loc.toHouseNumber}) }}</li>
+                <li>{{ 'regulation.detail.where.road_name'|trans({'%roadName%': loc.roadName}) }}</li>
+                {% if loc.fromHouseNumber %}
+                    <li>{{ 'regulation.detail.where.from_house_number'|trans({'%number%': loc.fromHouseNumber}) }}</li>
+                {% endif %}
+                {% if loc.toHouseNumber %}
+                    <li>{{ 'regulation.detail.where.to_house_number'|trans({'%number%': loc.toHouseNumber}) }}</li>
+                {% endif %}
             </ul>
         {% endif %}
     </div>

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -38,19 +38,25 @@
                     <conditions xsi:type="LocationCondition">
                         <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
                             <loc:secondarySupplementaryDescription>
-                                <loc:locationDescription>
-                                    <com:values>
-                                        <com:value>695 - 253, Avenue de Fonneuve, 82000 Montauban</com:value>
-                                    </com:values>
-                                </loc:locationDescription>
-                                <loc:roadInformation>
-                                    <loc:roadName>Avenue de Fonneuve</loc:roadName>
-                                </loc:roadInformation>
+                                <loc:namedArea>
+                                    <loc:areaName>
+                                        <com:values>
+                                            <com:value>82000 Montauban</com:value>
+                                        </com:values>
+                                    </loc:areaName>
+                                    <loc:namedAreaType>municipality</loc:namedAreaType>
+                                    <loc:country>FR</loc:country>
+                                </loc:namedArea>
                             </loc:secondarySupplementaryDescription>
                             <loc:linearWithinLinearElement>
                                 <loc:directionRelativeOnLinearSection>both</loc:directionRelativeOnLinearSection>
                                 <loc:heightGradeOfLinearSection>atGrade</loc:heightGradeOfLinearSection>
                                 <loc:linearElement xsi:type="loc:LinearElementByPoints">
+                                    <loc:roadName>
+                                        <com:values>
+                                            <com:value>Avenue de Fonneuve</com:value>
+                                        </com:values>
+                                    </loc:roadName>
                                     <loc:startPointOfLinearElement>
                                         <loc:referentIdentifier>start</loc:referentIdentifier>
                                         <loc:referentName>695</loc:referentName>

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -19,7 +19,6 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertMetaTitle("Réglementation - Route du Grand Brossais - DiaLog", $crawler);
         $step1 = $crawler->filter('div.for-what');
         $step2 = $crawler->filter('div.where');
-        $step4 = $crawler->filter('div.vehicles');
 
         // Step 1
         $this->assertSame('Description 1', $step1->filter('li')->eq(0)->text());
@@ -29,7 +28,9 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
 
         // Step 2
         $this->assertSame('Ville : 44260 Savenay', $step2->filter('li')->eq(0)->text());
-        $this->assertSame('Rue : du 15 au 37bis, Route du Grand Brossais', $step2->filter('li')->eq(1)->text());
+        $this->assertSame('Rue : Route du Grand Brossais', $step2->filter('li')->eq(1)->text());
+        $this->assertSame('Numéro de début : 15', $step2->filter('li')->eq(2)->text());
+        $this->assertSame('Numéro de fin : 37bis', $step2->filter('li')->eq(3)->text());
         $this->assertSame('http://localhost/regulations/form/e413a47e-5928-4353-a8b2-8b7dda27f9a5/2', $step2->filter('a')->link()->getUri());
 
         // Status action

--- a/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step2ControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Steps/Step2ControllerTest.php
@@ -23,11 +23,32 @@ final class Step2ControllerTest extends AbstractWebTestCase
         $this->assertSame("Cette valeur ne doit pas être vide.", $crawler->filter('#step2_form_postalCode_error')->text());
         $this->assertSame("Cette valeur ne doit pas être vide.", $crawler->filter('#step2_form_city_error')->text());
         $this->assertSame("Cette valeur ne doit pas être vide.", $crawler->filter('#step2_form_roadName_error')->text());
-        $this->assertSame("Cette valeur ne doit pas être vide.", $crawler->filter('#step2_form_fromHouseNumber_error')->text());
-        $this->assertSame("Cette valeur ne doit pas être vide.", $crawler->filter('#step2_form_toHouseNumber_error')->text());
     }
 
-    public function testAdd(): void
+    public function testAddFullRoad(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/regulations/form/4ce75a1f-82f3-40ee-8f95-48d0f04446aa/2'); // Has no location yet
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSame('Étape 2 sur 4 Localisation', $crawler->filter('h2')->text());
+        $this->assertSame('Étape suivante : Véhicules concernés', $crawler->filter('p.fr-stepper__details')->text());
+        $this->assertMetaTitle("Étape 2 sur 4 - DiaLog", $crawler);
+        $saveButton = $crawler->selectButton('Suivant');
+        $form = $saveButton->form();
+        $form['step2_form[postalCode]'] = '44260';
+        $form['step2_form[city]'] = 'Savenay';
+        $form['step2_form[roadName]'] = 'Route du Grand Brossais';
+
+        $client->submit($form);
+        $this->assertResponseStatusCodeSame(303);
+
+        $crawler = $client->followRedirect();
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertRouteSame('app_regulation_detail');
+    }
+
+    public function testAddRoadSection(): void
     {
         $client = $this->login();
         $crawler = $client->request('GET', '/regulations/form/4ce75a1f-82f3-40ee-8f95-48d0f04446aa/2'); // Has no location yet

--- a/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep2CommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Steps/SaveRegulationStep2CommandHandlerTest.php
@@ -10,7 +10,6 @@ use App\Application\IdFactoryInterface;
 use App\Application\Regulation\Command\Steps\SaveRegulationStep2Command;
 use App\Application\Regulation\Command\Steps\SaveRegulationStep2CommandHandler;
 use App\Domain\Regulation\Location;
-use App\Domain\Condition\Condition;
 use App\Domain\Regulation\Repository\LocationRepositoryInterface;
 use App\Domain\Geography\Coordinates;
 use App\Domain\Regulation\RegulationOrder;
@@ -165,6 +164,55 @@ final class SaveRegulationStep2CommandHandlerTest extends TestCase
         $command->roadName = $this->roadName;
         $command->fromHouseNumber = $this->fromHouseNumber;
         $command->toHouseNumber = $this->toHouseNumber;
+
+        $this->assertEmpty($handler($command));
+    }
+
+    public function testHouseNumbersOptional(): void
+    {
+        $location = $this->createMock(Location::class);
+        $location
+            ->expects(self::once())
+            ->method('update')
+            ->with(
+                $this->postalCode,
+                $this->city,
+                $this->roadName,
+            );
+
+        $idFactory = $this->createMock(IdFactoryInterface::class);
+        $idFactory
+            ->expects(self::never())
+            ->method('make');
+
+        $geocoder = $this->createMock(GeocoderInterface::class);
+        $geocoder
+            ->expects(self::never())
+            ->method('computeCoordinates');
+
+        $geometryFormatter = $this->createMock(GeometryFormatter::class);
+        $geometryFormatter
+            ->expects(self::never())
+            ->method('formatPoint');
+
+        $locationRepository = $this->createMock(LocationRepositoryInterface::class);
+        $locationRepository
+            ->expects(self::never())
+            ->method('save');
+
+        $handler = new SaveRegulationStep2CommandHandler(
+            $idFactory,
+            $locationRepository,
+            $geocoder,
+            $geometryFormatter,
+        );
+
+        $command = new SaveRegulationStep2Command($this->regulationOrderRecord, $location);
+        $command->postalCode = $this->postalCode;
+        $command->city = $this->city;
+        $command->roadName = $this->roadName;
+        $command->fromHouseNumber = null;
+        $command->toHouseNumber = null;
 
         $this->assertEmpty($handler($command));
     }

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandlerTest.php
@@ -14,15 +14,35 @@ use PHPUnit\Framework\TestCase;
 
 final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
 {
-    public function testGetOne(): void
+    public function provideGetOne(): array
     {
-        $location = new DetailLocationView(
-            postalCode: '82000',
-            city: 'Montauban',
-            roadName: 'Avenue de Fonneuve',
-            fromHouseNumber: '695',
-            toHouseNumber: '253',
-        );
+        return [
+            [
+                new DetailLocationView(
+                    postalCode: '82000',
+                    city: 'Montauban',
+                    roadName: 'Avenue de Fonneuve',
+                    fromHouseNumber: '695',
+                    toHouseNumber: '253',
+                ),
+            ],
+            [
+                new DetailLocationView(
+                    postalCode: '82000',
+                    city: 'Montauban',
+                    roadName: 'Avenue de Fonneuve',
+                    fromHouseNumber: null,
+                    toHouseNumber: null,
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetOne
+     */
+    public function testGetOne(DetailLocationView $location): void
+    {
 
         $startDate = new \DateTime('2022-12-07');
         $endDate = new \DateTime('2022-12-17');
@@ -66,7 +86,6 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                     $location->fromHouseNumber,
                     $location->toHouseNumber,
                 ),
-                null,
             ),
             $regulationOrders,
         );
@@ -104,7 +123,6 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'a8439603-40f7-4b1e-8a35-cee9e53b98d4',
                 'draft',
                 'Description 1',
-                null,
                 null,
                 null,
                 null,

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -258,9 +258,17 @@
                 <source>regulation.detail.where.city</source>
                 <target>Ville : %postalCode% %city%</target>
             </trans-unit>
-            <trans-unit id="regulation.detail.where.road_segment">
-                <source>regulation.detail.where.road_segment</source>
-                <target>Rue : du %from% au %to%, %roadName%</target>
+            <trans-unit id="regulation.detail.where.road_name">
+                <source>regulation.detail.where.road_name</source>
+                <target>Rue : %roadName%</target>
+            </trans-unit>
+            <trans-unit id="regulation.detail.where.from_house_number">
+                <source>regulation.detail.where.from_house_number</source>
+                <target>Numéro de début : %number%</target>
+            </trans-unit>
+            <trans-unit id="regulation.detail.where.to_house_number">
+                <source>regulation.detail.where.to_house_number</source>
+                <target>Numéro de fin : %number%</target>
             </trans-unit>
             <trans-unit id="regulation.detail.when">
                 <source>regulation.detail.when</source>


### PR DESCRIPTION
* Closes #240 

## Description

Cette PR rend optionnel les champs "Numéro de début" et "Numéro de fin"

Il a fallu pour cela les rendre nullable en BDD, les rendre optionnels dans le formulaire step 2, et adapter la tuyauterie (commands, command handlers) et le rendu résumé

J'ai aussi simplifié l'affichage dans le résumé. Le cas échéant, "Numéro de début" et "Numéro de fin" ne sont plus combinés dans la "Rue", mais montrés comme des champs à part. On pourra adapter selon le rendu final de la maquette.

## Aperçu

![Screenshot 2023-03-29 at 11-58-32 Étape 2 sur 4 - DiaLog](https://user-images.githubusercontent.com/15911462/228499872-434996bf-6095-4925-9829-1f66214a066a.png) (25 kB) ![Screenshot 2023-03-29 at 11-58-39 Réglementation - Rue de la Concertation - DiaLog](https://user-images.githubusercontent.com/15911462/228499896-5775e810-63b3-41e0-b542-18d03da9c0ff.png) (9 kB)

![Screenshot 2023-03-29 at 11-58-52 Étape 2 sur 4 - DiaLog](https://user-images.githubusercontent.com/15911462/228499959-6c9a1eaa-fd3d-4bf2-ae06-9f9f1add5202.png) (23 kB) ![Screenshot 2023-03-29 at 11-58-46 Réglementation - Rue de la Concertation - DiaLog](https://user-images.githubusercontent.com/15911462/228499990-8bb8461d-2842-4228-8614-e3fe81f0da43.png) (12 kB)


