### PR TITLE
Change login parameters name to improve login security

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -17,6 +17,8 @@ security:
                 login_path: app_login
                 check_path: app_login
                 enable_csrf: true
+                username_parameter: email
+                password_parameter: password
             logout:
                 path: app_logout
     access_control:

--- a/templates/login.html.twig
+++ b/templates/login.html.twig
@@ -22,18 +22,18 @@
                                             <fieldset class="fr-fieldset" id="credentials" aria-labelledby="credentials-message">
                                                 <div class="fr-fieldset__element">
                                                     <div class="fr-input-group">
-                                                        <label class="fr-label" for="username">
+                                                        <label class="fr-label" for="email">
                                                             {{ 'login.email'|trans }}
                                                             <span class="fr-hint-text">{{ 'login.email_format'|trans }}</span>
                                                         </label>
-                                                        <input class="fr-input" type="email" autocomplete="email" id="username" required name="_username" value="{{ last_username }}"/>
+                                                        <input class="fr-input" type="email" autocomplete="email" id="email" required name="email" value="{{ last_username }}"/>
                                                     </div>
                                                 </div>
                                                 <div class="fr-fieldset__element">
                                                     <div class="fr-password">
                                                         <label class="fr-label" for="password">{{ 'login.password'|trans }}</label>
                                                         <div class="fr-input-wrap">
-                                                            <input class="fr-password__input fr-input" aria-required="true" required name="_password" autocomplete="current-password" id="password" type="password"/>
+                                                            <input class="fr-password__input fr-input" aria-required="true" required name="password" autocomplete="current-password" id="password" type="password"/>
                                                         </div>
                                                         <div class="fr-password__checkbox fr-checkbox-group fr-checkbox-group--sm">
                                                             <input aria-label="{{ 'login.display'|trans }}" id="password-show" type="checkbox"/>

--- a/tests/Integration/Infrastructure/Controller/LoginControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/LoginControllerTest.php
@@ -18,8 +18,8 @@ final class LoginControllerTest extends AbstractWebTestCase
         $saveButton = $crawler->selectButton('Se connecter');
         $form = $saveButton->form();
 
-        $form["_username"] = "mathieu.marchois@beta.gouv.fr";
-        $form["_password"] = "password";
+        $form["email"] = "mathieu.marchois@beta.gouv.fr";
+        $form["password"] = "password";
         $client->submit($form);
         $this->assertResponseStatusCodeSame(302);
         $crawler = $client->followRedirect();
@@ -35,8 +35,8 @@ final class LoginControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Se connecter');
         $form = $saveButton->form();
-        $form["_username"] = "mathieu@fairness.coop";
-        $form["_password"] = "password";
+        $form["email"] = "mathieu@fairness.coop";
+        $form["password"] = "password";
 
         $client->submit($form);
         $this->assertResponseStatusCodeSame(302);


### PR DESCRIPTION
Par défaut, Symfony utilise les paramètres `_username` et `_password` dans les formulaires de connexion.
Le fait d'utiliser ces champs donne une indication, à une personne malveillante, que la techno utilisée derrière est Symfony. 
Il est donc recommandé de les renommer avec des champs plus génériques.