### PR TITLE
Add app rate limiter

### DIFF
--- a/.env
+++ b/.env
@@ -31,3 +31,9 @@ API_ADRESSE_BASE_URL=https://api-adresse.data.gouv.fr
 ###> sentry/sentry-symfony ###
 SENTRY_DSN=
 ###< sentry/sentry-symfony ###
+
+###> symfony/lock ###
+# Choose one of the stores below
+# postgresql+advisory://db_user:db_password@localhost/db_name
+LOCK_DSN=flock
+###< symfony/lock ###

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "symfony/form": "6.2.*",
         "symfony/framework-bundle": "6.2.*",
         "symfony/http-client": "6.2.*",
+        "symfony/lock": "6.2.*",
         "symfony/messenger": "6.2.*",
         "symfony/proxy-manager-bridge": "6.2.*",
         "symfony/rate-limiter": "6.2.*",
@@ -34,6 +35,7 @@
     },
     "require-dev": {
         "dama/doctrine-test-bundle": "^7.1",
+        "dg/bypass-finals": "^1.4",
         "doctrine/doctrine-fixtures-bundle": "^3.4",
         "friendsofphp/php-cs-fixer": "^3.13",
         "phpstan/phpstan": "^1.9",
@@ -51,7 +53,8 @@
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "symfony/flex": true,
-            "symfony/runtime": true
+            "symfony/runtime": true,
+            "php-http/discovery": true
         },
         "optimize-autoloader": true,
         "preferred-install": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0b8356e5676b8e3ef15d0929670efff",
+    "content-hash": "c9bb0b5d20d92077b6d99b51d1921259",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -4933,6 +4933,84 @@
             "time": "2023-02-28T13:26:41+00:00"
         },
         {
+            "name": "symfony/lock",
+            "version": "v6.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/lock.git",
+                "reference": "febdeed9473e568ff34bf4350c04760f5357dfe2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/lock/zipball/febdeed9473e568ff34bf4350c04760f5357dfe2",
+                "reference": "febdeed9473e568ff34bf4350c04760f5357dfe2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/log": "^1|^2|^3"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.13",
+                "symfony/cache": "<6.2"
+            },
+            "require-dev": {
+                "doctrine/dbal": "^2.13|^3.0",
+                "predis/predis": "~1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Lock\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jérémy Derussé",
+                    "email": "jeremy@derusse.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Creates and manages locks, a mechanism to provide exclusive access to a shared resource",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "cas",
+                "flock",
+                "locking",
+                "mutex",
+                "redlock",
+                "semaphore"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/lock/tree/v6.2.7"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-02-24T10:42:00+00:00"
+        },
+        {
             "name": "symfony/messenger",
             "version": "v6.2.7",
             "source": {
@@ -8114,6 +8192,59 @@
                 "source": "https://github.com/dmaicher/doctrine-test-bundle/tree/v7.2.1"
             },
             "time": "2023-02-07T10:02:27+00:00"
+        },
+        {
+            "name": "dg/bypass-finals",
+            "version": "v1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dg/bypass-finals.git",
+                "reference": "4c424c3ed359220fce044f35cdf9f48b0089b2ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dg/bypass-finals/zipball/4c424c3ed359220fce044f35cdf9f48b0089b2ca",
+                "reference": "4c424c3ed359220fce044f35cdf9f48b0089b2ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "nette/tester": "^2.3",
+                "phpstan/phpstan": "^0.12"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause",
+                "GPL-2.0",
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "David Grudl",
+                    "homepage": "https://davidgrudl.com"
+                }
+            ],
+            "description": "Removes final keyword from source code on-the-fly and allows mocking of final methods and classes",
+            "keywords": [
+                "finals",
+                "mocking",
+                "phpunit",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/dg/bypass-finals/issues",
+                "source": "https://github.com/dg/bypass-finals/tree/v1.4.1"
+            },
+            "time": "2022-09-13T17:27:26+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/config/packages/lock.yaml
+++ b/config/packages/lock.yaml
@@ -1,0 +1,2 @@
+framework:
+    lock: '%env(LOCK_DSN)%'

--- a/config/packages/rate_limiter.yaml
+++ b/config/packages/rate_limiter.yaml
@@ -1,0 +1,6 @@
+framework:
+    rate_limiter:
+        app:
+            policy: 'sliding_window'
+            limit: 100
+            interval: '5 minutes'

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -9,8 +9,6 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         main:
-            # by default, the feature allows 5 login attempts per minute
-            login_throttling: ~
             lazy: true
             provider: user
             form_login:

--- a/src/Infrastructure/Symfony/EventSubscriber/RateLimiterSubscriber.php
+++ b/src/Infrastructure/Symfony/EventSubscriber/RateLimiterSubscriber.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Symfony\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+class RateLimiterSubscriber implements EventSubscriberInterface
+{
+    public function __construct(
+        private KernelInterface $kernel,
+        private RateLimiterFactory $appLimiter,
+    ) {
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => [
+                ['onKernelRequest', 0],
+            ],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if ($this->kernel->isDebug()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $limiter = $this->appLimiter->create($request->getClientIp());
+
+        if (false === $limiter->consume(1)->isAccepted()) {
+            throw new TooManyRequestsHttpException();
+        }
+    }
+}

--- a/symfony.lock
+++ b/symfony.lock
@@ -176,6 +176,18 @@
             "src/Kernel.php"
         ]
     },
+    "symfony/lock": {
+        "version": "6.2",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "5.2",
+            "ref": "8e937ff2b4735d110af1770f242c1107fdab4c8e"
+        },
+        "files": [
+            "config/packages/lock.yaml"
+        ]
+    },
     "symfony/messenger": {
         "version": "6.1",
         "recipe": {

--- a/tests/Unit/Infrastructure/Symfony/EventSubscriber/RateLimiterSubscriberTest.php
+++ b/tests/Unit/Infrastructure/Symfony/EventSubscriber/RateLimiterSubscriberTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\Unit\Infrastructure\Symfony\Command;
+
+use App\Infrastructure\Symfony\EventSubscriber\RateLimiterSubscriber;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\TooManyRequestsHttpException;
+use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Component\RateLimiter\LimiterInterface;
+use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\RateLimiter\RateLimiterFactory;
+
+class RateLimiterSubscriberTest extends TestCase
+{
+    public function testSubscribedEvents(): void
+    {
+        $this->assertEquals([
+            'kernel.request' => [
+                ['onKernelRequest', 0],
+            ],
+        ], RateLimiterSubscriber::getSubscribedEvents());
+    }
+
+    public function testDebug(): void
+    {
+        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $kernel = $this->createMock(KernelInterface::class);
+        $request = $this->createMock(Request::class);
+        $event = new RequestEvent($kernel, $request, 1);
+
+        $kernel
+            ->expects(self::once())
+            ->method('isDebug')
+            ->willReturn(true);
+
+        $rateLimiter
+            ->expects(self::never())
+            ->method('create');
+
+        $subscriber = new RateLimiterSubscriber($kernel, $rateLimiter);
+        $subscriber->onKernelRequest($event);
+    }
+
+    public function testProductionNotLimited(): void
+    {
+        $rateLimit = $this->createMock(RateLimit::class);
+        $rateLimit
+            ->expects(self::once())
+            ->method('isAccepted')
+            ->willReturn(true);
+
+        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $kernel = $this->createMock(KernelInterface::class);
+
+        $limiter = $this->createMock(LimiterInterface::class);
+        $limiter
+            ->expects(self::once())
+            ->method('consume')
+            ->with(1)
+            ->willReturn($rateLimit);
+
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects(self::once())
+            ->method('getClientIp')
+            ->willReturn('127.0.0.1');
+
+        $kernel
+            ->expects(self::once())
+            ->method('isDebug')
+            ->willReturn(false);
+
+        $rateLimiter
+            ->expects(self::once())
+            ->method('create')
+            ->with('127.0.0.1')
+            ->willReturn($limiter);
+
+        $event = new RequestEvent($kernel, $request, 1);
+        $subscriber = new RateLimiterSubscriber($kernel, $rateLimiter);
+        $subscriber->onKernelRequest($event);
+    }
+
+    public function testProductionLimited(): void
+    {
+        $this->expectException(TooManyRequestsHttpException::class);
+        $rateLimit = $this->createMock(RateLimit::class);
+        $rateLimit
+            ->expects(self::once())
+            ->method('isAccepted')
+            ->willReturn(false);
+
+        $rateLimiter = $this->createMock(RateLimiterFactory::class);
+        $kernel = $this->createMock(KernelInterface::class);
+
+        $limiter = $this->createMock(LimiterInterface::class);
+        $limiter
+            ->expects(self::once())
+            ->method('consume')
+            ->with(1)
+            ->willReturn($rateLimit);
+
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects(self::once())
+            ->method('getClientIp')
+            ->willReturn('127.0.0.1');
+
+        $kernel
+            ->expects(self::once())
+            ->method('isDebug')
+            ->willReturn(false);
+
+        $rateLimiter
+            ->expects(self::once())
+            ->method('create')
+            ->with('127.0.0.1')
+            ->willReturn($limiter);
+
+        $event = new RequestEvent($kernel, $request, 1);
+        $subscriber = new RateLimiterSubscriber($kernel, $rateLimiter);
+        $subscriber->onKernelRequest($event);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -4,6 +4,8 @@ use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';
 
+DG\BypassFinals::enable();
+
 if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
     require dirname(__DIR__).'/config/bootstrap.php';
 } elseif (method_exists(Dotenv::class, 'bootEnv')) {


### PR DESCRIPTION
Cette PR permet de rajouter un rate limit global à toute l'application.
Pour le moment, j'ai mis une limite un peu arbitraire (100 appels / 5minutes) et sera évolué certainement dans le futur.

@florimondmanca j'ai rajouté un test unitaire sur l'event subscriver qui gère la limitation, mais je me demande si je peux le faire en test d'intégration également (sans casser ceux déjà en place).