### PR TITLE
Translate breadcrumb titles explicitly

### DIFF
--- a/templates/common/breadcrumb.html.twig
+++ b/templates/common/breadcrumb.html.twig
@@ -4,11 +4,11 @@
             {% for item in items %}
                 {% if loop.last %}
                     <li>
-                        <a class="fr-breadcrumb__link" aria-current="page">{{ item.title|trans }}</a>
+                        <a class="fr-breadcrumb__link" aria-current="page">{{ item.title }}</a>
                     </li>
                 {% else %}
                     <li>
-                        <a class="fr-breadcrumb__link" href="{{ path(item.path) }}">{{ item.title|trans }}</a>
+                        <a class="fr-breadcrumb__link" href="{{ path(item.path) }}">{{ item.title }}</a>
                     </li>
                 {% endif %}
             {% endfor %}

--- a/templates/regulation/create.html.twig
+++ b/templates/regulation/create.html.twig
@@ -11,7 +11,7 @@
 {% block body %}
     <div class="fr-container fr-py-5w" aria-labelledby="add-title">
         {% include "common/breadcrumb.html.twig" with { items: [
-            { title: 'regulation.breadcrumb', path: 'app_regulations_list'},
+            { title: 'regulation.breadcrumb'|trans, path: 'app_regulations_list'},
             { title },
         ]} %}
 

--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -12,7 +12,7 @@
     {% set isDraft = regulationOrderRecord.status == 'draft' %}
     <section class="fr-container fr-py-5w" aria-labelledby="regulation-detail">
         {% include "common/breadcrumb.html.twig" with { items: [
-            { title: 'regulation.breadcrumb', path: 'app_regulations_list'},
+            { title: 'regulation.breadcrumb'|trans, path: 'app_regulations_list'},
             { title: 'regulation.detail.breadcrumb'|trans({ '%identifier%': regulationOrderRecord.identifier }) },
         ]} %}
 


### PR DESCRIPTION
Le fait que le composant breadcrumb traduisait automatiquement les items qu'on lui filait était pratique,

Mais dans certains cas le `title` est déjà traduit (par ex quand il provient d'une variable qu'on réutilise dans un template, cf `create.html.twig` @ L15) ce qui aboutit à des clés de traduction manquante

Cette PR utilise une traduction explicite avec `|trans` quand on inclut le composant breadcrumb