### PR TITLE
Add localisations to regulation order list

### DIFF
--- a/src/Application/Regulation/Query/GetRegulationsQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationsQueryHandler.php
@@ -19,7 +19,7 @@ final class GetRegulationsQueryHandler
 
     public function __invoke(GetRegulationsQuery $query): Pagination
     {
-        $regulations = $this->repository->findRegulationsByOrganization(
+        $regulationOrderRecords = $this->repository->findRegulationsByOrganization(
             $query->organization,
             $query->pageSize,
             $query->page,
@@ -32,16 +32,21 @@ final class GetRegulationsQueryHandler
         );
         $regulationOrderViews = [];
 
-        foreach ($regulations as $regulation) {
+        foreach ($regulationOrderRecords as $regulationOrderRecord) {
+            $regulationOrder = $regulationOrderRecord->getRegulationOrder();
+            $locations = $regulationOrder->getLocations();
+            $nbLocations = $locations->count();
+
             $regulationOrderViews[] = new RegulationOrderListItemView(
-                $regulation['uuid'],
-                $regulation['identifier'],
-                $regulation['status'],
-                $regulation['address'] ? new LocationView(
-                    LocationAddress::fromString($regulation['address']),
+                uuid: $regulationOrderRecord->getUuid(),
+                identifier: $regulationOrder->getIdentifier(),
+                status: $regulationOrderRecord->getStatus(),
+                numLocations: $nbLocations,
+                location: $nbLocations ? new LocationView(
+                    LocationAddress::fromString($locations->first()->getAddress()),
                 ) : null,
-                $regulation['startDate'],
-                $regulation['endDate'],
+                startDate: $regulationOrder->getStartDate(),
+                endDate: $regulationOrder->getEndDate(),
             );
         }
 

--- a/src/Application/Regulation/View/RegulationOrderListItemView.php
+++ b/src/Application/Regulation/View/RegulationOrderListItemView.php
@@ -10,6 +10,7 @@ final class RegulationOrderListItemView
         public readonly string $uuid,
         public readonly string $identifier,
         public readonly string $status,
+        public readonly int $numLocations,
         public readonly ?LocationView $location,
         public readonly ?\DateTimeInterface $startDate,
         public readonly ?\DateTimeInterface $endDate,

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/LocationFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/LocationFixture.php
@@ -23,6 +23,26 @@ final class LocationFixture extends Fixture implements DependentFixtureInterface
             'POINT(-1.930973 47.347917)',
         );
 
+        $location1Bis = new Location(
+            '34247125-38f4-4e69-b5d7-5516a577d149',
+            $this->getReference('regulationOrder'),
+            'Rue Victor Hugo 44260 Savenay',
+            null,
+            null,
+            null,
+            null,
+        );
+
+        $location1Ter = new Location(
+            '0b5d0ddf-f7aa-4f0a-af12-1f654a505200',
+            $this->getReference('regulationOrder'),
+            'Route du Lac 44260 Savenay',
+            null,
+            null,
+            null,
+            null,
+        );
+
         $location2 = new Location(
             '2d79e1ff-c991-4767-b8c0-36b644038d0f',
             $this->getReference('regulationOrder2'),
@@ -44,6 +64,8 @@ final class LocationFixture extends Fixture implements DependentFixtureInterface
         );
 
         $manager->persist($location1);
+        $manager->persist($location1Bis);
+        $manager->persist($location1Ter);
         $manager->persist($location2);
         $manager->persist($location3);
         $manager->flush();

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.RegulationOrder.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.RegulationOrder.orm.xml
@@ -8,6 +8,6 @@
     <field name="description" type="text" column="description" nullable="false"/>
     <field name="startDate" type="datetimetz" column="start_date" nullable="true"/>
     <field name="endDate" type="datetimetz" column="end_date" nullable="true"/>
-    <one-to-many field="locations" target-entity="App\Domain\Regulation\Location" mapped-by="regulationOrder"/>
+    <one-to-many field="locations" target-entity="App\Domain\Regulation\Location" mapped-by="regulationOrder" fetch="EAGER"/>
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.RegulationOrderRecord.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.RegulationOrderRecord.orm.xml
@@ -10,10 +10,10 @@
             <option name="default">CURRENT_TIMESTAMP</option>
         </options>
     </field>
-    <one-to-one field="regulationOrder" target-entity="App\Domain\Regulation\RegulationOrder">
+    <one-to-one field="regulationOrder" target-entity="App\Domain\Regulation\RegulationOrder" fetch="EAGER">
         <join-column name="regulation_order_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE"/>
     </one-to-one>
-    <many-to-one field="organization" target-entity="App\Domain\User\Organization" fetch="LAZY">
+    <many-to-one field="organization" target-entity="App\Domain\User\Organization">
         <join-columns>
             <join-column name="organization_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE"/>
         </join-columns>

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -25,12 +25,12 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
         bool $isPermanent,
     ): array {
         return $this->createQueryBuilder('roc')
-            ->select('roc.uuid, ro.identifier, loc.address, ro.startDate, ro.endDate, roc.status')
             ->where('roc.organization = :organization')
             ->setParameter('organization', $organization->getUuid())
             ->innerJoin('roc.regulationOrder', 'ro', 'WITH', $isPermanent ? 'ro.endDate IS NULL' : 'ro.endDate IS NOT NULL')
             ->leftJoin('ro.locations', 'loc')
             ->orderBy('ro.startDate', 'DESC')
+            ->addGroupBy('ro, roc')
             ->setFirstResult($maxItemsPerPage * ($page - 1))
             ->setMaxResults($maxItemsPerPage)
             ->getQuery()

--- a/templates/regulation/_items.html.twig
+++ b/templates/regulation/_items.html.twig
@@ -22,7 +22,11 @@
                     </td>
                     <td>
                         {% if regulation.location %}
-                            {{ regulation.location.address }}
+                            {{ regulation.location.address.city }}<br/>
+                            <b>{{ regulation.location.address.roadName }}</b>
+                            {% if regulation.numLocations > 1%}
+                                <em>{{ 'regulation.locations.more'|trans({'%count%': regulation.numLocations - 1}) }}</em>
+                            {% endif %}
                         {% endif %}
                     </td>
                     <td>

--- a/templates/regulation/index.html.twig
+++ b/templates/regulation/index.html.twig
@@ -36,7 +36,7 @@
                 {% include "common/pagination.html.twig" with {
                     pagination: temporaryRegulations,
                     currentPage: isTemporaryTab ? app.request.get('page', 1) : 1,
-                    queryParams: app.request.query.all,
+                    queryParams: app.request.query.all|merge({ tab: 'temporary' }),
                 } only %}
             </div>
             <div
@@ -50,7 +50,7 @@
                 {% include "common/pagination.html.twig" with {
                     pagination: permanentRegulations,
                     currentPage: isPermanent ? app.request.get('page', 1) : 1,
-                    queryParams: app.request.query.all,
+                    queryParams: app.request.query.all|merge({ tab: 'permanent' }),
                 } only %}
             </div>
         </div>

--- a/tests/Integration/Infrastructure/Common/PaginationTest.php
+++ b/tests/Integration/Infrastructure/Common/PaginationTest.php
@@ -17,9 +17,9 @@ final class PaginationTest extends WebTestCase
 
         $html = $twig->render('common/pagination.html.twig', [
             'queryParams' => [
+                'tab' => 'temporary',
                 'page' => 1,
                 'pageSize' => 10,
-                'tab' => 'temporary',
             ],
             'pagination' => [
                 'windowPages' => [3, 4, 5],

--- a/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
@@ -36,10 +36,10 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
         $this->assertSame(1, $pageOneTemporaryRows->count()); // One item per page
 
         $pageOneTemporaryRow0 = $pageOneTemporaryRows->eq(0)->filter('td');
-        $this->assertSame('FO1/2023', $pageOneTemporaryRow0->eq(0)->text());
-        $this->assertSame('Route du Grand Brossais, 44260 Savenay', $pageOneTemporaryRow0->eq(1)->text());
-        $this->assertSame('du 13/03/2023 au 15/03/2023 passé', $pageOneTemporaryRow0->eq(2)->text());
-        $this->assertSame('Brouillon', $pageOneTemporaryRow0->eq(3)->text());
+        $this->assertSame("FO1/2023", $pageOneTemporaryRow0->eq(0)->text());
+        $this->assertSame('Savenay Route du Grand Brossais + 2 localisations', $pageOneTemporaryRow0->eq(1)->text());
+        $this->assertSame("du 13/03/2023 au 15/03/2023 passé", $pageOneTemporaryRow0->eq(2)->text());
+        $this->assertSame("Brouillon", $pageOneTemporaryRow0->eq(3)->text());
 
         $links = $pageOneTemporaryRow0->eq(4)->filter('a');
         $this->assertSame('Modifier', $links->eq(0)->text());
@@ -47,6 +47,7 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
 
         // Second item
         $pageTwo = $client->request('GET', '/regulations?pageSize=1&tab=temporary&page=2');
+
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
@@ -76,7 +77,7 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
 
         $pageThreeTemporaryRow0 = $pageThreeTemporaryRows->eq(0)->filter('td');
         $this->assertSame('FO2/2023', $pageThreeTemporaryRow0->eq(0)->text());
-        $this->assertSame('Avenue de Fonneuve, 82000 Montauban', $pageThreeTemporaryRow0->eq(1)->text());
+        $this->assertSame('Montauban Avenue de Fonneuve', $pageThreeTemporaryRow0->eq(1)->text());
         $this->assertSame('du 10/03/2023 au 20/03/2023 passé', $pageThreeTemporaryRow0->eq(2)->text());
         $this->assertSame('Publié', $pageThreeTemporaryRow0->eq(3)->text());
 
@@ -96,8 +97,8 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
         $this->assertSame(1, $pageOnePermanentRows->count());
 
         $pageOnePermanentRow0 = $pageOnePermanentRows->eq(0)->filter('td');
-        $this->assertSame('FO3/2023', $pageOnePermanentRow0->eq(0)->text());
-        $this->assertSame('75018 Paris 18e Arrondissement', $pageOnePermanentRow0->eq(1)->text());
+        $this->assertSame("FO3/2023", $pageOnePermanentRow0->eq(0)->text());
+        $this->assertSame('Paris 18e Arrondissement', $pageOnePermanentRow0->eq(1)->text());
         $this->assertSame('à partir du 11/03/2023 en cours', $pageOnePermanentRow0->eq(2)->text());
         $this->assertSame('Brouillon', $pageOnePermanentRow0->eq(3)->text());
 

--- a/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
@@ -11,7 +11,11 @@ use App\Application\Regulation\View\RegulationOrderListItemView;
 use App\Domain\Pagination;
 use App\Domain\Regulation\LocationAddress;
 use App\Domain\Regulation\Repository\RegulationOrderRecordRepositoryInterface;
+use App\Domain\Regulation\Location;
+use App\Domain\Regulation\RegulationOrder;
+use App\Domain\Regulation\RegulationOrderRecord;
 use App\Domain\User\Organization;
+use Doctrine\Common\Collections\Collection;
 use PHPUnit\Framework\TestCase;
 
 final class GetRegulationsQueryHandlerTest extends TestCase
@@ -22,33 +26,94 @@ final class GetRegulationsQueryHandlerTest extends TestCase
         $startDate2 = new \DateTime('2022-12-10');
         $organization = $this->createMock(Organization::class);
 
-        $location = new LocationView(
-            address: new LocationAddress('82000', 'Montauban', 'Avenue de Fonneuve'),
-        );
+        $location = $this->createMock(Location::class);
+        $location
+            ->expects(self::once())
+            ->method('getAddress')
+            ->willReturn('Avenue de Fonneuve, 82000 Montauban');
+
+        $locations1 = $this->createMock(Collection::class);
+        $locations1
+            ->expects(self::once())
+            ->method('count')
+            ->willReturn(2);
+        $locations1
+            ->expects(self::once())
+            ->method('first')
+            ->willReturn($location);
+
+        $locations2 = $this->createMock(Collection::class);
+        $locations2
+            ->expects(self::once())
+            ->method('count')
+            ->willReturn(0);
+        $locations2
+            ->expects(self::never())
+            ->method('first');
+
+        $regulationOrder1 = $this->createMock(RegulationOrder::class);
+        $regulationOrder1
+            ->expects(self::once())
+            ->method('getStartDate')
+            ->willReturn($startDate1);
+            $regulationOrder1
+                ->expects(self::once())
+                ->method('getIdentifier')
+                ->willReturn('F01/2023');
+        $regulationOrder1
+            ->expects(self::once())
+            ->method('getLocations')
+            ->willReturn($locations1);
+
+        $regulationOrderRecord1 = $this->createMock(RegulationOrderRecord::class);
+        $regulationOrderRecord1
+            ->expects(self::once())
+            ->method('getRegulationOrder')
+            ->willReturn($regulationOrder1);
+        $regulationOrderRecord1
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf');
+        $regulationOrderRecord1
+            ->expects(self::once())
+            ->method('getStatus')
+            ->willReturn('draft');
+
+        $regulationOrder2 = $this->createMock(RegulationOrder::class);
+        $regulationOrder2
+            ->expects(self::once())
+            ->method('getStartDate')
+            ->willReturn($startDate2);
+        $regulationOrder2
+            ->expects(self::once())
+            ->method('getIdentifier')
+            ->willReturn('F02/2023');
+        $regulationOrder2
+            ->expects(self::once())
+            ->method('getLocations')
+            ->willReturn($locations2);
+
+        $regulationOrderRecord2 = $this->createMock(RegulationOrderRecord::class);
+        $regulationOrderRecord2
+            ->expects(self::once())
+            ->method('getRegulationOrder')
+            ->willReturn($regulationOrder2);
+        $regulationOrderRecord2
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('247edaa2-58d1-43de-9d33-9753bf6f4d30');
+        $regulationOrderRecord2
+            ->expects(self::once())
+            ->method('getStatus')
+            ->willReturn('draft');
 
         $regulationOrderRecordRepository = $this->createMock(RegulationOrderRecordRepositoryInterface::class);
-        $regulationOrder1 = [
-            'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
-            'identifier' => 'F01/2023',
-            'address' => 'Avenue de Fonneuve 82000 Montauban',
-            'startDate' => $startDate1,
-            'endDate' => null,
-            'status' => 'draft',
-        ];
-        $regulationOrder2 = [
-            'uuid' => '247edaa2-58d1-43de-9d33-9753bf6f4d30',
-            'identifier' => 'F02/2023',
-            'address' => null,
-            'startDate' => $startDate2,
-            'endDate' => null,
-            'status' => 'draft',
-        ];
 
         $regulationOrderRecordRepository
             ->expects(self::once())
             ->method('findRegulationsByOrganization')
             ->with($organization, 20, 1, true)
-            ->willReturn([$regulationOrder2, $regulationOrder1]);
+            ->willReturn([$regulationOrderRecord2, $regulationOrderRecord1]);
 
         $regulationOrderRecordRepository
             ->expects(self::once())
@@ -65,6 +130,7 @@ final class GetRegulationsQueryHandlerTest extends TestCase
                     '247edaa2-58d1-43de-9d33-9753bf6f4d30',
                     'F02/2023',
                     'draft',
+                    0,
                     null,
                     $startDate2,
                     null,
@@ -73,7 +139,10 @@ final class GetRegulationsQueryHandlerTest extends TestCase
                     '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
                     'F01/2023',
                     'draft',
-                    $location,
+                    2,
+                    new LocationView(
+                        address: new LocationAddress('82000', 'Montauban', 'Avenue de Fonneuve'),
+                    ),
                     $startDate1,
                     null,
                 ),

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -343,6 +343,10 @@
                 <source>regulation.period</source>
                 <target>Période</target>
             </trans-unit>
+            <trans-unit id="regulation.locations.more">
+                <source>regulation.locations.more</source>
+                <target>+ 1 localisation |+ %count% localisations</target>
+            </trans-unit>
             <trans-unit id="regulation.present">
                 <source>regulation.present</source>
                 <target>Réglementation en cours</target>


### PR DESCRIPTION
## Tester

https://dialog-staging-pr272.osc-fr1.scalingo.io/

## Aperçu
![image](https://user-images.githubusercontent.com/2683379/232726904-c281844a-06bf-4767-9268-cc40fb431073.png)

## Point perf

Le fait de mettre les relations en `fetch="EAGER"` a permis de diviser par deux le nombre de requêtes et le temps d'exécution sur la liste des arrêtés (à cause de la récupération des localisations).
Avant :
![image](https://user-images.githubusercontent.com/2683379/232731958-fec435c5-8b8d-43ce-9542-83f68b73040d.png)
Après :
![image](https://user-images.githubusercontent.com/2683379/232732173-9cb1034b-fb09-418c-9ab4-4036dfb34639.png)

À noter qu'on a deux queries supplémentaires par rapport à `main` lié à la relation `$regulationOrderRecord->getRegulationOrder()`. Ce problème a déjà été remonté à un autre endroit de l'application et devra être traité dans [une issue à part](https://github.com/MTES-MCT/dialog/issues/273).
