### PR TITLE
Rename save repositories methods to add

### DIFF
--- a/src/Application/Regulation/Command/SaveRegulationLocationCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommandHandler.php
@@ -37,7 +37,7 @@ final class SaveRegulationLocationCommandHandler
             $fromPoint = $command->fromHouseNumber ? $this->computePoint($command->address, $command->fromHouseNumber) : null;
             $toPoint = $command->toHouseNumber ? $this->computePoint($command->address, $command->toHouseNumber) : null;
 
-            $this->locationRepository->save(
+            $this->locationRepository->add(
                 new Location(
                     uuid: $this->idFactory->make(),
                     regulationOrder: $regulationOrder,

--- a/src/Application/Regulation/Command/SaveRegulationOrderCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveRegulationOrderCommandHandler.php
@@ -40,7 +40,7 @@ final class SaveRegulationOrderCommandHandler
 
         // If submitting the form the first time, we create the regulationOrder and regulationOrderRecord
         if (!$command->regulationOrderRecord instanceof RegulationOrderRecord) {
-            $regulationOrder = $this->regulationOrderRepository->save(
+            $regulationOrder = $this->regulationOrderRepository->add(
                 new RegulationOrder(
                     uuid: $this->idFactory->make(),
                     identifier: $command->identifier,
@@ -50,7 +50,7 @@ final class SaveRegulationOrderCommandHandler
                 ),
             );
 
-            $regulationOrderRecord = $this->regulationOrderRecordRepository->save(
+            $regulationOrderRecord = $this->regulationOrderRecordRepository->add(
                 new RegulationOrderRecord(
                     uuid: $this->idFactory->make(),
                     status: RegulationOrderRecordStatusEnum::DRAFT,

--- a/src/Domain/Regulation/Repository/LocationRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/LocationRepositoryInterface.php
@@ -8,7 +8,7 @@ use App\Domain\Regulation\Location;
 
 interface LocationRepositoryInterface
 {
-    public function save(Location $location): Location;
+    public function add(Location $location): Location;
 
     public function findOneByUuid(string $uuid): ?Location;
 }

--- a/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
@@ -9,7 +9,7 @@ use App\Domain\User\Organization;
 
 interface RegulationOrderRecordRepositoryInterface
 {
-    public function save(RegulationOrderRecord $regulationOrderRecord): RegulationOrderRecord;
+    public function add(RegulationOrderRecord $regulationOrderRecord): RegulationOrderRecord;
 
     public function findOneByUuid(string $uuid): RegulationOrderRecord|null;
 

--- a/src/Domain/Regulation/Repository/RegulationOrderRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/RegulationOrderRepositoryInterface.php
@@ -8,7 +8,7 @@ use App\Domain\Regulation\RegulationOrder;
 
 interface RegulationOrderRepositoryInterface
 {
-    public function save(RegulationOrder $regulationOrder): RegulationOrder;
+    public function add(RegulationOrder $regulationOrder): RegulationOrder;
 
     public function delete(RegulationOrder $regulationOrder): void;
 }

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
@@ -16,7 +16,7 @@ final class LocationRepository extends ServiceEntityRepository implements Locati
         parent::__construct($registry, Location::class);
     }
 
-    public function save(Location $location): Location
+    public function add(Location $location): Location
     {
         $this->getEntityManager()->persist($location);
 

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -118,7 +118,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
         ;
     }
 
-    public function save(RegulationOrderRecord $regulationOrderRecord): RegulationOrderRecord
+    public function add(RegulationOrderRecord $regulationOrderRecord): RegulationOrderRecord
     {
         $this->getEntityManager()->persist($regulationOrderRecord);
 

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRepository.php
@@ -16,7 +16,7 @@ final class RegulationOrderRepository extends ServiceEntityRepository implements
         parent::__construct($registry, RegulationOrder::class);
     }
 
-    public function save(RegulationOrder $regulationOrder): RegulationOrder
+    public function add(RegulationOrder $regulationOrder): RegulationOrder
     {
         $this->getEntityManager()->persist($regulationOrder);
 

--- a/tests/Unit/Application/Regulation/Command/SaveRegulationLocationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/SaveRegulationLocationCommandHandlerTest.php
@@ -81,7 +81,7 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $locationRepository = $this->createMock(LocationRepositoryInterface::class);
         $locationRepository
             ->expects(self::once())
-            ->method('save')
+            ->method('add')
             ->with($this->equalTo($location));
 
         $handler = new SaveRegulationLocationCommandHandler(
@@ -139,7 +139,7 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $locationRepository = $this->createMock(LocationRepositoryInterface::class);
         $locationRepository
             ->expects(self::never())
-            ->method('save');
+            ->method('add');
 
         $handler = new SaveRegulationLocationCommandHandler(
             $idFactory,
@@ -184,7 +184,7 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $locationRepository = $this->createMock(LocationRepositoryInterface::class);
         $locationRepository
             ->expects(self::never())
-            ->method('save');
+            ->method('add');
 
         $handler = new SaveRegulationLocationCommandHandler(
             $idFactory,
@@ -255,7 +255,7 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $locationRepository = $this->createMock(LocationRepositoryInterface::class);
         $locationRepository
             ->expects(self::never())
-            ->method('save');
+            ->method('add');
 
         $handler = new SaveRegulationLocationCommandHandler(
             $idFactory,

--- a/tests/Unit/Application/Regulation/Command/SaveRegulationOrderCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/SaveRegulationOrderCommandHandlerTest.php
@@ -53,7 +53,7 @@ final class SaveRegulationOrderCommandHandlerTest extends TestCase
 
         $this->regulationOrderRepository
             ->expects(self::once())
-            ->method('save')
+            ->method('add')
             ->with(
                 $this->equalTo(
                     new RegulationOrder(
@@ -75,7 +75,7 @@ final class SaveRegulationOrderCommandHandlerTest extends TestCase
 
         $this->regulationOrderRecordRepository
             ->expects(self::once())
-            ->method('save')
+            ->method('add')
             ->with(
                 $this->equalTo(
                     new RegulationOrderRecord(
@@ -123,7 +123,7 @@ final class SaveRegulationOrderCommandHandlerTest extends TestCase
 
         $this->regulationOrderRepository
             ->expects(self::never())
-            ->method('save');
+            ->method('add');
 
         $this->doesOrganizationAlreadyHaveRegulationOrderWithThisIdentifier
             ->expects(self::once())
@@ -133,7 +133,7 @@ final class SaveRegulationOrderCommandHandlerTest extends TestCase
 
         $this->regulationOrderRecordRepository
             ->expects(self::never())
-            ->method('save');
+            ->method('add');
 
         $handler = new SaveRegulationOrderCommandHandler(
             $this->idFactory,
@@ -170,11 +170,11 @@ final class SaveRegulationOrderCommandHandlerTest extends TestCase
 
         $this->regulationOrderRepository
             ->expects(self::never())
-            ->method('save');
+            ->method('add');
 
         $this->regulationOrderRecordRepository
             ->expects(self::never())
-            ->method('save');
+            ->method('add');
 
         $regulationOrder = $this->createMock(RegulationOrder::class);
         $regulationOrder
@@ -248,11 +248,11 @@ final class SaveRegulationOrderCommandHandlerTest extends TestCase
 
         $this->regulationOrderRepository
             ->expects(self::never())
-            ->method('save');
+            ->method('add');
 
         $this->regulationOrderRecordRepository
             ->expects(self::never())
-            ->method('save');
+            ->method('add');
 
         $regulationOrder = $this->createMock(RegulationOrder::class);
         $regulationOrder


### PR DESCRIPTION
Dans un souci de clarté, cette PR renomme toutes les méthodes `save` des repositories en `add`. Ces méthodes sont uniquement utilisées lors de la création d'objets (et donc la prise en connaissance de ceux-ci par doctrine).  
Pour la mise à jour, la sauvegarde en base de donnée est gérée via des transactions qui sont configurées au niveau des middlewares du command bus.