### PR TITLE
Pre-filter housenumber in location autocomplete

### DIFF
--- a/src/Infrastructure/Adapter/APIAdresseGeocoder.php
+++ b/src/Infrastructure/Adapter/APIAdresseGeocoder.php
@@ -12,7 +12,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class APIAdresseGeocoder implements GeocoderInterface
 {
-    private const HOUSENUMBER_FILTER_REGEX = '/^(\d+\s?(bis|ter)?)\s/i';
+    private const HOUSENUMBER_FILTER_REGEX = '/^(\d+\s?(bis|b|ter|t|quater|q)?)\s/i';
 
     public function __construct(
         private HttpClientInterface $apiAdresseClient,

--- a/src/Infrastructure/Adapter/APIAdresseGeocoder.php
+++ b/src/Infrastructure/Adapter/APIAdresseGeocoder.php
@@ -12,6 +12,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class APIAdresseGeocoder implements GeocoderInterface
 {
+    private const HOUSENUMBER_FILTER_REGEX = '/^(\d+\s?(bis|ter)?)\s/i';
+
     public function __construct(
         private HttpClientInterface $apiAdresseClient,
     ) {
@@ -103,6 +105,8 @@ final class APIAdresseGeocoder implements GeocoderInterface
 
     public function findAddresses(string $search): array
     {
+        $search = preg_replace(self::HOUSENUMBER_FILTER_REGEX, '', $search);
+
         $response = $this->apiAdresseClient->request('GET', '/search/', [
             'headers' => [
                 'Accept' => 'application/json',
@@ -120,10 +124,6 @@ final class APIAdresseGeocoder implements GeocoderInterface
 
             foreach ($data['features'] as $feature) {
                 $type = $feature['properties']['type'];
-
-                if ($type === 'housenumber') {
-                    continue;
-                }
 
                 $label = match ($type) {
                     'street', 'locality' => sprintf('%s, %s %s', $feature['properties']['name'], $feature['properties']['postcode'], $feature['properties']['city']),

--- a/tests/Unit/Infrastructure/Adapter/APIAdresseGeocoderTest.php
+++ b/tests/Unit/Infrastructure/Adapter/APIAdresseGeocoderTest.php
@@ -128,8 +128,13 @@ final class APIAdresseGeocoderTest extends TestCase
         return [
             ['search' => '3 Rue Eugene'],
             ['search' => '3bis Rue Eugene'],
+            ['search' => '3b Rue Eugene'],
             ['search' => '3ter Rue Eugene'],
+            ['search' => '3t Rue Eugene'],
+            ['search' => '3quater Rue Eugene'],
+            ['search' => '3q Rue Eugene'],
             ['search' => '12 bis Rue Eugene'],
+            ['search' => '12 quater Rue Eugene'],
         ];
     }
 


### PR DESCRIPTION
Closes #267 

Pour tester : https://dialog-staging-pr294.osc-fr1.scalingo.io/

Au lieu de filtrer les résultats après-coup, cette PR propose de retirer préventivement tout numéro de maison saisi en début de terme de recherche. Ainsi, "3 Rue Eugène" est traité comme "Rue Eugène". Les bis et ter séparés ou non du numéro sont supportés : "2 bis", "13ter".

## Aperçu

Avant: aucun résultat
![avant](https://user-images.githubusercontent.com/15911462/233960875-370bcc6f-f51a-49aa-92d0-c661c33ba3d7.png)

Après : même résultats que si l'utilisateur avait saisi "rue eugène"

![apres](https://user-images.githubusercontent.com/15911462/233961703-6ea2f9ab-24a7-429c-9fda-42826361b401.png)

