### PR TITLE
Setup E2E tests using Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,16 +29,36 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys:
+            ${{ runner.os }}-node-
+
       - name: Init CI environment variables
         # HACK: Symfony won't read from 'env: { DATABASE_URL: ... }', so we need to edit
         # .env directly.
         run: |
           echo "DATABASE_URL=postgresql://dialog:dialog@localhost:5432/dialog" >> .env
 
+      - name: Install Symfony CLI
+        # Required for E2E testing
+        run: |
+          curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | sudo -E bash
+          sudo apt install symfony-cli
+
       - name: CI
-        run: make ci BIN_PHP="php" NPM="npm" BIN_CONSOLE="php bin/console" BIN_COMPOSER="composer"
+        run: make ci CI=1 BIN_PHP="php" BIN_CONSOLE="php bin/console" BIN_COMPOSER="composer" BIN_NPM="npm" BIN_NPX="npx" PLAYWRIGHT_BASE_URL="http://localhost:8000"
 
       - uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ coverage/
 npm-debug.log
 yarn-error.log
 ###< symfony/webpack-encore-bundle ###
+/test-results/
+/playwright-report/
+/playwright/.cache/
+/playwright/.auth/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       context: ./docker/php
     ports:
       - '9000:9000'
+      - '9323:9323' # Playwright report server
     volumes:
       - ./:/var/www/dialog
       - ./docker/php/php.ini:/usr/local/etc/php/php.ini

--- a/docs/tools/quality.md
+++ b/docs/tools/quality.md
@@ -2,7 +2,7 @@
 
 ## Tests
 
-Nous utilisons le framework [PHPUnit](https://phpunit.de/) pour faire nos tests.
+Nous utilisons le framework [PHPUnit](https://phpunit.de/) pour faire nos tests, ainsi que [Playwright](https://playwright.dev) pour les tests end-to-end (E2E).
 
 Exécuter tous les tests :
 
@@ -20,6 +20,26 @@ Exécuter les tests d'intégration uniquement :
 
 ```bash
 make test_integration
+```
+
+Exécuter les tests E2E uniquement :
+
+```bash
+make test_e2e
+```
+
+Passez des arguments Playwright supplémentaires à l'aide de `ARGS="..."`. Par exemple, pour lancer un unique test :
+
+```bash
+make test_e2e ARGS="tests/e2e/list.spec.js"
+```
+
+Voir la [documentation Playwright](https://playwright.dev/docs/debug#playwright-inspector) pour toutes les options de débogage disponibles.
+
+Pour visualiser le rapport de tests E2E :
+
+```bash
+make report_e2e
 ```
 
 ## Formatage

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@babel/preset-env": "^7.16.0",
                 "@hotwired/stimulus": "^3.0.0",
                 "@hotwired/turbo": "^7.0.1",
+                "@playwright/test": "^1.32.3",
                 "@symfony/stimulus-bridge": "^3.2.0",
                 "@symfony/ux-turbo": "file:vendor/symfony/ux-turbo/assets",
                 "@symfony/webpack-encore": "^4.0.0",
@@ -1867,6 +1868,25 @@
             },
             "peerDependencies": {
                 "webpack": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.32.3",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.3.tgz",
+            "integrity": "sha512-BvWNvK0RfBriindxhLVabi8BRe3X0J9EVjKlcmhxjg4giWBD/xleLcg2dz7Tx0agu28rczjNIPQWznwzDwVsZQ==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*",
+                "playwright-core": "1.32.3"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
             }
         },
         "node_modules/@sinclair/typebox": {
@@ -5906,6 +5926,18 @@
                 "node": ">=4"
             }
         },
+        "node_modules/playwright-core": {
+            "version": "1.32.3",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.3.tgz",
+            "integrity": "sha512-SB+cdrnu74ZIn5Ogh/8278ngEh9NEEV0vR4sJFmK04h2iZpybfbqBY0bX6+BLYWVdV12JLLI+JEFtSnYgR+mWg==",
+            "dev": true,
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.4.21",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -8067,6 +8099,7 @@
             }
         },
         "vendor/symfony/ux-turbo/assets": {
+            "name": "@symfony/ux-turbo",
             "version": "0.1.0",
             "dev": true,
             "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
         "@babel/preset-env": "^7.16.0",
         "@hotwired/stimulus": "^3.0.0",
         "@hotwired/turbo": "^7.0.1",
+        "@playwright/test": "^1.32.3",
         "@symfony/stimulus-bridge": "^3.2.0",
         "@symfony/ux-turbo": "file:vendor/symfony/ux-turbo/assets",
         "@symfony/webpack-encore": "^4.0.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,41 @@
+// @ts-check
+const { defineConfig, devices } = require('@playwright/test');
+
+// This port is specific to the web server configured below for E2E testing.
+const PORT = 8001;
+
+/**
+ * @see https://playwright.dev/docs/test-configuration
+ */
+module.exports = defineConfig({
+    testDir: './tests/e2e',
+    forbidOnly: !!process.env.CI,
+    retries: process.env.CI ? 2 : 0,
+    workers: 1,
+    reporter: 'html',
+    use: {
+        baseURL: `http://localhost:${PORT}`,
+        trace: 'on-first-retry',
+        screenshot: 'only-on-failure',
+    },
+    projects: [
+        { name: 'setup', testMatch: /.*\.setup\.js/ },
+        {
+            name: 'desktop-firefox',
+            use: { ...devices['Desktop Firefox'] },
+            dependencies: ['setup'],
+        },
+        {
+            name: 'mobile-chromium',
+            use: { ...devices['Pixel 5'] },
+            dependencies: ['setup'],
+        },
+    ],
+    webServer: {
+        command: `symfony server:start --port=${PORT}`,
+        env: {
+            APP_ENV: 'test',
+        },
+        url: `http://localhost:${PORT}`,
+    },
+});

--- a/templates/regulation/_items.html.twig
+++ b/templates/regulation/_items.html.twig
@@ -83,7 +83,8 @@
                                     data-modal-trigger-key-value="{{ regulation.uuid }}"
                                     data-action="modal-trigger#showModal:prevent"
                                     aria-controls="regulation-delete-modal"
-                                    title="{{ 'common.delete'|trans }}"
+                                    aria-label="{{ 'regulation.delete'|trans({'%identifier%': regulation.identifier}) }}"
+                                    title="{{ 'regulation.delete'|trans({'%identifier%': regulation.identifier}) }}"
                                 ></button>
                                 <input type="hidden" name="token" value="{{ deleteCsrfToken }}" />
                             </form>

--- a/tests/e2e/auth.setup.js
+++ b/tests/e2e/auth.setup.js
@@ -1,0 +1,13 @@
+// @ts-check
+const { test: setup } = require("@playwright/test");
+
+const mathieuFile = 'playwright/.auth/mathieu.json';
+
+setup('authenticate', async ({ page }) => {
+    await page.goto("/login");
+    await page.fill("input[name='email']", 'mathieu.marchois@beta.gouv.fr');
+    await page.fill("input[name='password']", 'password');
+    await page.getByRole('button', { name: 'Se connecter' }).click();
+    await page.waitForURL("/regulations");
+    await page.context().storageState({ path: mathieuFile });
+});

--- a/tests/e2e/list.spec.js
+++ b/tests/e2e/list.spec.js
@@ -1,0 +1,50 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.use({ storageState: 'playwright/.auth/mathieu.json' });
+
+test.describe('Regulation list', () => {
+    test('Tabs', async ({ page }) => {
+        await page.goto('/regulations');
+
+        const temporaryTab = page.getByRole('tab', { name: 'Temporaires (3)' })
+        await temporaryTab.waitFor();
+        expect(temporaryTab).toHaveAttribute('aria-selected', 'true');
+        const permanentTab = page.getByRole('tab', { name: 'Permanents (1)' });
+        await permanentTab.waitFor();
+        expect(permanentTab).toHaveAttribute('aria-selected', 'false');
+
+        const temporaryTabPanel = page.getByRole('tabpanel', { name: 'Temporaires (3)' });
+        const permanentTabPanel = page.getByRole('tabpanel', { name: 'Permanents (1)' });
+        await expect(temporaryTabPanel).toBeVisible();
+        await expect(permanentTabPanel).not.toBeVisible();
+
+        await permanentTab.click();
+        expect(temporaryTab).toHaveAttribute('aria-selected', 'false');
+        await expect(temporaryTabPanel).not.toBeVisible();
+        expect(permanentTab).toHaveAttribute('aria-selected', 'true');
+        await expect(permanentTabPanel).toBeVisible();
+    });
+
+    test('Delete modal', async ({ page }) => {
+        await page.goto('/regulations');
+
+        const deleteModal = page.locator('[id="regulation-delete-modal"]');
+        await expect(deleteModal).not.toBeVisible();
+
+        const deleteBtn = page.getByRole('button', { name: "Supprimer l'arrêté FO1/2023", exact: true });
+        await deleteBtn.click();
+        await expect(deleteModal).toBeVisible();
+
+        // Don't delete
+        await deleteModal.getByRole('button', { name: 'Ne pas supprimer', exact: true }).click();
+        await expect(deleteModal).not.toBeVisible();
+        await expect(page.getByText('FO1/2023', { exact: true })).toBeVisible();
+
+        // Proceed to deletion
+        await deleteBtn.click();
+        await deleteModal.getByRole('button', { name: 'Supprimer', exact: true }).click();
+        await expect(deleteModal).not.toBeVisible();
+        await expect(page.getByText('FO1/2023', { exact: true })).not.toBeVisible();
+    });
+});

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -166,6 +166,10 @@
                 <source>regulation.list.title</source>
                 <target>Arrêtés de circulation</target>
             </trans-unit>
+            <trans-unit id="regulation.delete">
+                <source>regulation.delete</source>
+                <target>Supprimer l'arrêté %identifier%</target>
+            </trans-unit>
             <trans-unit id="regulation.status_badge.draft.text">
                 <source>regulation.status_badge.draft.text</source>
                 <target>Brouillon</target>
@@ -516,7 +520,7 @@
             </trans-unit>
             <trans-unit id="regulation.delete_modal.title">
                 <source>regulation.delete_modal.title</source>
-                <target>Supprimer cette réglementation ?</target>
+                <target>Supprimer cet arrêté ?</target>
             </trans-unit>
             <trans-unit id="location.delete_modal.title">
                 <source>location.delete_modal.title</source>


### PR DESCRIPTION
* Closes #279 

Alternative à #298 qui utilise [Playwright](https://playwright.dev) au lieu de Panther

Avantages de Playwright (informés par le retour d'expérience sur catalogue.data.gouv.fr) :

* Le développement est encore actif
* Plus facile à maintenir, probablement moins flaky, notamment grâce au wait automatique
* L'API d'assertions est plus orientée a11y : on peut sélectionner des éléments par leur texte visible, et vérifier leur comportement "réel" du point de vue utilisateur, plutôt que s'appuyer trop sur des sélecteurs et attributs du DOM. 
* Peut aussi émuler un mobile

Inconvénients

* On peut s'attendre à ce que Microsoft y pousse son écosystème. Par exemple lors de l'installation, on a une suggestion pour configurer GitHub Actions automatiquement (pourquoi pas d'autres CI ?). De même, dans la page [Debugging Tests](https://playwright.dev/docs/debug), VS Code a une place de choix. Cela dit je n'ai rien vu de capturant. On peut toujours faire sans les outils recommandés par Microsoft parce que ce sont les siens. Par exemple, on peut déboguer manuellement, sans avoir besoin de VS Code (qui ne propose qu'une surcouche).

Tests à réaliser : certains sont inclus dans cette PR, les autres peuvent être ajoutés ensuite

* [x] Modale de suppression à partir de la liste
* [x] Comportement des onglets de la liste
* [ ] Blocs éditables
* [ ] Ajout et suppression d'une localisation : le bouton "Publier" doit être activé/désactivé en fonction
* [ ] Publication : le badge doit devenir "Publié" et le bouton "Publier" doit disparaître

Suites possibles

* Réintroduire le pattern [documenté par Symfony](https://symfony.com/bundles/ux-turbo/current/index.html#forms) (le if sur si la requête accepte le format turbo_stream) et voir comment étendre le coverage en le combinant à partir de 3 sources : PHPunit pour les tests unit/integration, PHPunit lors des tests e2e, JS (contrôleurs stimulus) lors des tests e2e