### PR TITLE
Display Symfony error responses instead of "Content missing"

### DIFF
--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -1,4 +1,5 @@
 import { startStimulusApp } from '@symfony/stimulus-bridge';
+import { registerTurboEventHandlers } from './lib';
 
 // Registers Stimulus controllers from controllers.json and in the controllers/ directory
 export const app = startStimulusApp(require.context(
@@ -10,28 +11,4 @@ export const app = startStimulusApp(require.context(
 // register any custom, 3rd party controllers here
 // app.register('some_controller_name', SomeImportedController);
 
-// Register Turbo event handlers
-// See: https://turbo.hotwired.dev/reference/events
-
-document.addEventListener('turbo:frame-missing', (event) => {
-    _displayAnyDebugExceptionPage(event);
-});
-
-const _displayAnyDebugExceptionPage = (event) => {
-    /** @type {Response} */
-    const response = event.detail.response;
-
-    if (response.status !== 500 || !response.headers.has('X-Debug-Exception')) {
-        // Most likely not a Symfony debug error response.
-        return;
-    }
-
-    event.preventDefault();
-
-    response.text().then(html => {
-        document.open();
-        document.write(html);
-        document.close();
-        history.pushState({}, '', response.url);
-    });
-};
+registerTurboEventHandlers();

--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -9,3 +9,29 @@ export const app = startStimulusApp(require.context(
 
 // register any custom, 3rd party controllers here
 // app.register('some_controller_name', SomeImportedController);
+
+// Register Turbo event handlers
+// See: https://turbo.hotwired.dev/reference/events
+
+document.addEventListener('turbo:frame-missing', (event) => {
+    _displayAnyDebugExceptionPage(event);
+});
+
+const _displayAnyDebugExceptionPage = (event) => {
+    /** @type {Response} */
+    const response = event.detail.response;
+
+    if (response.status !== 500 || !response.headers.has('X-Debug-Exception')) {
+        // Most likely not a Symfony debug error response.
+        return;
+    }
+
+    event.preventDefault();
+
+    response.text().then(html => {
+        document.open();
+        document.write(html);
+        document.close();
+        history.pushState({}, '', response.url);
+    });
+};

--- a/assets/lib.js
+++ b/assets/lib.js
@@ -1,0 +1,25 @@
+// See: https://turbo.hotwired.dev/reference/events
+export function registerTurboEventHandlers() {
+    document.addEventListener('turbo:frame-missing', (event) => {
+        _displayAnyDebugExceptionPage(event);
+    });
+}
+
+function _displayAnyDebugExceptionPage(event) {
+    /** @type {Response} */
+    const response = event.detail.response;
+
+    if (response.status !== 500 || !response.headers.has('X-Debug-Exception')) {
+        // Most likely not a Symfony debug error response.
+        return;
+    }
+
+    event.preventDefault();
+
+    response.text().then(html => {
+        document.open();
+        document.write(html);
+        document.close();
+        history.pushState({}, '', response.url);
+    });
+};


### PR DESCRIPTION
Petite amélioration de qualité de vie

En cas d'erreur 500 suite à une requête via Turbo Frames, actuellement on voit juste un message "Content missing" et il faut aller dans la console pour avoir la page de debug Symfony

Cette PR ajoute un listener pour `turbo:frame-missing` (voir [doc Turbo](https://turbo.hotwired.dev/reference/events)) qui affiche le contenu de la réponse

## Pour tester

* Ajouter un `throw new \Exception('Oops')` dans le `UpdateLocationController`
* Cliquer sur "Modifier" une localisation
* Constater l'affichage de la page Symfony habituelle (sur `main`, la zone du bloc éditable de localisation dirait "Content missing")