### PR TITLE
Add, edit and display measure's type to locations

### DIFF
--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -1,4 +1,5 @@
 import { startStimulusApp } from '@symfony/stimulus-bridge';
+import { registerTurboEventHandlers } from './lib';
 
 // Registers Stimulus controllers from controllers.json and in the controllers/ directory
 export const app = startStimulusApp(require.context(
@@ -9,3 +10,5 @@ export const app = startStimulusApp(require.context(
 
 // register any custom, 3rd party controllers here
 // app.register('some_controller_name', SomeImportedController);
+
+registerTurboEventHandlers();

--- a/assets/controllers/form_collection_controller.js
+++ b/assets/controllers/form_collection_controller.js
@@ -5,14 +5,13 @@ export default class extends Controller {
 
     static values = {
         index: Number,
-        prototype:String,
+        prototype: String,
     };
 
     addCollectionElement(_event) {
-        const item = document.createElement('li');
-        item.className = 'app-list-item';
-        item.innerHTML = this.prototypeValue.replace(/__name__/g, this.indexValue);
-        this.collectionContainerTarget.appendChild(item);
+        const el = document.createElement('div');
+        el.innerHTML = this.prototypeValue.replace(/__name__/g, this.indexValue).replace(/__oneBasedIndex__/g, this.indexValue + 1);
+        this.collectionContainerTarget.appendChild(el.children[0]);
         this.indexValue++;
     }
 }

--- a/assets/controllers/form_collection_controller.js
+++ b/assets/controllers/form_collection_controller.js
@@ -1,0 +1,17 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static targets = ['collectionContainer'];
+
+    static values = {
+        index: Number,
+        prototype:String,
+    };
+
+    addCollectionElement(_event) {
+        const item = document.createElement('li');
+        item.innerHTML = this.prototypeValue.replace(/__name__/g, this.indexValue);
+        this.collectionContainerTarget.appendChild(item);
+        this.indexValue++;
+    }
+}

--- a/assets/controllers/form_collection_controller.js
+++ b/assets/controllers/form_collection_controller.js
@@ -10,6 +10,7 @@ export default class extends Controller {
 
     addCollectionElement(_event) {
         const item = document.createElement('li');
+        item.className = 'app-list-item';
         item.innerHTML = this.prototypeValue.replace(/__name__/g, this.indexValue);
         this.collectionContainerTarget.appendChild(item);
         this.indexValue++;

--- a/assets/lib.js
+++ b/assets/lib.js
@@ -1,0 +1,25 @@
+// See: https://turbo.hotwired.dev/reference/events
+export function registerTurboEventHandlers() {
+    document.addEventListener('turbo:frame-missing', (event) => {
+        _displayAnyDebugExceptionPage(event);
+    });
+}
+
+function _displayAnyDebugExceptionPage(event) {
+    /** @type {Response} */
+    const response = event.detail.response;
+
+    if (response.status !== 500 || !response.headers.has('X-Debug-Exception')) {
+        // Most likely not a Symfony debug error response.
+        return;
+    }
+
+    event.preventDefault();
+
+    response.text().then(html => {
+        document.open();
+        document.write(html);
+        document.close();
+        history.pushState({}, '', response.url);
+    });
+};

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -147,12 +147,6 @@ label.required > .fr-x-label-content::after {
     background-color: var(--background-alt-grey);
 }
 
-.app-list {
-    padding: 0;
-    margin: 0;
-    list-style-type: none;
-}
-
 .app-list-item {
     border: 1px solid var(--border-default-grey);
 

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -146,3 +146,17 @@ label.required > .fr-x-label-content::after {
 .app-background--alt-grey {
     background-color: var(--background-alt-grey);
 }
+
+.app-list {
+    padding: 0;
+    margin: 0;
+    list-style-type: none;
+}
+
+.app-list-item {
+    border: 1px solid var(--border-default-grey);
+
+    &:not(:first-child) {
+        border-top: none;
+    }
+}

--- a/config/validator/Application/Regulation/Command/SaveRegulationLocationCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveRegulationLocationCommand.xml
@@ -21,9 +21,6 @@
             </constraint>
        </property>
        <property name="measures">
-            <constraint name="NotBlank">
-                <option name="message">location.measures.error.not_blank</option>
-            </constraint>
             <constraint name="Valid"/>
        </property>
     </class>

--- a/config/validator/Application/Regulation/Command/SaveRegulationLocationCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveRegulationLocationCommand.xml
@@ -19,5 +19,8 @@
                 <option name="max">8</option>
             </constraint>
        </property>
+       <property name="measures">
+            <constraint name="Valid"/>
+       </property>
     </class>
 </constraint-mapping>

--- a/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
+++ b/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
@@ -50,6 +50,7 @@ final class DuplicateRegulationCommandHandler
         RegulationOrder $originalRegulationOrder,
         RegulationOrderRecord $duplicatedRegulationOrderRecord,
     ): void {
+        // todo : duplicate measures
         foreach ($originalRegulationOrder->getLocations() as $location) {
             $locationCommand = new SaveRegulationLocationCommand($duplicatedRegulationOrderRecord);
             $locationCommand->address = $location->getAddress();

--- a/src/Application/Regulation/Command/SaveMeasureCommand.php
+++ b/src/Application/Regulation/Command/SaveMeasureCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\Command;
+
+use App\Application\CommandInterface;
+use App\Domain\Regulation\Location;
+use App\Domain\Regulation\Measure;
+
+final class SaveMeasureCommand implements CommandInterface
+{
+    public ?string $type;
+
+    public function __construct(
+        public readonly Location $location,
+        public readonly ?Measure $measure = null,
+    ) {
+    }
+
+    public static function create(
+        Location $location,
+        Measure $measure = null,
+    ): self
+    {
+        $command = new self($location, $measure);
+        $command->type = $measure->type;
+        return $command;
+    }
+}

--- a/src/Application/Regulation/Command/SaveMeasureCommand.php
+++ b/src/Application/Regulation/Command/SaveMeasureCommand.php
@@ -16,16 +16,7 @@ final class SaveMeasureCommand implements CommandInterface
     public function __construct(
         public readonly ?Measure $measure = null,
     ) {
-    }
-
-    public static function create(
-        ?Location $location = null,
-        ?Measure $measure = null,
-    ): self {
-        $command = new self($measure);
-        $command->location = $location;
-        $command->type = $measure?->getType();
-
-        return $command;
+        $this->location = $measure?->getLocation();
+        $this->type = $measure?->getType();
     }
 }

--- a/src/Application/Regulation/Command/SaveMeasureCommand.php
+++ b/src/Application/Regulation/Command/SaveMeasureCommand.php
@@ -6,25 +6,9 @@ namespace App\Application\Regulation\Command;
 
 use App\Application\CommandInterface;
 use App\Domain\Regulation\Location;
-use App\Domain\Regulation\Measure;
 
 final class SaveMeasureCommand implements CommandInterface
 {
     public ?string $type;
-
-    public function __construct(
-        public readonly Location $location,
-        public readonly ?Measure $measure = null,
-    ) {
-    }
-
-    public static function create(
-        Location $location,
-        Measure $measure = null,
-    ): self
-    {
-        $command = new self($location, $measure);
-        $command->type = $measure->type;
-        return $command;
-    }
+    public ?Location $location;
 }

--- a/src/Application/Regulation/Command/SaveMeasureCommand.php
+++ b/src/Application/Regulation/Command/SaveMeasureCommand.php
@@ -6,9 +6,26 @@ namespace App\Application\Regulation\Command;
 
 use App\Application\CommandInterface;
 use App\Domain\Regulation\Location;
+use App\Domain\Regulation\Measure;
 
 final class SaveMeasureCommand implements CommandInterface
 {
     public ?string $type;
     public ?Location $location;
+
+    public function __construct(
+        public readonly ?Measure $measure = null,
+    ) {
+    }
+
+    public static function create(
+        ?Location $location = null,
+        ?Measure $measure = null,
+    ): self {
+        $command = new self($measure);
+        $command->location = $location;
+        $command->type = $measure?->getType();
+
+        return $command;
+    }
 }

--- a/src/Application/Regulation/Command/SaveMeasureCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveMeasureCommandHandler.php
@@ -18,6 +18,12 @@ final class SaveMeasureCommandHandler
 
     public function __invoke(SaveMeasureCommand $command): Measure
     {
+        if ($command->measure) {
+            $command->measure->update($command->type);
+
+            return $command->measure;
+        }
+
         return $this->measureRepository->add(
             new Measure(
                 uuid: $this->idFactory->make(),

--- a/src/Application/Regulation/Command/SaveMeasureCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveMeasureCommandHandler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\Command;
+
+use App\Application\IdFactoryInterface;
+use App\Domain\Regulation\Measure;
+use App\Domain\Regulation\Repository\MeasureRepositoryInterface;
+
+final class SaveMeasureCommandHandler
+{
+    public function __construct(
+        private IdFactoryInterface $idFactory,
+        private MeasureRepositoryInterface $measureRepository,
+    ) {
+    }
+
+    public function __invoke(SaveMeasureCommand $command): Measure
+    {
+        return $this->measureRepository->add(
+            new Measure(
+                uuid: $this->idFactory->make(),
+                location: $command->location,
+                type: $command->type,
+            ),
+        );
+    }
+}

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
@@ -34,7 +34,7 @@ final class SaveRegulationLocationCommand implements CommandInterface
             foreach ($location->getMeasures() as $measure) {
                 array_push(
                     $command->measures,
-                    SaveMeasureCommand::create($location, $measure),
+                    new SaveMeasureCommand($measure),
                 );
             }
         }

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
@@ -13,7 +13,7 @@ final class SaveRegulationLocationCommand implements CommandInterface
     public ?string $address;
     public ?string $fromHouseNumber;
     public ?string $toHouseNumber;
-    public ?iterable $measures;
+    public array $measures = [];
 
     public function __construct(
         public readonly RegulationOrderRecord $regulationOrderRecord,
@@ -26,10 +26,18 @@ final class SaveRegulationLocationCommand implements CommandInterface
         Location $location = null,
     ): self {
         $command = new self($regulationOrderRecord, $location);
-
         $command->address = $location?->getAddress();
         $command->fromHouseNumber = $location?->getFromHouseNumber();
         $command->toHouseNumber = $location?->getToHouseNumber();
+
+        if ($location) {
+            foreach ($location->getMeasures() as $measure) {
+                array_push(
+                    $command->measures,
+                    SaveMeasureCommand::create($location, $measure),
+                );
+            }
+        }
 
         return $command;
     }

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
@@ -13,6 +13,7 @@ final class SaveRegulationLocationCommand implements CommandInterface
     public ?string $address;
     public ?string $fromHouseNumber;
     public ?string $toHouseNumber;
+    public ?iterable $measures;
 
     public function __construct(
         public readonly RegulationOrderRecord $regulationOrderRecord,
@@ -30,6 +31,19 @@ final class SaveRegulationLocationCommand implements CommandInterface
         $command->fromHouseNumber = $location?->getFromHouseNumber();
         $command->toHouseNumber = $location?->getToHouseNumber();
 
+        $measures = [];
+
+        foreach ($location?->getMeasures() as $measure) {
+            $measures[] = SaveMeasureCommand::create($location, $measure);
+        }
+
+        $command->measures = $measures;
+
         return $command;
+    }
+
+    public function addMeasure(SaveMeasureCommand $measure): void
+    {
+        array_push($this->measures, $measure);
     }
 }

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
@@ -31,19 +31,6 @@ final class SaveRegulationLocationCommand implements CommandInterface
         $command->fromHouseNumber = $location?->getFromHouseNumber();
         $command->toHouseNumber = $location?->getToHouseNumber();
 
-        $measures = [];
-
-        /*foreach ($location?->getMeasures() as $measure) {
-            $measures[] = SaveMeasureCommand::create($location, $measure);
-        }*/
-
-        $command->measures = $measures;
-
         return $command;
-    }
-
-    public function addMeasure(SaveMeasureCommand $measure): void
-    {
-        array_push($this->measures, $measure);
     }
 }

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
@@ -33,9 +33,9 @@ final class SaveRegulationLocationCommand implements CommandInterface
 
         $measures = [];
 
-        foreach ($location?->getMeasures() as $measure) {
+        /*foreach ($location?->getMeasures() as $measure) {
             $measures[] = SaveMeasureCommand::create($location, $measure);
-        }
+        }*/
 
         $command->measures = $measures;
 

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommandHandler.php
@@ -53,9 +53,10 @@ final class SaveRegulationLocationCommandHandler
                 ),
             );
 
-            foreach ($command->measures as $measureCmd) {
-                $measureCmd->location = $location;
-                $this->commandBus->handle($measureCmd);
+            foreach ($command->measures as $measureCommand) {
+                $measureCommand->location = $location;
+                $measure = $this->commandBus->handle($measureCommand);
+                $location->addMeasure($measure);
             }
 
             return $location->getUuid();

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommandHandler.php
@@ -10,7 +10,6 @@ use App\Application\IdFactoryInterface;
 use App\Domain\Geography\GeometryFormatter;
 use App\Domain\Regulation\Location;
 use App\Domain\Regulation\Repository\LocationRepositoryInterface;
-use App\Domain\Regulation\Repository\MeasureRepositoryInterface;
 
 final class SaveRegulationLocationCommandHandler
 {
@@ -18,7 +17,6 @@ final class SaveRegulationLocationCommandHandler
         private IdFactoryInterface $idFactory,
         private CommandBusInterface $commandBus,
         private LocationRepositoryInterface $locationRepository,
-        private MeasureRepositoryInterface $measureRepository,
         private GeocoderInterface $geocoder,
         private GeometryFormatter $geometryFormatter,
     ) {

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommandHandler.php
@@ -80,6 +80,10 @@ final class SaveRegulationLocationCommandHandler
             $toPoint = $command->location->getToPoint();
         }
 
+        foreach ($command->measures as $measureCommand) {
+            $this->commandBus->handle($measureCommand);
+        }
+
         $command->location->update(
             address: $command->address,
             fromHouseNumber: $command->fromHouseNumber,

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommandHandler.php
@@ -76,6 +76,7 @@ final class SaveRegulationLocationCommandHandler
             fromPoint: $fromPoint,
             toHouseNumber: $command->toHouseNumber,
             toPoint: $toPoint,
+            measures: $command->measureCommands,
         );
 
         return $command->location->getUuid();

--- a/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Application\Regulation\Query;
 
 use App\Application\Regulation\View\DetailLocationView;
+use App\Application\Regulation\View\MeasureView;
 use App\Application\Regulation\View\RegulationOrderRecordSummaryView;
 use App\Domain\Regulation\Exception\RegulationOrderRecordNotFoundException;
 use App\Domain\Regulation\LocationAddress;
@@ -27,33 +28,45 @@ final class GetRegulationOrderRecordSummaryQueryHandler
             throw new RegulationOrderRecordNotFoundException();
         }
 
-        $locations = [];
+        $locationViews = [];
+
         foreach ($row as $regulationOrder) {
             if (empty($regulationOrder['locationUuid'])) {
                 continue;
             }
 
-            $locations[] = new DetailLocationView(
+            if (array_key_exists($regulationOrder['locationUuid'], $locationViews)) {
+                array_push(
+                    $locationViews[$regulationOrder['locationUuid']]->measures,
+                    new MeasureView($regulationOrder['type'])
+                );
+
+                continue;
+            }
+
+            $locationViews[$regulationOrder['locationUuid']] = new DetailLocationView(
                 $regulationOrder['locationUuid'],
                 LocationAddress::fromString($regulationOrder['address']),
                 $regulationOrder['fromHouseNumber'],
                 $regulationOrder['toHouseNumber'],
-                [],
+                [
+                    new MeasureView($regulationOrder['type']),
+                ],
             );
         }
 
         $row = current($row);
 
         return new RegulationOrderRecordSummaryView(
-            $row['uuid'],
-            $row['identifier'],
-            $row['organizationUuid'],
-            $row['organizationName'],
-            $row['status'],
-            $row['description'],
-            $locations,
-            $row['startDate'],
-            $row['endDate'],
+            uuid: $row['uuid'],
+            identifier: $row['identifier'],
+            organizationUuid: $row['organizationUuid'],
+            organizationName: $row['organizationName'],
+            status: $row['status'],
+            description: $row['description'],
+            locations: $locationViews,
+            startDate: $row['startDate'],
+            endDate: $row['endDate'],
         );
     }
 }

--- a/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
@@ -38,6 +38,7 @@ final class GetRegulationOrderRecordSummaryQueryHandler
                 LocationAddress::fromString($regulationOrder['address']),
                 $regulationOrder['fromHouseNumber'],
                 $regulationOrder['toHouseNumber'],
+                [],
             );
         }
 

--- a/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
@@ -35,10 +35,10 @@ final class GetRegulationOrderRecordSummaryQueryHandler
                 continue;
             }
 
-            if (array_key_exists($regulationOrder['locationUuid'], $locationViews)) {
+            if (\array_key_exists($regulationOrder['locationUuid'], $locationViews)) {
                 array_push(
                     $locationViews[$regulationOrder['locationUuid']]->measures,
-                    new MeasureView($regulationOrder['type'])
+                    new MeasureView($regulationOrder['type']),
                 );
 
                 continue;
@@ -49,9 +49,9 @@ final class GetRegulationOrderRecordSummaryQueryHandler
                 LocationAddress::fromString($regulationOrder['address']),
                 $regulationOrder['fromHouseNumber'],
                 $regulationOrder['toHouseNumber'],
-                [
+                $regulationOrder['type'] ? [
                     new MeasureView($regulationOrder['type']),
-                ],
+                ] : null,
             );
         }
 

--- a/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandler.php
@@ -38,7 +38,7 @@ final class GetRegulationOrderRecordSummaryQueryHandler
             if (\array_key_exists($regulationOrder['locationUuid'], $locationViews)) {
                 array_push(
                     $locationViews[$regulationOrder['locationUuid']]->measures,
-                    new MeasureView($regulationOrder['type']),
+                    new MeasureView($regulationOrder['measureType']),
                 );
 
                 continue;
@@ -49,8 +49,8 @@ final class GetRegulationOrderRecordSummaryQueryHandler
                 LocationAddress::fromString($regulationOrder['address']),
                 $regulationOrder['fromHouseNumber'],
                 $regulationOrder['toHouseNumber'],
-                $regulationOrder['type'] ? [
-                    new MeasureView($regulationOrder['type']),
+                $regulationOrder['measureType'] ? [
+                    new MeasureView($regulationOrder['measureType']),
                 ] : null,
             );
         }

--- a/src/Application/Regulation/View/DetailLocationView.php
+++ b/src/Application/Regulation/View/DetailLocationView.php
@@ -14,7 +14,7 @@ class DetailLocationView
         public readonly LocationAddress $address,
         public readonly ?string $fromHouseNumber,
         public readonly ?string $toHouseNumber,
-        public readonly ?iterable $measures,
+        public ?array $measures,
     ) {
     }
 
@@ -23,7 +23,9 @@ class DetailLocationView
         $measures = [];
 
         foreach($location->getMeasures() as $measure) {
-            $measures[] = new MeasureView($measure->getType());
+            $measures[] = new MeasureView(
+                $measure->getType(),
+            );
         }
 
         return new self(

--- a/src/Application/Regulation/View/DetailLocationView.php
+++ b/src/Application/Regulation/View/DetailLocationView.php
@@ -14,16 +14,23 @@ class DetailLocationView
         public readonly LocationAddress $address,
         public readonly ?string $fromHouseNumber,
         public readonly ?string $toHouseNumber,
+        public readonly ?iterable $measures, 
     ) {
     }
 
     public static function fromEntity(Location $location): self
     {
+        $measures=[];
+        foreach($location->getMeasures() as $measure)
+        {
+            $measures[]= new MeasureView($measure->getType());
+        }
         return new self(
             uuid: $location->getUuid(),
             address: LocationAddress::fromString($location->getAddress()),
             fromHouseNumber: $location->getFromHouseNumber(),
             toHouseNumber: $location->getToHouseNumber(),
+            measures: $measures,
         );
     }
 }

--- a/src/Application/Regulation/View/DetailLocationView.php
+++ b/src/Application/Regulation/View/DetailLocationView.php
@@ -22,7 +22,7 @@ class DetailLocationView
     {
         $measures = [];
 
-        foreach($location->getMeasures() as $measure) {
+        foreach ($location->getMeasures() as $measure) {
             $measures[] = new MeasureView(
                 $measure->getType(),
             );

--- a/src/Application/Regulation/View/DetailLocationView.php
+++ b/src/Application/Regulation/View/DetailLocationView.php
@@ -14,17 +14,18 @@ class DetailLocationView
         public readonly LocationAddress $address,
         public readonly ?string $fromHouseNumber,
         public readonly ?string $toHouseNumber,
-        public readonly ?iterable $measures, 
+        public readonly ?iterable $measures,
     ) {
     }
 
     public static function fromEntity(Location $location): self
     {
-        $measures=[];
-        foreach($location->getMeasures() as $measure)
-        {
-            $measures[]= new MeasureView($measure->getType());
+        $measures = [];
+
+        foreach($location->getMeasures() as $measure) {
+            $measures[] = new MeasureView($measure->getType());
         }
+
         return new self(
             uuid: $location->getUuid(),
             address: LocationAddress::fromString($location->getAddress()),

--- a/src/Application/Regulation/View/MeasureView.php
+++ b/src/Application/Regulation/View/MeasureView.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\View;
+
+class MeasureView
+{
+    public function __construct(
+        public readonly string $type,
+    ) {
+    }
+}

--- a/src/Domain/Regulation/Enum/MeasureTypeEnum.php
+++ b/src/Domain/Regulation/Enum/MeasureTypeEnum.php
@@ -16,7 +16,7 @@ enum MeasureTypeEnum: string
         $choices = [];
 
         foreach ($values as $value) {
-            $choices[sprintf('measures.types.%s', $value)] = $value;
+            $choices[sprintf('regulation.measure.type.%s', $value)] = $value;
         }
 
         return $choices;

--- a/src/Domain/Regulation/Enum/MeasureTypeEnum.php
+++ b/src/Domain/Regulation/Enum/MeasureTypeEnum.php
@@ -6,7 +6,19 @@ namespace App\Domain\Regulation\Enum;
 
 enum MeasureTypeEnum: string
 {
-    public const NO_ENTRY = 'noEntry';
-    public const ALTERNATE_ROAD = 'alternateRoad';
-    public const ONE_WAY_TRAFFIC = 'oneWayTraffic';
+    case NO_ENTRY = 'noEntry';
+    case ALTERNATE_ROAD = 'alternateRoad';
+    case ONE_WAY_TRAFFIC = 'oneWayTraffic';
+
+    public static function getFormChoices(): array
+    {
+        $values = array_column(self::cases(), 'value');
+        $choices = [];
+
+        foreach ($values as $value) {
+            $choices[sprintf('measures.types.%s', $value)] = $value;
+        }
+
+        return $choices;
+    }
 }

--- a/src/Domain/Regulation/Enum/MeasureTypeEnum.php
+++ b/src/Domain/Regulation/Enum/MeasureTypeEnum.php
@@ -9,16 +9,4 @@ enum MeasureTypeEnum: string
     case NO_ENTRY = 'noEntry';
     case ALTERNATE_ROAD = 'alternateRoad';
     case ONE_WAY_TRAFFIC = 'oneWayTraffic';
-
-    public static function getFormChoices(): array
-    {
-        $values = array_column(self::cases(), 'value');
-        $choices = [];
-
-        foreach ($values as $value) {
-            $choices[sprintf('regulation.measure.type.%s', $value)] = $value;
-        }
-
-        return $choices;
-    }
 }

--- a/src/Domain/Regulation/Location.php
+++ b/src/Domain/Regulation/Location.php
@@ -65,13 +65,11 @@ class Location
         ?string $fromPoint,
         ?string $toHouseNumber,
         ?string $toPoint,
-        ?array $measures,
     ): void {
         $this->address = $address;
         $this->fromHouseNumber = $fromHouseNumber;
         $this->fromPoint = $fromPoint;
         $this->toHouseNumber = $toHouseNumber;
         $this->toPoint = $toPoint;
-        $this->measures = $measures;
     }
 }

--- a/src/Domain/Regulation/Location.php
+++ b/src/Domain/Regulation/Location.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace App\Domain\Regulation;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
+
 class Location
 {
-    private iterable $measures = [];
+    private Collection $measures;
 
     public function __construct(
         private string $uuid,
@@ -17,6 +20,7 @@ class Location
         private ?string $toHouseNumber,
         private ?string $toPoint,
     ) {
+        $this->measures = new ArrayCollection();
     }
 
     public function getUuid(): string
@@ -57,6 +61,15 @@ class Location
     public function getMeasures(): iterable
     {
         return $this->measures;
+    }
+
+    public function addMeasure(Measure $measure): void
+    {
+        if ($this->measures->contains($measure)) {
+            return;
+        }
+
+        $this->measures->add($measure);
     }
 
     public function update(

--- a/src/Domain/Regulation/Location.php
+++ b/src/Domain/Regulation/Location.php
@@ -65,11 +65,13 @@ class Location
         ?string $fromPoint,
         ?string $toHouseNumber,
         ?string $toPoint,
+        ?array $measures,
     ): void {
         $this->address = $address;
         $this->fromHouseNumber = $fromHouseNumber;
         $this->fromPoint = $fromPoint;
         $this->toHouseNumber = $toHouseNumber;
         $this->toPoint = $toPoint;
+        $this->measures = $measures;
     }
 }

--- a/src/Domain/Regulation/Measure.php
+++ b/src/Domain/Regulation/Measure.php
@@ -34,4 +34,9 @@ class Measure
     {
         return $this->conditions;
     }
+
+    public function update(string $type): void
+    {
+        $this->type = $type;
+    }
 }

--- a/src/Domain/Regulation/Measure.php
+++ b/src/Domain/Regulation/Measure.php
@@ -30,11 +30,6 @@ class Measure
         return $this->location;
     }
 
-    public function setLocation(Location $location): void
-    {
-        $this->location = $location;
-    }
-
     public function getConditions(): iterable
     {
         return $this->conditions;

--- a/src/Domain/Regulation/Measure.php
+++ b/src/Domain/Regulation/Measure.php
@@ -30,6 +30,11 @@ class Measure
         return $this->location;
     }
 
+    public function setLocation(Location $location): void
+    {
+        $this->location = $location;
+    }
+
     public function getConditions(): iterable
     {
         return $this->conditions;

--- a/src/Domain/Regulation/Repository/MeasureRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/MeasureRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Regulation\Repository;
+
+use App\Domain\Regulation\Measure;
+
+interface MeasureRepositoryInterface
+{
+    public function add(Measure $measure): Measure;
+}

--- a/src/Infrastructure/Controller/Regulation/Fragments/AddLocationController.php
+++ b/src/Infrastructure/Controller/Regulation/Fragments/AddLocationController.php
@@ -52,6 +52,7 @@ final class AddLocationController extends AbstractRegulationController
             'action' => $this->router->generate('fragment_regulations_location_add', ['uuid' => $uuid]),
         ]);
         $form->handleRequest($request);
+        dd($command);
         $commandFailed = false;
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Infrastructure/Controller/Regulation/Fragments/AddLocationController.php
+++ b/src/Infrastructure/Controller/Regulation/Fragments/AddLocationController.php
@@ -52,7 +52,6 @@ final class AddLocationController extends AbstractRegulationController
             'action' => $this->router->generate('fragment_regulations_location_add', ['uuid' => $uuid]),
         ]);
         $form->handleRequest($request);
-        dd($command);
         $commandFailed = false;
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Infrastructure/Form/Regulation/LocationFormType.php
+++ b/src/Infrastructure/Form/Regulation/LocationFormType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\Form\Regulation;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -38,6 +39,13 @@ final class LocationFormType extends AbstractType
                     'label' => 'regulation.location.to_house_number',
                 ],
             )
+            ->add('measures', CollectionType::class, [
+                'entry_type' => MeasureFormType::class,
+                'entry_options' => ['label' => false],
+                'allow_add' => true,
+                'by_reference' => false,
+                'block_name' => 'measures',
+            ])
             ->add(
                 'save',
                 SubmitType::class,

--- a/src/Infrastructure/Form/Regulation/LocationFormType.php
+++ b/src/Infrastructure/Form/Regulation/LocationFormType.php
@@ -43,7 +43,6 @@ final class LocationFormType extends AbstractType
                 'entry_type' => MeasureFormType::class,
                 'entry_options' => ['label' => false],
                 'allow_add' => true,
-                'by_reference' => false,
                 'block_name' => 'measures',
             ])
             ->add(

--- a/src/Infrastructure/Form/Regulation/LocationFormType.php
+++ b/src/Infrastructure/Form/Regulation/LocationFormType.php
@@ -42,7 +42,7 @@ final class LocationFormType extends AbstractType
             ->add('measures', CollectionType::class, [
                 'entry_type' => MeasureFormType::class,
                 'entry_options' => ['label' => false],
-                'label' => false,
+                'label' => 'regulation.measure_list',
                 'allow_add' => true,
             ])
             ->add(

--- a/src/Infrastructure/Form/Regulation/MeasureFormType.php
+++ b/src/Infrastructure/Form/Regulation/MeasureFormType.php
@@ -23,6 +23,9 @@ final class MeasureFormType extends AbstractType
                     'choices' => MeasureTypeEnum::getFormChoices(),
                     'label' => 'measure.type',
                     'help' => 'measure.type.help',
+                    'attr' => [
+                        'class' => 'fr-select',
+                    ],
                 ],
             )
         ;

--- a/src/Infrastructure/Form/Regulation/MeasureFormType.php
+++ b/src/Infrastructure/Form/Regulation/MeasureFormType.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Form\Regulation;
 
+use App\Application\Regulation\Command\SaveMeasureCommand;
 use App\Domain\Regulation\Enum\MeasureTypeEnum;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class MeasureFormType extends AbstractType
 {
@@ -19,10 +21,17 @@ final class MeasureFormType extends AbstractType
                 ChoiceType::class,
                 options: [
                     'choices' => MeasureTypeEnum::getFormChoices(),
-                    'label' => 'regulation.measure.type',
-                    'help' => 'regulation.measure.type.help',
+                    'label' => 'measure.type',
+                    'help' => 'measure.type.help',
                 ],
             )
         ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => SaveMeasureCommand::class,
+        ]);
     }
 }

--- a/src/Infrastructure/Form/Regulation/MeasureFormType.php
+++ b/src/Infrastructure/Form/Regulation/MeasureFormType.php
@@ -4,14 +4,10 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Form\Regulation;
 
-use App\Application\Regulation\Command\SaveMeasureCommand;
 use App\Domain\Regulation\Enum\MeasureTypeEnum;
-use App\Domain\Regulation\Measure;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
-use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class MeasureFormType extends AbstractType
 {
@@ -19,28 +15,14 @@ final class MeasureFormType extends AbstractType
     {
         $builder
             ->add(
-                'measureType',
+                'type',
                 ChoiceType::class,
                 options: [
-                    'choices' => array_column(MeasureTypeEnum::cases(), 'value'),
+                    'choices' => MeasureTypeEnum::getFormChoices(),
                     'label' => 'regulation.measure.type',
                     'help' => 'regulation.measure.type.help',
                 ],
             )
-            ->add(
-                'save',
-                SubmitType::class,
-                options: [
-                    'label' => 'common.form.validate',
-                ],
-            )
         ;
-    }
-
-    public function configureOptions(OptionsResolver $resolver): void
-    {
-        $resolver->setDefaults([
-            'data_class' => SaveMeasureCommand::class,
-        ]);
     }
 }

--- a/src/Infrastructure/Form/Regulation/MeasureFormType.php
+++ b/src/Infrastructure/Form/Regulation/MeasureFormType.php
@@ -19,13 +19,27 @@ final class MeasureFormType extends AbstractType
             ->add(
                 'type',
                 ChoiceType::class,
-                options: [
-                    'choices' => MeasureTypeEnum::getFormChoices(),
-                    'label' => 'regulation.measure.type',
-                    'help' => 'regulation.measure.type.help',
-                ],
+                options: $this->getTypeOptions(),
             )
         ;
+    }
+
+    private function getTypeOptions(): array
+    {
+        $choices = [];
+
+        foreach (MeasureTypeEnum::cases() as $case) {
+            $choices[sprintf('regulation.measure.type.%s', $case->value)] = $case->value;
+        }
+
+        return [
+            'choices' => array_merge(
+                ['regulation.measure.type.placeholder' => ''],
+                $choices,
+            ),
+            'label' => 'regulation.measure.type',
+            'help' => 'regulation.measure.type.help',
+        ];
     }
 
     public function configureOptions(OptionsResolver $resolver): void

--- a/src/Infrastructure/Form/Regulation/MeasureFormType.php
+++ b/src/Infrastructure/Form/Regulation/MeasureFormType.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Form\Regulation;
+
+use App\Application\Regulation\Command\SaveMeasureCommand;
+use App\Domain\Regulation\Enum\MeasureTypeEnum;
+use App\Domain\Regulation\Measure;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class MeasureFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(
+                'measureType',
+                ChoiceType::class,
+                options: [
+                    'choices' => array_column(MeasureTypeEnum::cases(), 'value'),
+                    'label' => 'regulation.measure.type',
+                    'help' => 'regulation.measure.type.help',
+                ],
+            )
+            ->add(
+                'save',
+                SubmitType::class,
+                options: [
+                    'label' => 'common.form.validate',
+                ],
+            )
+        ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'data_class' => SaveMeasureCommand::class,
+        ]);
+    }
+}

--- a/src/Infrastructure/Form/Regulation/MeasureFormType.php
+++ b/src/Infrastructure/Form/Regulation/MeasureFormType.php
@@ -21,11 +21,8 @@ final class MeasureFormType extends AbstractType
                 ChoiceType::class,
                 options: [
                     'choices' => MeasureTypeEnum::getFormChoices(),
-                    'label' => 'measure.type',
-                    'help' => 'measure.type.help',
-                    'attr' => [
-                        'class' => 'fr-select',
-                    ],
+                    'label' => 'regulation.measure.type',
+                    'help' => 'regulation.measure.type.help',
                 ],
             )
         ;

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
@@ -22,6 +22,6 @@
     <many-to-one field="regulationOrder" target-entity="App\Domain\Regulation\RegulationOrder" inversed-by="locations">
         <join-column name="regulation_order_uuid" referenced-column-name="uuid" on-delete="CASCADE"/>
     </many-to-one>
-    <one-to-many field="measures" target-entity="App\Domain\Regulation\Measure" mapped-by="location" />
+    <one-to-many field="measures" target-entity="App\Domain\Regulation\Measure" mapped-by="location" fetch="EAGER"/>
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
@@ -22,6 +22,6 @@
     <many-to-one field="regulationOrder" target-entity="App\Domain\Regulation\RegulationOrder" inversed-by="locations">
         <join-column name="regulation_order_uuid" referenced-column-name="uuid" on-delete="CASCADE"/>
     </many-to-one>
-    <one-to-many field="measures" target-entity="App\Domain\Regulation\Measure" mapped-by="location" fetch="EAGER"/>
+    <one-to-many field="measures" target-entity="App\Domain\Regulation\Measure" mapped-by="location"/>
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
@@ -22,6 +22,10 @@
     <many-to-one field="regulationOrder" target-entity="App\Domain\Regulation\RegulationOrder" inversed-by="locations">
         <join-column name="regulation_order_uuid" referenced-column-name="uuid" on-delete="CASCADE"/>
     </many-to-one>
-    <one-to-many field="measures" target-entity="App\Domain\Regulation\Measure" mapped-by="location"/>
+    <one-to-many field="measures" target-entity="App\Domain\Regulation\Measure" mapped-by="location">
+      <cascade>
+        <cascade-persist />
+      </cascade>
+    </one-to-many>
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
@@ -22,10 +22,6 @@
     <many-to-one field="regulationOrder" target-entity="App\Domain\Regulation\RegulationOrder" inversed-by="locations">
         <join-column name="regulation_order_uuid" referenced-column-name="uuid" on-delete="CASCADE"/>
     </many-to-one>
-    <one-to-many field="measures" target-entity="App\Domain\Regulation\Measure" mapped-by="location">
-      <cascade>
-        <cascade-persist />
-      </cascade>
-    </one-to-many>
+    <one-to-many field="measures" target-entity="App\Domain\Regulation\Measure" mapped-by="location" />
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
@@ -33,7 +33,7 @@ final class LocationRepository extends ServiceEntityRepository implements Locati
         return $this->createQueryBuilder('loc')
             ->where('loc.uuid = :uuid')
             ->innerJoin('loc.regulationOrder', 'ro')
-            ->leftJoin('loc.measures','measure')
+            ->leftJoin('loc.measures', 'measure')
             ->setParameter('uuid', $uuid)
             ->setMaxResults(1)
             ->getQuery()

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
@@ -33,6 +33,7 @@ final class LocationRepository extends ServiceEntityRepository implements Locati
         return $this->createQueryBuilder('loc')
             ->where('loc.uuid = :uuid')
             ->innerJoin('loc.regulationOrder', 'ro')
+            ->leftJoin('loc.measures','measure')
             ->setParameter('uuid', $uuid)
             ->setMaxResults(1)
             ->getQuery()

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/MeasureRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/MeasureRepository.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Repository\Regulation;
+
+use App\Domain\Regulation\Measure;
+use App\Domain\Regulation\Repository\MeasureRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class MeasureRepository extends ServiceEntityRepository implements MeasureRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Measure::class);
+    }
+
+    public function add(Measure $measure): Measure
+    {
+        $this->getEntityManager()->persist($measure);
+
+        return $measure;
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -56,6 +56,8 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->setParameter('uuid', $uuid)
             ->innerJoin('roc.regulationOrder', 'ro')
             ->innerJoin('roc.organization', 'o')
+            ->leftJoin('ro.locations', 'l')
+            ->leftJoin('l.measures', 'm')
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult()
@@ -78,7 +80,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
                 'l.address',
                 'l.fromHouseNumber',
                 'l.toHouseNumber',
-                'm.type',
+                'm.type as measureType',
             )
             ->where('roc.uuid = :uuid')
             ->setParameter('uuid', $uuid)

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -78,12 +78,14 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
                 'l.address',
                 'l.fromHouseNumber',
                 'l.toHouseNumber',
+                'm.type',
             )
             ->where('roc.uuid = :uuid')
             ->setParameter('uuid', $uuid)
             ->innerJoin('roc.organization', 'org')
             ->innerJoin('roc.regulationOrder', 'ro')
             ->leftJoin('ro.locations', 'l')
+            ->leftJoin('l.measures', 'm')
             ->getQuery()
             ->getResult()
         ;

--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -73,7 +73,11 @@
                                     </li>
                                 {% endif %}
                                 <li>
-                                    <button class="fr-btn fr-btn--secondary" disabled>Dupliquer</button>
+                                    {% set duplicateCsrfToken = csrf_token('duplicate-regulation') %}
+                                    <form method="post" action="{{ path('app_regulation_duplicate', { uuid: regulationOrderRecord.uuid })}}">
+                                        <button class="fr-btn fr-btn--secondary" title="{{ 'common.duplicate'|trans }}">{{ 'common.duplicate'|trans }}</button>
+                                        <input type="hidden" name="token" value="{{ duplicateCsrfToken }}"/>
+                                    </form>
                                 </li>
                                 <li>
                                     <button class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-delete-bin-line" disabled>Supprimer</button>

--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -28,24 +28,27 @@
                         {% include "regulation/fragments/_general_info.html.twig" with { 'canEdit': isDraft, regulationOrderRecord } only %}
                     </div>
 
-                    <h3 class="fr-h5 fr-text--default-grey fr-mt-5w">
-                        {{ 'regulation.locations'|trans }}
-                    </h3>
+                    <section aria-labelledby="locations-title">
+                        <h3 id="locations-title" class="fr-h5 fr-text--default-grey fr-mt-5w">
+                            {{ 'regulation.locations'|trans }}
+                        </h3>
 
-                    <ul id="location_list" class="fr-raw-list">
-                        {% for location in regulationOrderRecord.locations %}
-                            <li class="fr-mx-n4v fr-mx-md-0">
-                                {% include "regulation/fragments/_location.html.twig" with { location, regulationOrderRecord, canDelete } only %}
-                            </li>
-                        {% endfor %}
-                    </ul>
-                    {% if isDraft %}
-                        {% if regulationOrderRecord.locations|length > 0 %}
-                            {% include "regulation/fragments/_add_location_link.html.twig" with { regulationOrderRecordUuid: regulationOrderRecord.uuid } only %}
-                        {% else %}
-                            {{ render(path('fragment_regulations_location_add', { uuid: regulationOrderRecord.uuid })) }}
+                        <ul id="location_list" class="fr-raw-list">
+                            {% for location in regulationOrderRecord.locations %}
+                                <li class="fr-mx-n4v fr-mx-md-0">
+                                    {% include "regulation/fragments/_location.html.twig" with { location, regulationOrderRecord, canDelete } only %}
+                                </li>
+                            {% endfor %}
+                        </ul>
+
+                        {% if isDraft %}
+                            {% if regulationOrderRecord.locations|length > 0 %}
+                                {% include "regulation/fragments/_add_location_link.html.twig" with { regulationOrderRecordUuid: regulationOrderRecord.uuid } only %}
+                            {% else %}
+                                {{ render(path('fragment_regulations_location_add', { uuid: regulationOrderRecord.uuid })) }}
+                            {% endif %}
                         {% endif %}
-                    {% endif %}
+                    </section>
                 </div>
 
                 <aside class="fr-col">

--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -80,7 +80,25 @@
                                     </form>
                                 </li>
                                 <li>
-                                    <button class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-delete-bin-line" disabled>Supprimer</button>
+                                    {% set deleteCsrfToken = csrf_token('delete-regulation') %}
+                                    <form
+                                        method="delete"
+                                        action="{{ path('app_regulation_delete', { uuid: regulationOrderRecord.uuid }) }}"
+                                        data-controller="form-submit"
+                                        data-action="modal-trigger:submit->form-submit#submit"
+                                    >
+                                        <button
+                                            class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-delete-bin-line"
+                                            data-controller="modal-trigger"
+                                            data-modal-trigger-modal-outlet="#regulation-delete-modal"
+                                            data-modal-trigger-key-value="delete"
+                                            data-action="modal-trigger#showModal:prevent"
+                                            aria-controls="regulation-delete-modal"
+                                        >
+                                            {{'common.delete'|trans}}
+                                        </button>
+                                        <input type="hidden" name="token" value="{{ deleteCsrfToken }}" />
+                                    </form>
                                 </li>
                             </ul>
                         </div>
@@ -90,11 +108,12 @@
         </div>
     </section>
 {% endblock %}
-{% block body_end %}
-{{ parent() }}
 
-{% if isDraft %}
-    {% include "common/confirmation_modal.html.twig" with {
+{% block body_end %}
+    {{ parent() }}
+
+    {% if isDraft %}
+        {% include "common/confirmation_modal.html.twig" with {
             id: 'regulation-publish-modal',
             title: 'regulation.publish_modal.title'|trans,
             confirmLabel: 'common.publish'|trans,
@@ -106,4 +125,11 @@
             confirmLabel: 'common.delete'|trans,
             cancelLabel: 'common.do_not_delete'|trans,
         } only %}
-{% endif %}{% endblock %}
+        {% include "common/confirmation_modal.html.twig" with {
+            id: 'regulation-delete-modal',
+            title: 'regulation.delete_modal.title'|trans,
+            confirmLabel: 'common.delete'|trans,
+            cancelLabel: 'common.do_not_delete'|trans,
+        } only %}
+    {% endif %}
+{% endblock %}

--- a/templates/regulation/fragments/_location.html.twig
+++ b/templates/regulation/fragments/_location.html.twig
@@ -45,9 +45,11 @@
                     {% endif %}
                 </li>
                 <li>
-                    <a href="{{ path('fragment_regulations_location_update', { regulationOrderRecordUuid: regulationOrderRecord.uuid, uuid: location.uuid }) }}" class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-edit-line fr-mt-2w fr-mt-md-0">
-                        {{ 'common.update'|trans }}
-                    </a>
+                    <form method="GET" action="{{ path('fragment_regulations_location_update', { regulationOrderRecordUuid: regulationOrderRecord.uuid, uuid: location.uuid }) }}">
+                        <button class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-edit-line fr-mt-2w fr-mt-md-0">
+                            {{ 'common.update'|trans }}
+                        </button>
+                    </form>
                 </li>
             </ul>
         {% endif %}

--- a/templates/regulation/fragments/_location.html.twig
+++ b/templates/regulation/fragments/_location.html.twig
@@ -32,7 +32,9 @@
                         {% endif %}
                 </li>
                 {% endif %}
-                <li>{{ 'regulation.location.all_vehicles_forbidden'|trans }}</li>
+                {% for measure in location.measures %}
+                <li>{{ measure.type }}</li>
+                {% endfor %}
             </ul>
         </div>
         {% if regulationOrderRecord.isDraft %}

--- a/templates/regulation/fragments/_location.html.twig
+++ b/templates/regulation/fragments/_location.html.twig
@@ -33,7 +33,7 @@
                 </li>
                 {% endif %}
                 {% for measure in location.measures %}
-                    <li>{{ ('measures.types.' ~ measure.type)|trans }}</li>
+                    <li>{{ ('regulation.measure.type.' ~ measure.type)|trans }}</li>
                 {% endfor %}
             </ul>
         </div>

--- a/templates/regulation/fragments/_location.html.twig
+++ b/templates/regulation/fragments/_location.html.twig
@@ -33,7 +33,7 @@
                 </li>
                 {% endif %}
                 {% for measure in location.measures %}
-                <li>{{ measure.type }}</li>
+                    <li>{{ ('measures.types.' ~ measure.type)|trans }}</li>
                 {% endfor %}
             </ul>
         </div>

--- a/templates/regulation/fragments/_location_form.html.twig
+++ b/templates/regulation/fragments/_location_form.html.twig
@@ -1,10 +1,20 @@
-{% form_theme form _self %}
-
 {% set frame = location ? "block_location_" ~ location.uuid : 'block_location' %}
 {% set cancelUrl = location
     ? path('fragment_regulations_location', {regulationOrderRecordUuid: regulationOrderRecord.uuid, uuid: location.uuid})
     : path('fragment_regulation_location_add_link', {regulationOrderRecordUuid: regulationOrderRecord.uuid})
 %}
+
+{% macro measures_list_item(form, index) %}
+    <li class="app-list-item fr-p-3w">
+        <h4 class="fr-h5 fr-mb-0">
+            {{ 'regulation.measure_list_item.title'|trans({'%index%': index}) }}
+        </h4>
+        <p class="fr-text-sm fr-text-mention--grey">
+            {{ 'regulation.measure_list_item.help'|trans }}
+        </p>
+        {{ form_row(form.type, { group_class: 'fr-select-group', widget_class: 'fr-select' }) }}
+    </li>
+{% endmacro %}
 
 <turbo-frame id="{{ frame }}">
     <div class="app-card fr-mt-3w">
@@ -35,17 +45,23 @@
                 <div
                     data-controller="form-collection"
                     data-form-collection-index-value="{{ form.measures|length > 0 ? form.measures|last.vars.name + 1 : 0 }}"
-                    data-form-collection-prototype-value="{{ form_widget(form.measures.vars.prototype)|e('html_attr') }}"
+                    data-form-collection-prototype-value="{{ _self.measures_list_item(form.measures.vars.prototype, '__oneBasedIndex__')|e('html_attr') }}"
+                    class="fr-mb-4w"
                 >
-                    <ul class="app-list" data-form-collection-target="collectionContainer">
-                        {{ form_row(form.measures)}}
+                    <ul id="measure-list" class="fr-raw-list fr-mb-2w" data-form-collection-target="collectionContainer" aria-label="{{ form.measures.vars.label|trans }}">
+                        {% for item in form.measures %}
+                            {{ _self.measures_list_item(item, loop.index) }}
+                        {% else %}
+                            {% do form.measures.setRendered %}
+                        {% endfor %}
                     </ul>
                     <button
                         type="button"
-                        class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-add-line"
+                        class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-add-line"
                         data-action="form-collection#addCollectionElement"
+                        aria-controls="measure-list"
                     >
-                        Ajouter une restriction
+                        {{ 'regulation.measure.add'|trans }}
                     </button>
                 </div>
 

--- a/templates/regulation/fragments/_location_form.html.twig
+++ b/templates/regulation/fragments/_location_form.html.twig
@@ -1,8 +1,17 @@
+{% form_theme form _self %}
+
 {% set frame = location ? "block_location_" ~ location.uuid : 'block_location' %}
 {% set cancelUrl = location
     ? path('fragment_regulations_location', {regulationOrderRecordUuid: regulationOrderRecord.uuid, uuid: location.uuid})
     : path('fragment_regulation_location_add_link', {regulationOrderRecordUuid: regulationOrderRecord.uuid})
 %}
+
+{% block _location_form_measures_entry_widget %}
+    <li class="app-list-item">
+        {{ form_widget(form.type) }}
+    </li>
+{% endblock %}
+
 <turbo-frame id="{{ frame }}">
     <div class="app-card fr-mt-3w">
         <div class="app-card__icon">
@@ -27,6 +36,21 @@
                         {{ form_row(form.fromHouseNumber, {group_class: 'fr-input-group', widget_class: 'fr-input', row_attr: {class: 'fr-col-12 fr-col-sm-6 fr-col-md-5 fr-col-lg-3'}}) }}
                         {{ form_row(form.toHouseNumber, {group_class: 'fr-input-group', widget_class: 'fr-input', row_attr: {class: 'fr-col-12 fr-col-sm-6 fr-col-md-5 fr-col-lg-3'}}) }}
                     </div>
+                </div>
+
+                <div
+                    data-controller="form-collection"
+                    data-form-collection-index-value="{{ form.measures|length > 0 ? form.measures|last.vars.name + 1 : 0 }}"
+                    data-form-collection-prototype-value="{{ form_widget(form.measures.vars.prototype)|e('html_attr') }}"
+                >
+                    <ul class="app-list" data-form-collection-target="collectionContainer"></ul>
+                    <button
+                        type="button"
+                        class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-add-line"
+                        data-action="form-collection#addCollectionElement"
+                    >
+                        Ajouter une restriction
+                    </button>
                 </div>
 
                 <a href="{{ cancelUrl }}" class="fr-btn fr-btn--tertiary fr-mr-3w">{{ "common.cancel"|trans }}</a>

--- a/templates/regulation/fragments/_location_form.html.twig
+++ b/templates/regulation/fragments/_location_form.html.twig
@@ -6,12 +6,6 @@
     : path('fragment_regulation_location_add_link', {regulationOrderRecordUuid: regulationOrderRecord.uuid})
 %}
 
-{% block _location_form_measures_entry_widget %}
-    <li class="app-list-item">
-        {{ form_widget(form.type) }}
-    </li>
-{% endblock %}
-
 <turbo-frame id="{{ frame }}">
     <div class="app-card fr-mt-3w">
         <div class="app-card__icon">
@@ -43,7 +37,9 @@
                     data-form-collection-index-value="{{ form.measures|length > 0 ? form.measures|last.vars.name + 1 : 0 }}"
                     data-form-collection-prototype-value="{{ form_widget(form.measures.vars.prototype)|e('html_attr') }}"
                 >
-                    <ul class="app-list" data-form-collection-target="collectionContainer"></ul>
+                    <ul class="app-list" data-form-collection-target="collectionContainer">
+                        {{ form_widget(form.measures)}}
+                    </ul>
                     <button
                         type="button"
                         class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-add-line"

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
@@ -19,9 +19,16 @@ final class AddLocationControllerTest extends AbstractWebTestCase
         $saveButton = $crawler->selectButton('Valider');
         $form = $saveButton->form();
 
-        $crawler = $client->submit($form);
+        // Get the raw values.
+        $values = $form->getPhpValues();
+        $values['location_form']['address'] = '';
+        $values['location_form']['measures'][0]['type'] = '';
+
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+
         $this->assertResponseStatusCodeSame(422);
         $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#location_form_address_error')->text());
+        $this->assertSame('Cette valeur ne doit pas être vide.Cette valeur doit être l\'un des choix proposés.', $crawler->filter('#location_form_measures_0_type_error')->text());
     }
 
     public function testAdd(): void
@@ -33,11 +40,15 @@ final class AddLocationControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Valider');
         $form = $saveButton->form();
-        $form['location_form[address]'] = 'Route du Grand Brossais 44260 Savenay';
-        $form['location_form[fromHouseNumber]'] = '15';
-        $form['location_form[toHouseNumber]'] = '37bis';
 
-        $crawler = $client->submit($form);
+        // Get the raw values.
+        $values = $form->getPhpValues();
+        $values['location_form']['address'] = 'Route du Grand Brossais 44260 Savenay';
+        $values['location_form']['fromHouseNumber'] = '15';
+        $values['location_form']['toHouseNumber'] = '37bis';
+        $values['location_form']['measures'][0]['type'] = 'noEntry';
+
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
         $this->assertResponseStatusCodeSame(200);
 
         $streams = $crawler->filter('turbo-stream');
@@ -105,6 +116,7 @@ final class AddLocationControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Valider');
         $form = $saveButton->form();
+
         $form['location_form[address]'] = str_repeat('a', 256);
         $form['location_form[fromHouseNumber]'] = str_repeat('a', 9);
         $form['location_form[toHouseNumber]'] = str_repeat('a', 9);

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
@@ -87,7 +87,7 @@ final class AddLocationControllerTest extends AbstractWebTestCase
         $crawler = $client->submit($form);
         dd($crawler);
         $this->assertResponseStatusCodeSame(422);
-        $this->assertStringStartsWith("Cette valeur ne doit pas être vide.", $crawler->filter('#location_form_error')->text());
+        $this->assertStringStartsWith('Cette valeur ne doit pas être vide.', $crawler->filter('#location_form_error')->text());
     }
 
     public function testRegulationOrderRecordNotFound(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
@@ -22,7 +22,6 @@ final class AddLocationControllerTest extends AbstractWebTestCase
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
         $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#location_form_address_error')->text());
-        $this->assertSame('Veuillez définir une ou plusieurs restrictions.', $crawler->filter('#location_form_error')->text());
     }
 
     public function testAdd(): void
@@ -85,7 +84,6 @@ final class AddLocationControllerTest extends AbstractWebTestCase
         $form['location_form[measures][0][type]'] = '';
 
         $crawler = $client->submit($form);
-        dd($crawler);
         $this->assertResponseStatusCodeSame(422);
         $this->assertStringStartsWith('Cette valeur ne doit pas être vide.', $crawler->filter('#location_form_error')->text());
     }

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
@@ -36,7 +36,6 @@ final class AddLocationControllerTest extends AbstractWebTestCase
         $form['location_form[address]'] = 'Route du Grand Brossais 44260 Savenay';
         $form['location_form[fromHouseNumber]'] = '15';
         $form['location_form[toHouseNumber]'] = '37bis';
-        $form['location_form[measures][0][type]'] = 'noEntry';
 
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(200);
@@ -65,27 +64,10 @@ final class AddLocationControllerTest extends AbstractWebTestCase
         $form['location_form[address]'] = 'Route du GEOCODING_FAILURE 44260 Savenay';
         $form['location_form[fromHouseNumber]'] = '15';
         $form['location_form[toHouseNumber]'] = '37bis';
-        $form['location_form[measures][0][type]'] = 'noEntry';
 
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
         $this->assertStringStartsWith("En raison d'un problème technique", $crawler->filter('#location_form_error')->text());
-    }
-
-    public function testBlankMeasureType(): void
-    {
-        $client = $this->login();
-        $crawler = $client->request('GET', '/_fragment/regulations/4ce75a1f-82f3-40ee-8f95-48d0f04446aa/location/add');
-        $this->assertResponseStatusCodeSame(200);
-
-        $saveButton = $crawler->selectButton('Valider');
-        $form = $saveButton->form();
-        $form['location_form[address]'] = 'Route du Grand Brossais 44260 Savenay';
-        $form['location_form[measures][0][type]'] = '';
-
-        $crawler = $client->submit($form);
-        $this->assertResponseStatusCodeSame(422);
-        $this->assertStringStartsWith('Cette valeur ne doit pas être vide.', $crawler->filter('#location_form_error')->text());
     }
 
     public function testRegulationOrderRecordNotFound(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetLocationControllerTest.php
@@ -20,7 +20,9 @@ final class GetLocationControllerTest extends AbstractWebTestCase
         $this->assertSame('Savenay (44260)', $crawler->filter('li')->eq(0)->text());
         $this->assertSame('Route du Grand Brossais - du n° 15 au n° 37bis', $crawler->filter('li')->eq(1)->text());
         $this->assertSame('Circulation interdite', $crawler->filter('li')->eq(2)->text());
-        $this->assertSame('http://localhost/_fragment/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5/location/51449b82-5032-43c8-a427-46b9ddb44762/form', $crawler->filter('a')->link()->getUri());
+        $editForm = $crawler->selectButton('Modifier')->form();
+        $this->assertSame('http://localhost/_fragment/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5/location/51449b82-5032-43c8-a427-46b9ddb44762/form', $editForm->getUri());
+        $this->assertSame('GET', $editForm->getMethod());
     }
 
     public function testGetLocationFromOtherRegulationOrderRecord(): void
@@ -41,9 +43,6 @@ final class GetLocationControllerTest extends AbstractWebTestCase
 
         $this->assertSame('Paris 18e Arrondissement', $crawler->filter('h3')->text());
         $this->assertSame('Paris 18e Arrondissement (75018)', $crawler->filter('li')->eq(0)->text());
-        $this->assertSame('Circulation interdite', $crawler->filter('li')->eq(1)->text());
-        $this->assertSame('Circulation alternée', $crawler->filter('li')->eq(2)->text());
-        $this->assertSame('http://localhost/_fragment/regulations/4ce75a1f-82f3-40ee-8f95-48d0f04446aa/location/f15ed802-fa9b-4d75-ab04-d62ea46597e9/form', $crawler->filter('a')->link()->getUri());
     }
 
     public function testIfPublishedThenCannotEdit(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
@@ -37,11 +37,16 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Valider');
         $form = $saveButton->form();
-        $form['location_form[address]'] = 'Route du Grand Brossais 44260 Savenay';
-        $form['location_form[fromHouseNumber]'] = '15';
-        $form['location_form[toHouseNumber]'] = '37bis';
 
-        $crawler = $client->submit($form);
+        // Get the raw values.
+        $values = $form->getPhpValues();
+        $values['location_form']['address'] = 'Route du Grand Brossais 44260 Savenay';
+        $values['location_form']['fromHouseNumber'] = '15';
+        $values['location_form']['toHouseNumber'] = '37bis';
+        $values['location_form']['measures'][0]['type'] = 'noEntry';
+        $values['location_form']['measures'][1]['type'] = 'alternateRoad';
+
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
         $this->assertResponseStatusCodeSame(303);
 
         $crawler = $client->followRedirect();

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
@@ -19,10 +19,13 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
         $saveButton = $crawler->selectButton('Valider');
         $form = $saveButton->form();
         $form['location_form[address]'] = ''; // reset
+        $form['location_form[measures][0][type]'] = '';
 
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
         $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#location_form_address_error')->text());
+        $this->assertStringContainsString('Cette valeur ne doit pas être vide.', $crawler->filter('#location_form_measures_0_type_error')->text());
+        $this->assertStringContainsString('Cette valeur doit être l\'un des choix proposés.', $crawler->filter('#location_form_measures_0_type_error')->text());
     }
 
     public function testEdit(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -37,8 +37,10 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertSame('http://localhost/_fragment/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5/location/51449b82-5032-43c8-a427-46b9ddb44762/form', $location->filter('a')->link()->getUri());
 
         // Actions
-        $duplicateBtn = $crawler->selectButton('Dupliquer');
-        $this->assertNotNull($duplicateBtn->attr('disabled'));
+        $duplicateForm = $crawler->selectButton('Dupliquer')->form();
+        $this->assertSame($duplicateForm->getUri(), 'http://localhost/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5/duplicate');
+        $this->assertSame($duplicateForm->getMethod(), 'POST');
+
         $publishBtn = $crawler->selectButton('Publier');
         $this->assertSame(0, $crawler->selectButton('Valider')->count()); // Location form
         $this->assertSame('http://localhost/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5/publish', $publishBtn->form()->getUri());

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -34,7 +34,9 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertSame('Savenay (44260)', $location->filter('li')->eq(0)->text());
         $this->assertSame('Route du Grand Brossais - du n° 15 au n° 37bis', $location->filter('li')->eq(1)->text());
         $this->assertSame('Circulation interdite', $location->filter('li')->eq(2)->text());
-        $this->assertSame('http://localhost/_fragment/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5/location/51449b82-5032-43c8-a427-46b9ddb44762/form', $location->filter('a')->link()->getUri());
+        $editLocationForm = $location->selectButton('Modifier')->form();
+        $this->assertSame('http://localhost/_fragment/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5/location/51449b82-5032-43c8-a427-46b9ddb44762/form', $editLocationForm->getUri());
+        $this->assertSame('GET', $editLocationForm->getMethod());
 
         // Actions
         $duplicateForm = $crawler->selectButton('Dupliquer')->form();

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -41,6 +41,10 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertSame($duplicateForm->getUri(), 'http://localhost/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5/duplicate');
         $this->assertSame($duplicateForm->getMethod(), 'POST');
 
+        $formDelete = $crawler->filter('aside')->selectButton('Supprimer')->form();
+        $this->assertSame($formDelete->getUri(), 'http://localhost/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5');
+        $this->assertSame($formDelete->getMethod(), 'DELETE');
+
         $publishBtn = $crawler->selectButton('Publier');
         $this->assertSame(0, $crawler->selectButton('Valider')->count()); // Location form
         $this->assertSame('http://localhost/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5/publish', $publishBtn->form()->getUri());
@@ -72,6 +76,10 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertSame('Publié', $crawler->filter('[data-testid="status-badge"]')->text());
         $this->assertSame(0, $crawler->selectButton('Modifier')->count()); // No edit buttons
         $this->assertSame(0, $crawler->selectButton('Publier')->count());
+
+        $formDelete = $crawler->filter('aside')->selectButton('Supprimer')->form();
+        $this->assertSame($formDelete->getUri(), 'http://localhost/regulations/3ede8b1a-1816-4788-8510-e08f45511cb5');
+        $this->assertSame($formDelete->getMethod(), 'DELETE');
     }
 
     public function testSeeAll(): void

--- a/tests/Unit/Application/Regulation/Command/SaveMeasureCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/SaveMeasureCommandHandlerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Application\Regulation\Command;
+
+use App\Application\IdFactoryInterface;
+use App\Application\Regulation\Command\SaveMeasureCommand;
+use App\Application\Regulation\Command\SaveMeasureCommandHandler;
+use App\Domain\Regulation\Enum\MeasureTypeEnum;
+use App\Domain\Regulation\Location;
+use App\Domain\Regulation\Measure;
+use App\Domain\Regulation\Repository\MeasureRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+final class SaveMeasureCommandHandlerTest extends TestCase
+{
+    private $idFactory;
+    private $measureRepository;
+
+    public function setUp(): void
+    {
+        $this->idFactory = $this->createMock(IdFactoryInterface::class);
+        $this->measureRepository = $this->createMock(MeasureRepositoryInterface::class);
+    }
+
+    public function testCreate(): void
+    {
+        $this->idFactory
+            ->expects(self::once())
+            ->method('make')
+            ->willReturn('d035fec0-30f3-4134-95b9-d74c68eb53e3');
+
+        $createdMeasure = $this->createMock(Measure::class);
+        $location = $this->createMock(Location::class);
+
+        $this->measureRepository
+            ->expects(self::once())
+            ->method('add')
+            ->with(
+                $this->equalTo(
+                    new Measure(
+                        uuid: 'd035fec0-30f3-4134-95b9-d74c68eb53e3',
+                        location: $location,
+                        type: MeasureTypeEnum::ALTERNATE_ROAD->value,
+                    ),
+                ),
+            )
+            ->willReturn($createdMeasure);
+
+        $handler = new SaveMeasureCommandHandler(
+            $this->idFactory,
+            $this->measureRepository,
+        );
+
+        $command = new SaveMeasureCommand();
+        $command->location = $location;
+        $command->type = MeasureTypeEnum::ALTERNATE_ROAD->value;
+
+        $result = $handler($command);
+
+        $this->assertSame($createdMeasure, $result);
+    }
+
+    public function testUpdate(): void
+    {
+        $this->idFactory
+            ->expects(self::never())
+            ->method('make');
+
+        $measure = $this->createMock(Measure::class);
+        $measure
+            ->expects(self::once())
+            ->method('update')
+            ->with(MeasureTypeEnum::ALTERNATE_ROAD->value);
+
+        $this->measureRepository
+            ->expects(self::never())
+            ->method('add');
+
+        $handler = new SaveMeasureCommandHandler(
+            $this->idFactory,
+            $this->measureRepository,
+        );
+
+        $command = new SaveMeasureCommand($measure);
+        $command->type = MeasureTypeEnum::ALTERNATE_ROAD->value;
+
+        $result = $handler($command);
+
+        $this->assertSame($measure, $result);
+    }
+}

--- a/tests/Unit/Application/Regulation/Command/SaveRegulationLocationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/SaveRegulationLocationCommandHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Application\Regulation\Command;
 
+use App\Application\CommandBusInterface;
 use App\Application\GeocoderInterface;
 use App\Application\IdFactoryInterface;
 use App\Application\Regulation\Command\SaveRegulationLocationCommand;
@@ -25,6 +26,11 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
     private $toPoint;
     private $regulationOrder;
     private $regulationOrderRecord;
+    private $commandBus;
+    private $idFactory;
+    private $locationRepository;
+    private $geocoder;
+    private $geometryFormatter;
 
     protected function setUp(): void
     {
@@ -34,7 +40,12 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $this->toHouseNumber = '37bis';
         $this->toPoint = 'POINT(-1.930973 47.347917)';
 
+        $this->locationRepository = $this->createMock(LocationRepositoryInterface::class);
+        $this->idFactory = $this->createMock(IdFactoryInterface::class);
+        $this->commandBus = $this->createMock(CommandBusInterface::class);
         $this->regulationOrder = $this->createMock(RegulationOrder::class);
+        $this->geocoder = $this->createMock(GeocoderInterface::class);
+        $this->geometryFormatter = $this->createMock(GeometryFormatter::class);
         $this->regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
         $this->regulationOrderRecord
             ->expects(self::once())
@@ -44,14 +55,12 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
 
     public function testCreate(): void
     {
-        $idFactory = $this->createMock(IdFactoryInterface::class);
-        $idFactory
+        $this->idFactory
             ->expects(self::once())
             ->method('make')
             ->willReturn('4430a28a-f9ad-4c4b-ba66-ce9cc9adb7d8');
 
-        $geocoder = $this->createMock(GeocoderInterface::class);
-        $geocoder
+        $this->geocoder
             ->expects(self::exactly(2))
             ->method('computeCoordinates')
             ->willReturnOnConsecutiveCalls(
@@ -59,8 +68,7 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
                 Coordinates::fromLonLat(-1.930973, 47.347917),
             );
 
-        $geometryFormatter = $this->createMock(GeometryFormatter::class);
-        $geometryFormatter
+        $this->geometryFormatter
             ->expects(self::exactly(2))
             ->method('formatPoint')
             ->willReturnOnConsecutiveCalls(
@@ -83,18 +91,18 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
             ->expects(self::once())
             ->method('getUuid')
             ->willReturn('73504e1a-45a1-4993-b82a-1189500715db');
-        $locationRepository = $this->createMock(LocationRepositoryInterface::class);
-        $locationRepository
+        $this->locationRepository
             ->expects(self::once())
             ->method('add')
             ->with($this->equalTo($location))
             ->willReturn($createdLocation);
 
         $handler = new SaveRegulationLocationCommandHandler(
-            $idFactory,
-            $locationRepository,
-            $geocoder,
-            $geometryFormatter,
+            $this->idFactory,
+            $this->commandBus,
+            $this->locationRepository,
+            $this->geocoder,
+            $this->geometryFormatter,
         );
 
         $command = new SaveRegulationLocationCommand($this->regulationOrderRecord);
@@ -123,13 +131,11 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
                 $this->toPoint,
             );
 
-        $idFactory = $this->createMock(IdFactoryInterface::class);
-        $idFactory
+        $this->idFactory
             ->expects(self::never())
             ->method('make');
 
-        $geocoder = $this->createMock(GeocoderInterface::class);
-        $geocoder
+        $this->geocoder
             ->expects(self::exactly(2))
             ->method('computeCoordinates')
             ->willReturnOnConsecutiveCalls(
@@ -137,8 +143,7 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
                 Coordinates::fromLonLat(-1.930973, 47.347917),
             );
 
-        $geometryFormatter = $this->createMock(GeometryFormatter::class);
-        $geometryFormatter
+        $this->geometryFormatter
             ->expects(self::exactly(2))
             ->method('formatPoint')
             ->willReturnOnConsecutiveCalls(
@@ -146,16 +151,16 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
                 'POINT(-1.930973 47.347917)',
             );
 
-        $locationRepository = $this->createMock(LocationRepositoryInterface::class);
-        $locationRepository
+        $this->locationRepository
             ->expects(self::never())
             ->method('add');
 
         $handler = new SaveRegulationLocationCommandHandler(
-            $idFactory,
-            $locationRepository,
-            $geocoder,
-            $geometryFormatter,
+            $this->idFactory,
+            $this->commandBus,
+            $this->locationRepository,
+            $this->geocoder,
+            $this->geometryFormatter,
         );
 
         $command = new SaveRegulationLocationCommand($this->regulationOrderRecord, $location);
@@ -180,31 +185,28 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
                 $this->address,
             );
 
-        $idFactory = $this->createMock(IdFactoryInterface::class);
-        $idFactory
+        $this->idFactory
             ->expects(self::never())
             ->method('make');
 
-        $geocoder = $this->createMock(GeocoderInterface::class);
-        $geocoder
+        $this->geocoder
             ->expects(self::never())
             ->method('computeCoordinates');
 
-        $geometryFormatter = $this->createMock(GeometryFormatter::class);
-        $geometryFormatter
+        $this->geometryFormatter
             ->expects(self::never())
             ->method('formatPoint');
 
-        $locationRepository = $this->createMock(LocationRepositoryInterface::class);
-        $locationRepository
+        $this->locationRepository
             ->expects(self::never())
             ->method('add');
 
         $handler = new SaveRegulationLocationCommandHandler(
-            $idFactory,
-            $locationRepository,
-            $geocoder,
-            $geometryFormatter,
+            $this->idFactory,
+            $this->commandBus,
+            $this->locationRepository,
+            $this->geocoder,
+            $this->geometryFormatter,
         );
 
         $command = new SaveRegulationLocationCommand($this->regulationOrderRecord, $location);
@@ -254,31 +256,28 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
                 $this->toPoint,
             );
 
-        $idFactory = $this->createMock(IdFactoryInterface::class);
-        $idFactory
+        $this->idFactory
             ->expects(self::never())
             ->method('make');
 
-        $geocoder = $this->createMock(GeocoderInterface::class);
-        $geocoder
+        $this->geocoder
             ->expects(self::never())
             ->method('computeCoordinates');
 
-        $geometryFormatter = $this->createMock(GeometryFormatter::class);
-        $geometryFormatter
+        $this->geometryFormatter
             ->expects(self::never())
             ->method('formatPoint');
 
-        $locationRepository = $this->createMock(LocationRepositoryInterface::class);
-        $locationRepository
+        $this->locationRepository
             ->expects(self::never())
             ->method('add');
 
         $handler = new SaveRegulationLocationCommandHandler(
-            $idFactory,
-            $locationRepository,
-            $geocoder,
-            $geometryFormatter,
+            $this->idFactory,
+            $this->commandBus,
+            $this->locationRepository,
+            $this->geocoder,
+            $this->geometryFormatter,
         );
 
         $command = new SaveRegulationLocationCommand($this->regulationOrderRecord, $location);

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandlerTest.php
@@ -8,6 +8,7 @@ use App\Application\Regulation\Query\GetRegulationOrderRecordSummaryQuery;
 use App\Application\Regulation\Query\GetRegulationOrderRecordSummaryQueryHandler;
 use App\Application\Regulation\View\DetailLocationView;
 use App\Application\Regulation\View\RegulationOrderRecordSummaryView;
+use App\Domain\Regulation\Enum\MeasureTypeEnum;
 use App\Domain\Regulation\Exception\RegulationOrderRecordNotFoundException;
 use App\Domain\Regulation\LocationAddress;
 use App\Domain\Regulation\Repository\RegulationOrderRecordRepositoryInterface;
@@ -26,6 +27,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                         'locationAddress' => new LocationAddress('82000', 'Montauban', 'Avenue de Fonneuve'),
                         'fromHouseNumber' => '695',
                         'toHouseNumber' => '253',
+                        'measureType' => MeasureTypeEnum::NO_ENTRY->value,
                     ],
                     [
                         'uuid' => '97ff1036-14cf-4fc4-b14b-0bb4095c9b39',
@@ -33,6 +35,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                         'locationAddress' => new LocationAddress('82000', 'Montauban', 'Rue de Paris'),
                         'fromHouseNumber' => null,
                         'toHouseNumber' => null,
+                        'measureType' => MeasureTypeEnum::NO_ENTRY->value,
                     ],
                 ],
             ],
@@ -44,6 +47,16 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                         'locationAddress' => new LocationAddress('82000', 'Montauban', 'Avenue de Fonneuve'),
                         'fromHouseNumber' => null,
                         'toHouseNumber' => null,
+                        'measureType' => MeasureTypeEnum::NO_ENTRY->value,
+                    ],
+                    // Same locations with 2 differents measures
+                    [
+                        'uuid' => 'fe0a44cb-53b5-4e94-bb7e-dfb8d20be061',
+                        'address' => 'Avenue de Paris 82000 Montauban',
+                        'locationAddress' => new LocationAddress('82000', 'Montauban', 'Avenue de Paris'),
+                        'fromHouseNumber' => '10',
+                        'toHouseNumber' => '90',
+                        'measureType' => MeasureTypeEnum::NO_ENTRY->value,
                     ],
                     [
                         'uuid' => 'fe0a44cb-53b5-4e94-bb7e-dfb8d20be061',
@@ -51,6 +64,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                         'locationAddress' => new LocationAddress('82000', 'Montauban', 'Avenue de Paris'),
                         'fromHouseNumber' => '10',
                         'toHouseNumber' => '90',
+                        'measureType' => MeasureTypeEnum::ALTERNATE_ROAD->value,
                     ],
                 ],
             ],
@@ -68,7 +82,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
         $regulationOrderRecordRepository = $this->createMock(RegulationOrderRecordRepositoryInterface::class);
 
         $regulationOrderRecord = [
-                [
+            [
                 'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
                 'identifier' => 'F01/2023',
                 'organizationUuid' => 'a8439603-40f7-4b1e-8a35-cee9e53b98d4',
@@ -81,6 +95,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'address' => $location[0]['address'],
                 'fromHouseNumber' => $location[0]['fromHouseNumber'],
                 'toHouseNumber' => $location[0]['toHouseNumber'],
+                'measureType' => MeasureTypeEnum::NO_ENTRY->value,
             ],
             [
                 'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
@@ -95,6 +110,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'address' => $location[1]['address'],
                 'fromHouseNumber' => $location[1]['fromHouseNumber'],
                 'toHouseNumber' => $location[1]['toHouseNumber'],
+                'measureType' => MeasureTypeEnum::ALTERNATE_ROAD->value,
             ],
         ];
 
@@ -120,6 +136,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                         $location[0]['locationAddress'],
                         $location[0]['fromHouseNumber'],
                         $location[0]['toHouseNumber'],
+                        []
                     ),
                     new DetailLocationView(
                         $location[1]['uuid'],

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandlerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Application\Regulation\Query;
 use App\Application\Regulation\Query\GetRegulationOrderRecordSummaryQuery;
 use App\Application\Regulation\Query\GetRegulationOrderRecordSummaryQueryHandler;
 use App\Application\Regulation\View\DetailLocationView;
+use App\Application\Regulation\View\MeasureView;
 use App\Application\Regulation\View\RegulationOrderRecordSummaryView;
 use App\Domain\Regulation\Enum\MeasureTypeEnum;
 use App\Domain\Regulation\Exception\RegulationOrderRecordNotFoundException;
@@ -19,7 +20,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
     public function provideGetOne(): array
     {
         return [
-            [
+            /*[
                 [
                     [
                         'uuid' => '2c85cbb4-cce4-460b-9e68-e8fc9de2c0ea',
@@ -38,7 +39,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                         'measureType' => MeasureTypeEnum::NO_ENTRY->value,
                     ],
                 ],
-            ],
+            ],*/
             [
                 [
                     [
@@ -95,7 +96,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'address' => $location[0]['address'],
                 'fromHouseNumber' => $location[0]['fromHouseNumber'],
                 'toHouseNumber' => $location[0]['toHouseNumber'],
-                'measureType' => MeasureTypeEnum::NO_ENTRY->value,
+                'measureType' => $location[0]['measureType'],
             ],
             [
                 'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
@@ -110,9 +111,34 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'address' => $location[1]['address'],
                 'fromHouseNumber' => $location[1]['fromHouseNumber'],
                 'toHouseNumber' => $location[1]['toHouseNumber'],
-                'measureType' => MeasureTypeEnum::ALTERNATE_ROAD->value,
+                'measureType' => $location[1]['measureType'],
             ],
         ];
+
+        $expectedLocation1Measures = [new MeasureView($location[1]['measureType'])];
+
+        if (!empty($location[2])) {
+            $regulationOrderRecord[] = [
+                'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
+                'identifier' => 'F01/2023',
+                'organizationUuid' => 'a8439603-40f7-4b1e-8a35-cee9e53b98d4',
+                'organizationName' => 'DiaLog',
+                'status' => 'draft',
+                'description' => 'Description 1',
+                'startDate' => $startDate,
+                'endDate' => $endDate,
+                'locationUuid' => $location[2]['uuid'],
+                'address' => $location[2]['address'],
+                'fromHouseNumber' => $location[2]['fromHouseNumber'],
+                'toHouseNumber' => $location[2]['toHouseNumber'],
+                'measureType' => $location[2]['measureType'],
+            ];
+
+            $expectedLocation1Measures = [
+                new MeasureView($location[1]['measureType']),
+                new MeasureView($location[2]['measureType']),
+            ];
+        }
 
         $regulationOrderRecordRepository
             ->expects(self::once())
@@ -131,18 +157,19 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'draft',
                 'Description 1',
                 [
-                    new DetailLocationView(
+                    $location[0]['uuid'] => new DetailLocationView(
                         $location[0]['uuid'],
                         $location[0]['locationAddress'],
                         $location[0]['fromHouseNumber'],
                         $location[0]['toHouseNumber'],
-                        []
+                        [new MeasureView($location[0]['measureType'])],
                     ),
-                    new DetailLocationView(
+                    $location[1]['uuid'] => new DetailLocationView(
                         $location[1]['uuid'],
                         $location[1]['locationAddress'],
                         $location[1]['fromHouseNumber'],
                         $location[1]['toHouseNumber'],
+                        $expectedLocation1Measures,
                     ),
                 ],
                 $startDate,

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrderRecordSummaryQueryHandlerTest.php
@@ -20,7 +20,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
     public function provideGetOne(): array
     {
         return [
-            /*[
+            [
                 [
                     [
                         'uuid' => '2c85cbb4-cce4-460b-9e68-e8fc9de2c0ea',
@@ -39,7 +39,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                         'measureType' => MeasureTypeEnum::NO_ENTRY->value,
                     ],
                 ],
-            ],*/
+            ],
             [
                 [
                     [
@@ -75,14 +75,14 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
     /**
      * @dataProvider provideGetOne
      */
-    public function testGetOne(array $location): void
+    public function testGetOne(array $locations): void
     {
         $startDate = new \DateTime('2022-12-07');
         $endDate = new \DateTime('2022-12-17');
 
         $regulationOrderRecordRepository = $this->createMock(RegulationOrderRecordRepositoryInterface::class);
 
-        $regulationOrderRecord = [
+        $summaryRows = [
             [
                 'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
                 'identifier' => 'F01/2023',
@@ -92,11 +92,11 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'description' => 'Description 1',
                 'startDate' => $startDate,
                 'endDate' => $endDate,
-                'locationUuid' => $location[0]['uuid'],
-                'address' => $location[0]['address'],
-                'fromHouseNumber' => $location[0]['fromHouseNumber'],
-                'toHouseNumber' => $location[0]['toHouseNumber'],
-                'measureType' => $location[0]['measureType'],
+                'locationUuid' => $locations[0]['uuid'],
+                'address' => $locations[0]['address'],
+                'fromHouseNumber' => $locations[0]['fromHouseNumber'],
+                'toHouseNumber' => $locations[0]['toHouseNumber'],
+                'measureType' => $locations[0]['measureType'],
             ],
             [
                 'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
@@ -107,18 +107,18 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'description' => 'Description 1',
                 'startDate' => $startDate,
                 'endDate' => $endDate,
-                'locationUuid' => $location[1]['uuid'],
-                'address' => $location[1]['address'],
-                'fromHouseNumber' => $location[1]['fromHouseNumber'],
-                'toHouseNumber' => $location[1]['toHouseNumber'],
-                'measureType' => $location[1]['measureType'],
+                'locationUuid' => $locations[1]['uuid'],
+                'address' => $locations[1]['address'],
+                'fromHouseNumber' => $locations[1]['fromHouseNumber'],
+                'toHouseNumber' => $locations[1]['toHouseNumber'],
+                'measureType' => $locations[1]['measureType'],
             ],
         ];
 
-        $expectedLocation1Measures = [new MeasureView($location[1]['measureType'])];
+        $expectedLocation1Measures = [new MeasureView($locations[1]['measureType'])];
 
-        if (!empty($location[2])) {
-            $regulationOrderRecord[] = [
+        if (!empty($locations[2])) {
+            $summaryRows[] = [
                 'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
                 'identifier' => 'F01/2023',
                 'organizationUuid' => 'a8439603-40f7-4b1e-8a35-cee9e53b98d4',
@@ -127,26 +127,26 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'description' => 'Description 1',
                 'startDate' => $startDate,
                 'endDate' => $endDate,
-                'locationUuid' => $location[2]['uuid'],
-                'address' => $location[2]['address'],
-                'fromHouseNumber' => $location[2]['fromHouseNumber'],
-                'toHouseNumber' => $location[2]['toHouseNumber'],
-                'measureType' => $location[2]['measureType'],
+                'locationUuid' => $locations[2]['uuid'],
+                'address' => $locations[2]['address'],
+                'fromHouseNumber' => $locations[2]['fromHouseNumber'],
+                'toHouseNumber' => $locations[2]['toHouseNumber'],
+                'measureType' => $locations[2]['measureType'],
             ];
 
             $expectedLocation1Measures = [
-                new MeasureView($location[1]['measureType']),
-                new MeasureView($location[2]['measureType']),
+                new MeasureView($locations[1]['measureType']),
+                new MeasureView($locations[2]['measureType']),
             ];
         }
 
         $regulationOrderRecordRepository
             ->expects(self::once())
             ->method('findOneForSummary')
-            ->willReturn($regulationOrderRecord);
+            ->willReturn($summaryRows);
 
         $handler = new GetRegulationOrderRecordSummaryQueryHandler($regulationOrderRecordRepository);
-        $regulationOrders = $handler(new GetRegulationOrderRecordSummaryQuery('3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf'));
+        $summary = $handler(new GetRegulationOrderRecordSummaryQuery('3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf'));
 
         $this->assertEquals(
             new RegulationOrderRecordSummaryView(
@@ -157,25 +157,25 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 'draft',
                 'Description 1',
                 [
-                    $location[0]['uuid'] => new DetailLocationView(
-                        $location[0]['uuid'],
-                        $location[0]['locationAddress'],
-                        $location[0]['fromHouseNumber'],
-                        $location[0]['toHouseNumber'],
-                        [new MeasureView($location[0]['measureType'])],
+                    $locations[0]['uuid'] => new DetailLocationView(
+                        $locations[0]['uuid'],
+                        $locations[0]['locationAddress'],
+                        $locations[0]['fromHouseNumber'],
+                        $locations[0]['toHouseNumber'],
+                        [new MeasureView($locations[0]['measureType'])],
                     ),
-                    $location[1]['uuid'] => new DetailLocationView(
-                        $location[1]['uuid'],
-                        $location[1]['locationAddress'],
-                        $location[1]['fromHouseNumber'],
-                        $location[1]['toHouseNumber'],
+                    $locations[1]['uuid'] => new DetailLocationView(
+                        $locations[1]['uuid'],
+                        $locations[1]['locationAddress'],
+                        $locations[1]['fromHouseNumber'],
+                        $locations[1]['toHouseNumber'],
                         $expectedLocation1Measures,
                     ),
                 ],
                 $startDate,
                 $endDate,
             ),
-            $regulationOrders,
+            $summary,
         );
     }
 
@@ -206,7 +206,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
             ->willReturn($regulationOrderRecord);
 
         $handler = new GetRegulationOrderRecordSummaryQueryHandler($regulationOrderRecordRepository);
-        $regulationOrders = $handler(new GetRegulationOrderRecordSummaryQuery('3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf'));
+        $summary = $handler(new GetRegulationOrderRecordSummaryQuery('3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf'));
 
         $this->assertEquals(
             new RegulationOrderRecordSummaryView(
@@ -220,7 +220,7 @@ final class GetRegulationOrderRecordSummaryQueryHandlerTest extends TestCase
                 null,
                 null,
             ),
-            $regulationOrders,
+            $summary,
         );
     }
 

--- a/tests/Unit/Domain/Regulation/LocationTest.php
+++ b/tests/Unit/Domain/Regulation/LocationTest.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Domain\Regulation;
 
 use App\Domain\Regulation\Location;
+use App\Domain\Regulation\Measure;
 use App\Domain\Regulation\RegulationOrder;
+use Doctrine\Common\Collections\ArrayCollection;
 use PHPUnit\Framework\TestCase;
 
 final class LocationTest extends TestCase
 {
     public function testGetters(): void
     {
+        $measure1 = $this->createMock(Measure::class);
+        $measure2 = $this->createMock(Measure::class);
         $regulationOrder = $this->createMock(RegulationOrder::class);
         $location = new Location(
             'b4812143-c4d8-44e6-8c3a-34688becae6e',
@@ -31,6 +35,12 @@ final class LocationTest extends TestCase
         $this->assertSame('37bis', $location->getToHouseNumber());
         $this->assertSame('POINT(-1.930973 47.347917)', $location->getToPoint());
         $this->assertEmpty($location->getMeasures());
+
+        $location->addMeasure($measure1);
+        $location->addMeasure($measure1); // Test doublon
+        $location->addMeasure($measure2);
+
+        $this->assertEquals(new ArrayCollection([$measure1, $measure2]), $location->getMeasures());
     }
 
     public function testUpdate(): void

--- a/tests/Unit/Domain/Regulation/MeasureTest.php
+++ b/tests/Unit/Domain/Regulation/MeasureTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
 
 final class MeasureTest extends TestCase
 {
-    public function testGetters(): void
+    public function testMeasure(): void
     {
         $location = $this->createMock(Location::class);
 
@@ -25,5 +25,8 @@ final class MeasureTest extends TestCase
         $this->assertSame($location, $measure->getLocation());
         $this->assertSame(MeasureTypeEnum::NO_ENTRY->value, $measure->getType());
         $this->assertEmpty($measure->getConditions()); // Automatically set by Doctrine
+
+        $measure->update(MeasureTypeEnum::ALTERNATE_ROAD->value);
+        $this->assertSame(MeasureTypeEnum::ALTERNATE_ROAD->value, $measure->getType());
     }
 }

--- a/tests/Unit/Domain/Regulation/MeasureTest.php
+++ b/tests/Unit/Domain/Regulation/MeasureTest.php
@@ -18,12 +18,12 @@ final class MeasureTest extends TestCase
         $measure = new Measure(
             uuid: '6598fd41-85cb-42a6-9693-1bc45f4dd392',
             location: $location,
-            type: MeasureTypeEnum::NO_ENTRY,
+            type: MeasureTypeEnum::NO_ENTRY->value,
         );
 
         $this->assertSame('6598fd41-85cb-42a6-9693-1bc45f4dd392', $measure->getUuid());
         $this->assertSame($location, $measure->getLocation());
-        $this->assertSame(MeasureTypeEnum::NO_ENTRY, $measure->getType());
+        $this->assertSame(MeasureTypeEnum::NO_ENTRY->value, $measure->getType());
         $this->assertEmpty($measure->getConditions()); // Automatically set by Doctrine
     }
 }

--- a/tests/e2e/regulation_edit.spec.js
+++ b/tests/e2e/regulation_edit.spec.js
@@ -1,0 +1,69 @@
+// @ts-check
+const { test, expect } = require('@playwright/test');
+
+test.use({ storageState: 'playwright/.auth/mathieu.json' });
+
+test('Manage regulation location measures', async ({ page }) => {
+    /**
+     * Add first location and a maesure
+     */
+
+    await page.goto('/regulations/b1a3e982-39a1-4f0e-8a6f-ea2fd5e872c2');
+
+    // Check regulation has no location yet
+    const locations = page.getByRole('region', { name: 'Localisations' }).getByRole('list');
+    expect(await locations.getByRole('listitem').count()).toBe(0);
+
+    // Fill mandatory location fields
+    await page.locator('text=Voie ou ville').fill('Route du Grand Brossais, 44260 Savenay');
+
+    // Add a measure
+    await page.getByRole('button', { name: 'Ajouter une restriction' }).click();
+    const measureItem = page.getByRole('listitem').filter({ has: page.getByText('Restriction 1') });
+    await measureItem.getByRole('combobox', { name: 'Type de restriction' }).selectOption({ label: 'Circulation à sens unique' });
+
+    // Submit and check location was added with the given measure
+    await page.getByRole('button', { name: 'Valider' }).click();
+    expect(await locations.getByRole('listitem').count()).toBe(1);
+    const locationItem = locations.getByRole('listitem').first();
+    await locationItem.getByRole('heading', { level: 3, name: 'Route du Grand Brossais' }).waitFor();
+    expect(locationItem).toContainText('Circulation à sens unique');
+
+    /**
+     * Add another measure to the now-existing location
+     */
+
+    // Enter location edit mode
+    await locationItem.getByRole('button', { name: 'Modifier' }).click();
+    const measureList = locationItem.getByRole('list', { name: 'Liste des restrictions' });
+    await measureList.waitFor();
+    expect(await measureList.getByRole('listitem').count()).toBe(1);
+
+    // Add a new measure
+    await locationItem.getByRole('button', { name: 'Ajouter une restriction' }).click();
+    const measureItem2 = locationItem.getByRole('listitem').filter({ has: page.getByText('Restriction 2') });
+    await measureItem2.getByRole('combobox', { name: 'Type de restriction' }).selectOption({ label: 'Circulation interdite' });
+
+    // Submit and check new measure is shown
+    await locationItem.getByRole('button', { name: 'Valider' }).click();
+    await expect(locationItem).toContainText('Circulation à sens unique');
+    await expect(locationItem).toContainText('Circulation interdite');
+
+    /**
+     * Change an existing measure
+     */
+
+    // Enter location edit mode
+    await locationItem.getByRole('button', { name: 'Modifier' }).click();
+    await measureList.waitFor();
+    expect(await measureList.getByRole('listitem').count()).toBe(2);
+
+    // Change existing measure
+    await measureItem2.getByRole('combobox', { name: 'Type de restriction' }).selectOption({ label: 'Circulation alternée' });
+
+    // Submit and check measure has been updated
+    await locationItem.getByRole('button', { name: 'Valider' }).click();
+    await expect(locationItem).toContainText('Circulation à sens unique');
+    await expect(locationItem).not.toContainText('Circulation interdite');
+    await expect(locationItem).toContainText('Circulation alternée');
+});

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -626,6 +626,10 @@
                 <source>regulation.measure.type.help</source>
                 <target>Quel type de restriction ou limitation est prévu ?</target>
             </trans-unit>
+            <trans-unit id="regulation.measure.type.placeholder">
+                <source>regulation.measure.type.placeholder</source>
+                <target>Sélectionner un type de restriction...</target>
+            </trans-unit>
             <trans-unit id="regulation.measure.type.noEntry">
                 <source>regulation.measure.type.noEntry</source>
                 <target>Circulation interdite</target>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -602,12 +602,28 @@
                 <source>regulation.list.meta.title</source>
                 <target>Arrêtés de circulation</target>
             </trans-unit>
-            <trans-unit id="measure.type">
-                <source>measure.type</source>
+            <trans-unit id="measures">
+                <source>regulation.measure_list</source>
+                <target>Liste des restrictions</target>
+            </trans-unit>
+            <trans-unit id="regulation.measure_list_item.title">
+                <source>regulation.measure_list_item.title</source>
+                <target>Restriction %index%</target>
+            </trans-unit>
+            <trans-unit id="regulation.measure_list_item.help">
+                <source>regulation.measure_list_item.help</source>
+                <target>Quelle perturbation est prévue ?</target>
+            </trans-unit>
+            <trans-unit id="regulation.measure.add">
+                <source>regulation.measure.add</source>
+                <target>Ajouter une restriction</target>
+            </trans-unit>
+            <trans-unit id="regulation.measure.type">
+                <source>regulation.measure.type</source>
                 <target>Type de restriction</target>
             </trans-unit>
-            <trans-unit id="measure.type.help">
-                <source>measure.type.help</source>
+            <trans-unit id="regulation.measure.type.help">
+                <source>regulation.measure.type.help</source>
                 <target>Quel type de restriction ou limitation est prévu ?</target>
             </trans-unit>
             <trans-unit id="measures.types.noEntry">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -602,6 +602,18 @@
                 <source>regulation.list.meta.title</source>
                 <target>Arrêtés de circulation</target>
             </trans-unit>
+            <trans-unit id="measures.types.noEntry">
+                <source>measures.types.noEntry</source>
+                <target>Circulation interdite</target>
+            </trans-unit>
+            <trans-unit id="measures.types.alternateRoad">
+                <source>measures.types.alternateRoad</source>
+                <target>Circulation alternée</target>
+            </trans-unit>
+            <trans-unit id="measures.types.oneWayTraffic">
+                <source>measures.types.oneWayTraffic</source>
+                <target>Circulation à sens unique</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -626,16 +626,16 @@
                 <source>regulation.measure.type.help</source>
                 <target>Quel type de restriction ou limitation est prévu ?</target>
             </trans-unit>
-            <trans-unit id="measures.types.noEntry">
-                <source>measures.types.noEntry</source>
+            <trans-unit id="regulation.measure.type.noEntry">
+                <source>regulation.measure.type.noEntry</source>
                 <target>Circulation interdite</target>
             </trans-unit>
-            <trans-unit id="measures.types.alternateRoad">
-                <source>measures.types.alternateRoad</source>
+            <trans-unit id="regulation.measure.type.alternateRoad">
+                <source>regulation.measure.type.alternateRoad</source>
                 <target>Circulation alternée</target>
             </trans-unit>
-            <trans-unit id="measures.types.oneWayTraffic">
-                <source>measures.types.oneWayTraffic</source>
+            <trans-unit id="regulation.measure.type.oneWayTraffic">
+                <source>regulation.measure.type.oneWayTraffic</source>
                 <target>Circulation à sens unique</target>
             </trans-unit>
         </body>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -602,6 +602,14 @@
                 <source>regulation.list.meta.title</source>
                 <target>Arrêtés de circulation</target>
             </trans-unit>
+            <trans-unit id="measure.type">
+                <source>measure.type</source>
+                <target>Type de restriction</target>
+            </trans-unit>
+            <trans-unit id="measure.type.help">
+                <source>measure.type.help</source>
+                <target>Quel type de restriction ou limitation est prévu ?</target>
+            </trans-unit>
             <trans-unit id="measures.types.noEntry">
                 <source>measures.types.noEntry</source>
                 <target>Circulation interdite</target>

--- a/translations/validators.fr.xlf
+++ b/translations/validators.fr.xlf
@@ -30,10 +30,6 @@
                 <source>location.error.valid_address</source>
                 <target>Veuillez saisir une adresse valide. Ex : Rue Saint-Léonard, 49000 Angers.</target>
             </trans-unit>
-            <trans-unit id="location.measures.error.not_blank">
-                <source>location.measures.error.not_blank</source>
-                <target>Veuillez définir une ou plusieurs restrictions.</target>
-            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
* Refs #187 

Cette PR permet d'ajouter des restrictions à une localisation et de les mettre à jour en même temps que la localisation

## Aperçus

Liste vide:

![Screenshot 2023-05-05 at 09-25-09 Arrêté temporaire F01_2023 (copie) - DiaLog](https://user-images.githubusercontent.com/15911462/236399303-7a11b35a-f869-4a7d-bd98-874f5e636724.png)

Liste avec un élément:

![Screenshot 2023-05-05 at 09-25-00 Arrêté temporaire F01_2023 (copie) - DiaLog](https://user-images.githubusercontent.com/15911462/236399309-8679110d-9935-4bed-ab74-e01f61896ab5.png)

## Autres

Documentation utile:

* https://symfony.com/doc/current/form/form_collections.html
* https://symfony.com/doc/current/form/form_themes.html#fragment-naming-for-collections
* https://stackoverflow.com/questions/53176207/symfony-how-to-render-a-collection-form-type-in-a-custom-format
* #260 contenait un exemple d'override de rendu de formulaire : https://github.com/MTES-MCT/dialog/pull/260/files#diff-4f35178395aba3cb8c20da842e32d86e883aa3f3e51899cc1d9d03cab9393302L10