### PR TITLE
Fix address parsing

### DIFF
--- a/src/Domain/Regulation/Exception/LocationAddressParsingException.php
+++ b/src/Domain/Regulation/Exception/LocationAddressParsingException.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace App\Domain\Regulation\Exception;
-
-final class LocationAddressParsingException extends \Exception
-{
-}

--- a/src/Domain/Regulation/LocationAddress.php
+++ b/src/Domain/Regulation/LocationAddress.php
@@ -4,46 +4,42 @@ declare(strict_types=1);
 
 namespace App\Domain\Regulation;
 
-use App\Domain\Regulation\Exception\LocationAddressParsingException;
-
 class LocationAddress
 {
     private const ADDRESS_PATTERN = "/((?<roadName>[^\d,]+),? )?(?<postCode>\d{5}) (?<city>.+)/i";
 
     public function __construct(
-        private string $postCode,
-        private string $city,
-        private string|null $roadName,
+        private ?string $postCode = null,
+        private ?string $city = null,
+        private ?string $roadName = null,
     ) {
     }
 
-    public function getPostCode(): string
+    public function getPostCode(): ?string
     {
         return $this->postCode;
     }
 
-    public function getCity(): string
+    public function getCity(): ?string
     {
         return $this->city;
     }
 
-    public function getRoadName(): string|null
+    public function getRoadName(): ?string
     {
         return $this->roadName;
     }
 
     /**
      * Convert a text address to a LocationAddress object.
-     *
-     * @throws LocationAddressParsingException: If parsing has failed.
      */
     public static function fromString(string $address): self
     {
         $matches = [];
 
+        // If parsing has failed
         if (!preg_match(self::ADDRESS_PATTERN, $address, $matches)) {
-            $message = sprintf("Address '%s' did not have expected format '%s'", $address, self::ADDRESS_PATTERN);
-            throw new LocationAddressParsingException($message);
+            return new LocationAddress(null, null, $address);
         }
 
         return new LocationAddress(

--- a/templates/regulation/fragments/_location.html.twig
+++ b/templates/regulation/fragments/_location.html.twig
@@ -13,9 +13,11 @@
 
         <div class="app-card__content">
             <ul class="fr-ml-1w fr-my-0 fr-list">
-                <li>{{ location.address.city }}
-				    ({{ location.address.postCode }})
-                </li>
+                {% if location.address.city %}
+                    <li>
+                        {{ location.address.city }} ({{ location.address.postCode }})
+                    </li>
+                {% endif %}
                 {% if location.address.roadName %}
                 <li>
                     {{ location.address.roadName }}

--- a/tests/Unit/Domain/Regulation/LocationAddressTest.php
+++ b/tests/Unit/Domain/Regulation/LocationAddressTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Domain\Regulation;
 
-use App\Domain\Regulation\Exception\LocationAddressParsingException;
 use App\Domain\Regulation\LocationAddress;
 use PHPUnit\Framework\TestCase;
 
@@ -12,9 +11,10 @@ final class LocationAddressTest extends TestCase
 {
     public function testParsingFailure(): void
     {
-        $this->expectException(LocationAddressParsingException::class);
-        $this->expectExceptionMessageMatches("/^Address 'This is not a valid address' did not have expected format/");
-        LocationAddress::fromString('This is not a valid address');
+        $locationAddress = LocationAddress::fromString('This is not a valid address');
+        $this->assertSame(null, $locationAddress->getPostCode());
+        $this->assertSame(null, $locationAddress->getCity());
+        $this->assertSame('This is not a valid address', $locationAddress->getRoadName());
     }
 
     private function provideParseRoad(): array


### PR DESCRIPTION
Cette PR permet de ne plus avoir d'erreur 500 lorsque l'utilisateur saisi une adresse ne respectant pas le bon format. 