### PR TITLE
Reuse browsers across Docker Compose restarts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ install: build start install_deps dbinstall assets ## Bootstrap project
 install_deps: ## Install dependencies
 	make composer CMD="install -n --prefer-dist"
 	$(BIN_NPM) ci
-	$(BIN_NPX) playwright install --with-deps firefox chromium
+	$(BIN_NPX) playwright install firefox chromium
 
 update_deps:
 	make composer CMD="update"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.8"
 volumes:
   database: {}
   pgadmin-data: {}
+  playwright-data: {}
 
 services:
   database:
@@ -25,6 +26,7 @@ services:
     volumes:
       - ./:/var/www/dialog
       - ./docker/php/php.ini:/usr/local/etc/php/php.ini
+      - playwright-data:/root/.cache/ms-playwright
     depends_on:
       - database
 

--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -43,4 +43,7 @@ RUN curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | b
 RUN curl -sSk https://getcomposer.org/installer | php -- --disable-tls && \
    mv composer.phar /usr/local/bin/composer
 
+# Install Playwright browser dependencies
+RUN npx playwright install-deps firefox chromium
+
 CMD ["php-fpm"]


### PR DESCRIPTION
* Suie à #300 

Jusqu'ici, les navigateurs étaient "oubliés" par le conteneur lorsqu'on redémarrait Docker Compose (par exemple le matin après avoir éteint l'ordinateur la veille).

Cette PR met ces navigateurs en cache dans un volume, pour n'avoir à les installer qu'une fois.

## Pour tester

* `make stop`
* Accéder à cette branche
* Faire `make build` pour mettre à jour l'image
* Faire `make install_deps` pour installer les navigateurs
* Vérifier que `make test_e2e` lance bien les tests E2E
* `make restart`
* Vérifier que `make test_e2e` lance toujours bien les tests E2E (précédemment on aurait eu un message "Please run npx playwright install ...")