### PR TITLE
Fix form error handling in AddRegulationController

### DIFF
--- a/src/Infrastructure/Controller/Regulation/AddRegulationController.php
+++ b/src/Infrastructure/Controller/Regulation/AddRegulationController.php
@@ -4,14 +4,20 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Controller\Regulation;
 
+use App\Application\CommandBusInterface;
 use App\Application\Regulation\Command\SaveRegulationGeneralInfoCommand;
+use App\Domain\User\Exception\OrganizationAlreadyHasRegulationOrderWithThisIdentifierException;
 use App\Infrastructure\Form\Regulation\GeneralInfoFormType;
 use App\Infrastructure\Security\SymfonyUser;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Routing\RouterInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class AddRegulationController
 {
@@ -19,7 +25,9 @@ final class AddRegulationController
         private \Twig\Environment $twig,
         private FormFactoryInterface $formFactory,
         private Security $security,
+        private TranslatorInterface $translator,
         private RouterInterface $router,
+        private CommandBusInterface $commandBus,
     ) {
     }
 
@@ -28,25 +36,62 @@ final class AddRegulationController
         name: 'app_regulation_add',
         methods: ['GET', 'POST'],
     )]
-    public function __invoke(): Response
+    public function __invoke(Request $request): Response
     {
         /** @var SymfonyUser */
         $user = $this->security->getUser();
 
+        $command = new SaveRegulationGeneralInfoCommand();
+
         $form = $this->formFactory->create(
             type: GeneralInfoFormType::class,
-            data: new SaveRegulationGeneralInfoCommand(),
+            data: $command,
             options: [
                 'organizations' => [$user->getOrganization()],
-                'action' => $this->router->generate('fragment_regulations_general_info_form'),
+                'action' => $this->router->generate('app_regulation_add'),
+                'save_options' => [
+                    'label' => 'common.form.continue',
+                    'attr' => [
+                        'class' => 'fr-btn fr-btn--icon-right fr-icon-arrow-right-line',
+                    ],
+                ],
             ],
         );
+
+        $form->handleRequest($request);
+        $hasCommandFailed = false;
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            try {
+                $regulationOrderRecord = $this->commandBus->handle($command);
+
+                return new RedirectResponse(
+                    url: $this->router->generate('app_regulation_detail', [
+                        'uuid' => $regulationOrderRecord->getUuid(),
+                    ]),
+                    status: Response::HTTP_SEE_OTHER,
+                );
+            } catch (OrganizationAlreadyHasRegulationOrderWithThisIdentifierException) {
+                $hasCommandFailed = true;
+                $form->get('identifier')->addError(
+                    new FormError(
+                        $this->translator->trans('regulation.general_info.error.identifier', [], 'validators'),
+                    ),
+                );
+            }
+        }
 
         return new Response(
             $this->twig->render(
                 name: 'regulation/create.html.twig',
-                context: ['form' => $form->createView()],
+                context: [
+                    'form' => $form->createView(),
+                    'cancelUrl' => $this->router->generate('app_regulations_list'),
+                ],
             ),
+            status: ($form->isSubmitted() && !$form->isValid()) || $hasCommandFailed
+                ? Response::HTTP_UNPROCESSABLE_ENTITY
+                : Response::HTTP_OK,
         );
     }
 }

--- a/src/Infrastructure/Form/Regulation/GeneralInfoFormType.php
+++ b/src/Infrastructure/Form/Regulation/GeneralInfoFormType.php
@@ -74,13 +74,7 @@ final class GeneralInfoFormType extends AbstractType
             ->add(
                 'save',
                 SubmitType::class,
-                options: [
-                    'label' => $options['isEdit'] ? 'common.form.validate' : 'common.form.continue',
-                    'attr' => [
-                        'class' => $options['isEdit'] ? 'fr-btn' : 'fr-btn fr-btn--icon-right fr-icon-arrow-right-line',
-                        'data-turbo-frame' => !$options['isEdit'] ? '_top' : null,
-                    ],
-                ],
+                options: $options['save_options'],
             )
         ;
     }
@@ -90,9 +84,9 @@ final class GeneralInfoFormType extends AbstractType
         $resolver->setDefaults([
             'validation_groups' => ['Default', 'html_form'],
             'organizations' => [],
-            'isEdit' => false,
+            'save_options' => [],
         ]);
         $resolver->setAllowedTypes('organizations', 'array');
-        $resolver->setAllowedTypes('isEdit', 'bool');
+        $resolver->setAllowedTypes('save_options', 'array');
     }
 }

--- a/templates/regulation/_general_info_form.html.twig
+++ b/templates/regulation/_general_info_form.html.twig
@@ -1,0 +1,21 @@
+<div class="app-card">
+    <div class="app-card__img">
+        <span class="fr-icon-article-fill fr-x-icon-decorative--blue-france fr-x-icon--xl" aria-hidden="true"></span>
+    </div>
+    <div class="app-card__content">
+        <h3 class="fr-h4">
+            {{ 'regulation.general_info'|trans }}
+        </h3>
+        {{ form_start(form) }}
+            {{ form_row(form.identifier, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
+            {{ form_row(form.organization, {group_class: 'fr-select-group', widget_class: 'fr-select'}) }}
+            {{ form_row(form.description, {group_class: 'fr-input-group', attr: {class: 'fr-input'}, help_attr: {class: 'fr-hint-text'}}) }}
+            {{ form_row(form.startDate, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
+            {{ form_row(form.endDate, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
+            <a href="{{ cancelUrl }}" class="fr-btn fr-btn--tertiary fr-mr-3w">
+                {{ "common.cancel"|trans }}
+            </a>
+            {{ form_widget(form.save) }}
+        {{ form_end(form) }}
+    </div>
+</div>

--- a/templates/regulation/create.html.twig
+++ b/templates/regulation/create.html.twig
@@ -19,6 +19,6 @@
             {{ title }}
         </h2>
 
-        {% include "regulation/fragments/_general_info_form.html.twig" with { form } only %}
+        {% include "regulation/_general_info_form.html.twig" with { form, cancelUrl } only %}
     </div>
 {% endblock %}

--- a/templates/regulation/fragments/_general_info_form.html.twig
+++ b/templates/regulation/fragments/_general_info_form.html.twig
@@ -1,29 +1,3 @@
 <turbo-frame id="block_general_info">
-    <div class="app-card">
-        <div class="app-card__img">
-            <span class="fr-icon-article-fill fr-x-icon-decorative--blue-france fr-x-icon--xl" aria-hidden="true"></span>
-        </div>
-        <div class="app-card__content">
-            <h3 class="fr-h4">
-                {{ 'regulation.general_info'|trans }}
-            </h3>
-            {{ form_start(form) }}
-                {{ form_row(form.identifier, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
-                {{ form_row(form.organization, {group_class: 'fr-select-group', widget_class: 'fr-select'}) }}
-                {{ form_row(form.description, {group_class: 'fr-input-group', attr: {class: 'fr-input'}, help_attr: {class: 'fr-hint-text'}}) }}
-                {{ form_row(form.startDate, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
-                {{ form_row(form.endDate, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
-
-                {% set isEdit = isEdit|default(false) %}
-                <a
-                    href="{{ isEdit ? path('fragment_regulations_general_info', { uuid }) : path('app_regulations_list') }}"
-                    class="fr-btn fr-btn--tertiary fr-mr-3w"
-                    {% if not isEdit %}data-turbo-frame="_top"{% endif %}
-                >
-                    {{ "common.cancel"|trans }}
-                </a>
-                {{ form_widget(form.save) }}
-            {{ form_end(form) }}
-        </div>
-    </div>
+    {% include "regulation/_general_info_form.html.twig" with { form, cancelUrl } only %}
 </turbo-frame>

--- a/tests/Integration/Infrastructure/Controller/Regulation/AddRegulationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/AddRegulationControllerTest.php
@@ -19,8 +19,6 @@ final class AddRegulationControllerTest extends AbstractWebTestCase
         $this->assertMetaTitle('Nouvel arrêté - DiaLog', $crawler);
 
         $saveButton = $crawler->selectButton('Continuer');
-        $this->assertSame('_top', $saveButton->attr('data-turbo-frame'));
-
         $form = $saveButton->form();
         $form['general_info_form[identifier]'] = 'F022023';
         $form['general_info_form[organization]'] = '0eed3bec-7fe0-469b-a3e9-1c24251bf48c'; // Dialog
@@ -86,13 +84,10 @@ final class AddRegulationControllerTest extends AbstractWebTestCase
     public function testCancel(): void
     {
         $client = $this->login();
-        $crawler = $client->request('GET', '/regulations/add');
+        $client->request('GET', '/regulations/add');
         $this->assertResponseStatusCodeSame(200);
 
-        $link = $crawler->selectLink('Annuler');
-        $this->assertSame('_top', $link->attr('data-turbo-frame'));
-
-        $client->click($link->link());
+        $client->clickLink('Annuler');
         $this->assertResponseStatusCodeSame(200);
         $this->assertRouteSame('app_regulations_list');
     }


### PR DESCRIPTION
Closes #285

Cette PR corrige le bug de traitement du formulaire de création d'arrêté en "dupliquant" expliciement la logique de traitement du formulaire.

Pour cela,

* Le formulaire est véritablement isolé dans un composant `regulations/_general_info_form.html.twig`
* Le fragment `regulations/fragment/_general_info_form.html.twig` ne fait qu'entourer cela d'un `<turbo-frame>`
* Le contrôleur `AddRegulationController` traite lui-même le formulaire

Cela simplifie le code en faisant disparaître le booléen `$isEdit`.