### PR TITLE
Mandatory restrictions and remove duplicate button from regulations list

### DIFF
--- a/config/validator/Application/Regulation/Command/SaveRegulationGeneralInfoCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveRegulationGeneralInfoCommand.xml
@@ -17,12 +17,19 @@
         </property>
         <property name="category">
             <constraint name="NotBlank" />
-            <constraint name="Choice">
-                <value>roadMaintenance</value>
-                <value>permanentRegulation</value>
-                <value>incident</value>
-                <value>event</value>
-                <value>other</value>
+            <constraint name="When">
+                <option name="expression">
+                    this.category != 'N/C'
+                </option>
+                <option name="constraints">
+                    <constraint name="Choice">
+                        <value>roadMaintenance</value>
+                        <value>permanentRegulation</value>
+                        <value>incident</value>
+                        <value>event</value>
+                        <value>other</value>
+                    </constraint>
+                </option>
             </constraint>
         </property>
         <property name="otherCategoryText">

--- a/config/validator/Application/Regulation/Command/SaveRegulationLocationCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveRegulationLocationCommand.xml
@@ -21,6 +21,12 @@
             </constraint>
        </property>
        <property name="measures">
+            <constraint name="NotBlank">
+                <option name="message">location.measures.error.not_blank</option>
+                <option name="groups">
+                    <value>html_form</value>
+                </option>
+            </constraint>
             <constraint name="Valid"/>
        </property>
     </class>

--- a/src/Application/Regulation/Command/PublishRegulationCommandHandler.php
+++ b/src/Application/Regulation/Command/PublishRegulationCommandHandler.php
@@ -8,7 +8,6 @@ use App\Domain\Regulation\Enum\RegulationOrderRecordStatusEnum;
 use App\Domain\Regulation\Exception\RegulationOrderRecordCannotBePublishedException;
 use App\Domain\Regulation\Specification\CanRegulationOrderRecordBePublished;
 
-// TODO : Verify locations
 final class PublishRegulationCommandHandler
 {
     public function __construct(

--- a/src/Infrastructure/Controller/Regulation/DuplicateRegulationController.php
+++ b/src/Infrastructure/Controller/Regulation/DuplicateRegulationController.php
@@ -55,6 +55,7 @@ final class DuplicateRegulationController extends AbstractRegulationController
         /** @var SymfonyUser */
         $user = $this->security->getUser();
         $regulationOrderRecord = $this->getRegulationOrderRecord($uuid);
+        $regulationOrder = $regulationOrderRecord->getRegulationOrder();
 
         try {
             $duplicatedRegulationOrderRecord = $this->commandBus->handle(
@@ -71,11 +72,13 @@ final class DuplicateRegulationController extends AbstractRegulationController
             );
         } catch (OrganizationAlreadyHasRegulationOrderWithThisIdentifierException) {
             $session->getFlashBag()->add('error', $this->translator->trans('regulation.duplicated.identifier_error'));
-
-            return new RedirectResponse(
-                url: $this->router->generate('app_regulations_list'),
-                status: Response::HTTP_SEE_OTHER,
-            );
         }
+
+        return new RedirectResponse(
+            url: $this->router->generate('app_regulations_list', [
+                'tab' => $regulationOrder->getEndDate() ? 'temporary' : 'permanent',
+            ]),
+            status: Response::HTTP_SEE_OTHER,
+        );
     }
 }

--- a/src/Infrastructure/Form/Regulation/LocationFormType.php
+++ b/src/Infrastructure/Form/Regulation/LocationFormType.php
@@ -9,6 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class LocationFormType extends AbstractType
 {
@@ -45,6 +46,7 @@ final class LocationFormType extends AbstractType
                 'label' => 'regulation.measure_list',
                 'allow_add' => true,
                 'allow_delete' => true,
+                'error_bubbling' => false,
             ])
             ->add(
                 'save',
@@ -54,5 +56,12 @@ final class LocationFormType extends AbstractType
                 ],
             )
         ;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'validation_groups' => ['Default', 'html_form'],
+        ]);
     }
 }

--- a/templates/regulation/fragments/_location_form.html.twig
+++ b/templates/regulation/fragments/_location_form.html.twig
@@ -89,6 +89,7 @@
                     >
                         {{ 'regulation.measure.add'|trans }}
                     </button>
+                    {{ form_errors(form.measures) }}
                 </div>
 
                 <a href="{{ cancelUrl }}" class="fr-btn fr-btn--tertiary fr-mr-3w">{{ "common.cancel"|trans }}</a>

--- a/tests/Integration/Infrastructure/Controller/Regulation/DuplicateRegulationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/DuplicateRegulationControllerTest.php
@@ -32,6 +32,31 @@ final class DuplicateRegulationControllerTest extends AbstractWebTestCase
         $this->assertSame('Circulation alternée', $location->filter('li')->eq(2)->text());
     }
 
+    public function testWithoutLocations(): void
+    {
+        $client = $this->login();
+        $client->request('POST', '/regulations/b1a3e982-39a1-4f0e-8a6f-ea2fd5e872c2/duplicate', [
+            'token' => $this->generateCsrfToken($client, 'duplicate-regulation'),
+        ]);
+
+        $crawler = $client->followRedirect();
+
+        $this->assertSame('Arrêté temporaire FO1/2023 (copie) (copie)', $crawler->filter('h2')->text());
+        $this->assertSame('Copiée avec succès Vous pouvez modifier les informations que vous souhaitez dans cette copie de la réglementation.', $crawler->filter('div.fr-alert')->text());
+    }
+
+    public function testWithoutRestrictions(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('POST', '/regulations/3ede8b1a-1816-4788-8510-e08f45511cb5/duplicate', [
+            'token' => $this->generateCsrfToken($client, 'duplicate-regulation'),
+        ]);
+        $crawler = $client->followRedirect();
+
+        $this->assertSame('Arrêté temporaire FO2/2023 (copie)', $crawler->filter('h2')->text());
+        $this->assertSame('Copiée avec succès Vous pouvez modifier les informations que vous souhaitez dans cette copie de la réglementation.', $crawler->filter('div.fr-alert')->text());
+    }
+
     public function testDuplicateAnAlreadyExistingIdentifier(): void
     {
         $client = $this->login();

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
@@ -72,11 +72,15 @@ final class AddLocationControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Valider');
         $form = $saveButton->form();
-        $form['location_form[address]'] = 'Route du GEOCODING_FAILURE 44260 Savenay';
-        $form['location_form[fromHouseNumber]'] = '15';
-        $form['location_form[toHouseNumber]'] = '37bis';
+        // Get the raw values.
+        $values = $form->getPhpValues();
+        $values['location_form']['address'] = 'Route du GEOCODING_FAILURE 44260 Savenay';
+        $values['location_form']['fromHouseNumber'] = '15';
+        $values['location_form']['toHouseNumber'] = '37bis';
+        $values['location_form']['measures'][0]['type'] = 'noEntry';
 
-        $crawler = $client->submit($form);
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+
         $this->assertResponseStatusCodeSame(422);
         $this->assertStringStartsWith("En raison d'un problème technique", $crawler->filter('#location_form_error')->text());
     }

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
@@ -28,7 +28,6 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
         $this->assertStringContainsString('Cette valeur doit être l\'un des choix proposés.', $crawler->filter('#location_form_measures_0_type_error')->text());
     }
 
-    /** @group only */
     public function testEditAndAddMeasure(): void
     {
         $client = $this->login();
@@ -58,7 +57,7 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
     public function testRemoveMeasure(): void
     {
         $client = $this->login();
-        $crawler = $client->request('GET', '/_fragment/regulations/e413a47e-5928-4353-a8b2-8b7dda27f9a5/location/51449b82-5032-43c8-a427-46b9ddb44762/form');
+        $crawler = $client->request('GET', '/_fragment/regulations/4ce75a1f-82f3-40ee-8f95-48d0f04446aa/location/f15ed802-fa9b-4d75-ab04-d62ea46597e9/form');
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
@@ -72,7 +71,7 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
 
         $crawler = $client->followRedirect();
         $this->assertResponseStatusCodeSame(200);
-        $this->assertRouteSame('fragment_regulations_location', ['uuid' => '51449b82-5032-43c8-a427-46b9ddb44762']);
+        $this->assertRouteSame('fragment_regulations_location', ['uuid' => 'f15ed802-fa9b-4d75-ab04-d62ea46597e9']);
         $this->assertNotContains('Circulation interdite', $crawler->filter('li')->extract(['_text']));
     }
 

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -79,6 +79,10 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $saveButton = $crawler->selectButton('Valider');
         $this->assertSame("Indiquez la voie concernée et la ville. Si la restriction s'applique à toute la ville, indiquez la ville uniquement.", $crawler->filter('#location_form_address_help')->text());
         $this->assertSame(1, $saveButton->count()); // Location form
+
+        $duplicateButton = $crawler->selectButton('Dupliquer')->form();
+        $this->assertSame($duplicateButton->getUri(), 'http://localhost/regulations/b1a3e982-39a1-4f0e-8a6f-ea2fd5e872c2/duplicate');
+        $this->assertSame($duplicateButton->getMethod(), 'POST');
     }
 
     public function testPublishedRegulationDetail(): void

--- a/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
@@ -34,12 +34,7 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
         $this->commandBus = $this->createMock(CommandBusInterface::class);
         $this->organization = $this->createMock(Organization::class);
         $this->originalRegulationOrder = $this->createMock(RegulationOrder::class);
-
         $this->originalRegulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
-        $this->originalRegulationOrderRecord
-            ->expects(self::once())
-            ->method('getRegulationOrder')
-            ->willReturn($this->originalRegulationOrder);
     }
 
     public function testRegulationFullyDuplicated(): void
@@ -56,6 +51,11 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
             ->expects(self::once())
             ->method('getType')
             ->willReturn(MeasureTypeEnum::ALTERNATE_ROAD->value);
+
+        $this->originalRegulationOrderRecord
+            ->expects(self::once())
+            ->method('getRegulationOrder')
+            ->willReturn($this->originalRegulationOrder);
 
         $location1 = $this->createMock(Location::class);
         $location1

--- a/translations/validators.fr.xlf
+++ b/translations/validators.fr.xlf
@@ -30,6 +30,10 @@
                 <source>location.error.valid_address</source>
                 <target>Veuillez saisir une adresse valide. Ex : Rue Saint-Léonard, 49000 Angers.</target>
             </trans-unit>
+            <trans-unit id="location.measures.error.not_blank">
+                <source>location.measures.error.not_blank</source>
+                <target>Veuillez définir une ou plusieurs restrictions.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Cette PR permet de : 
- [x] Supprimer le bouton duplication de la liste des arrêtés
- [x] Rendre l'ajout d'une restriction obligatoire sur le formulaire d'une localisation (ajout ou édition)
- [x] Ne plus rendre obligatoire les localisations et les restrictions sur une duplication 

À tester ici https://dialog-staging-pr326.osc-fr1.scalingo.io/