### PR TITLE
Init general form type with start date to tomorrow

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -74,6 +74,9 @@ when@test:
             # See: https://symfony.com/doc/current/service_container/service_decoration.html
             decorates: 'api.adresse.client'
             decoration_inner_name: 'App\Tests\Mock\APIAdresseMockClient::api.adresse.client'
+        App\Tests\Mock\DateUtilsMock:
+            decorates: App\Infrastructure\Adapter\DateUtils
+            arguments: ['@.inner']
 
         Psr\Log\NullLogger: ~
         logger: '@Psr\Log\NullLogger'

--- a/src/Application/DateUtilsInterface.php
+++ b/src/Application/DateUtilsInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application;
+
+interface DateUtilsInterface
+{
+    public function getTomorrow(): \DateTimeImmutable;
+}

--- a/src/Application/Regulation/Command/SaveRegulationGeneralInfoCommand.php
+++ b/src/Application/Regulation/Command/SaveRegulationGeneralInfoCommand.php
@@ -23,13 +23,14 @@ final class SaveRegulationGeneralInfoCommand implements CommandInterface
 
     public static function create(
         RegulationOrderRecord $regulationOrderRecord = null,
+        \DateTimeImmutable $startDate = null,
     ): self {
         $regulationOrder = $regulationOrderRecord?->getRegulationOrder();
         $command = new self($regulationOrderRecord);
         $command->organization = $regulationOrderRecord?->getOrganization();
         $command->identifier = $regulationOrder?->getIdentifier();
         $command->description = $regulationOrder?->getDescription();
-        $command->startDate = $regulationOrder?->getStartDate();
+        $command->startDate = $startDate ?? $regulationOrder?->getStartDate();
         $command->endDate = $regulationOrder?->getEndDate();
 
         return $command;

--- a/src/Infrastructure/Adapter/DateUtils.php
+++ b/src/Infrastructure/Adapter/DateUtils.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Adapter;
+
+use App\Application\DateUtilsInterface;
+
+final class DateUtils implements DateUtilsInterface
+{
+    private \DateTimeZone $clientTimezone;
+
+    public function __construct(
+        string $clientTimezone,
+    ) {
+        $this->clientTimezone = new \DateTimeZone($clientTimezone);
+    }
+
+    public function getTomorrow(): \DateTimeImmutable
+    {
+        return \DateTimeImmutable::createFromInterface(
+            new \DateTime('tomorrow'),
+        )->setTimeZone($this->clientTimezone);
+    }
+}

--- a/src/Infrastructure/Controller/Regulation/AddRegulationController.php
+++ b/src/Infrastructure/Controller/Regulation/AddRegulationController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\Controller\Regulation;
 
 use App\Application\CommandBusInterface;
+use App\Application\DateUtilsInterface;
 use App\Application\Regulation\Command\SaveRegulationGeneralInfoCommand;
 use App\Domain\User\Exception\OrganizationAlreadyHasRegulationOrderWithThisIdentifierException;
 use App\Infrastructure\Form\Regulation\GeneralInfoFormType;
@@ -28,6 +29,7 @@ final class AddRegulationController
         private TranslatorInterface $translator,
         private RouterInterface $router,
         private CommandBusInterface $commandBus,
+        private DateUtilsInterface $dateUtils,
     ) {
     }
 
@@ -40,8 +42,7 @@ final class AddRegulationController
     {
         /** @var SymfonyUser */
         $user = $this->security->getUser();
-
-        $command = new SaveRegulationGeneralInfoCommand();
+        $command = SaveRegulationGeneralInfoCommand::create(null, $this->dateUtils->getTomorrow());
 
         $form = $this->formFactory->create(
             type: GeneralInfoFormType::class,

--- a/tests/Integration/Infrastructure/Controller/Regulation/AddRegulationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/AddRegulationControllerTest.php
@@ -20,6 +20,7 @@ final class AddRegulationControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Continuer');
         $form = $saveButton->form();
+        $this->assertSame('2023-05-10', $form->get('general_info_form[startDate]')->getValue()); // Init with tomorrow date
         $form['general_info_form[identifier]'] = 'F022023';
         $form['general_info_form[organization]'] = '0eed3bec-7fe0-469b-a3e9-1c24251bf48c'; // Dialog
         $form['general_info_form[description]'] = 'Interdiction de circuler dans Paris';

--- a/tests/Mock/DateUtilsMock.php
+++ b/tests/Mock/DateUtilsMock.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Mock;
+
+use App\Application\DateUtilsInterface;
+
+final class DateUtilsMock implements DateUtilsInterface
+{
+    public function getTomorrow(): \DateTimeImmutable
+    {
+        return new \DateTimeImmutable('2023-05-10');
+    }
+}

--- a/tests/Unit/Infrastructure/Adapter/DateUtilsTest.php
+++ b/tests/Unit/Infrastructure/Adapter/DateUtilsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure\Adapter;
+
+use App\Infrastructure\Adapter\DateUtils;
+use PHPUnit\Framework\TestCase;
+
+final class DateUtilsTest extends TestCase
+{
+    public function testTomorrow(): void
+    {
+        $dateUtils = new DateUtils('Europe/Paris');
+
+        $this->assertEquals(new \DateTimeImmutable('tomorrow'), $dateUtils->getTomorrow());
+    }
+}


### PR DESCRIPTION
Suite à la remarque d'@astranchet (https://github.com/MTES-MCT/dialog/pull/326#issuecomment-1542250469), cette PR permet d'initialiser le formulaire avec la date de début de l'arrêté au lendemain.

A tester ici https://dialog-staging-pr328.osc-fr1.scalingo.io/