### PR TITLE
Remove the notion of decorator useless in our case

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -74,9 +74,7 @@ when@test:
             # See: https://symfony.com/doc/current/service_container/service_decoration.html
             decorates: 'api.adresse.client'
             decoration_inner_name: 'App\Tests\Mock\APIAdresseMockClient::api.adresse.client'
-        App\Tests\Mock\DateUtilsMock:
-            decorates: App\Infrastructure\Adapter\DateUtils
-            arguments: ['@.inner']
-
+        App\Infrastructure\Adapter\DateUtils:
+            class: App\Tests\Mock\DateUtilsMock
         Psr\Log\NullLogger: ~
         logger: '@Psr\Log\NullLogger'


### PR DESCRIPTION
Suite à la PR #328 ; je me suis rendu compte qu'un simple override de class était suffisant dans ce cas.