### PR TITLE
Remove datex link

### DIFF
--- a/templates/regulation/index.html.twig
+++ b/templates/regulation/index.html.twig
@@ -56,9 +56,6 @@
                 } only %}
             </div>
         </div>
-        <a href="{{ path('api_regulations_list', { _format: 'xml' }) }}" target="_blank">
-            {{ "regulation.link.datex"|trans }}
-        </a>
     </section>
 {% endblock %}
 

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -210,10 +210,6 @@
                 <source>regulation.list.total_permanent</source>
                 <target>Permanents (%count%)</target>
             </trans-unit>
-            <trans-unit id="regulation.link.datex">
-                <source>regulation.link.datex</source>
-                <target>Accéder au flux de données (DATEX II)</target>
-            </trans-unit>
             <trans-unit id="regulation.list.empty">
                 <source>regulation.list.empty</source>
                 <target>Aucun arrêté</target>


### PR DESCRIPTION
Cette PR permet de supprimer le lien datex présent sur la liste des arrêtés. La motivation est simple : les données présentes ne sont pas à jour et ce n'est pas implémenté dans la maquette.