### PR TITLE
Add basic GACS sync command

### DIFF
--- a/.env
+++ b/.env
@@ -18,6 +18,7 @@ APP_ENV=dev
 APP_SERVER_TIMEZONE=UTC
 APP_CLIENT_TIMEZONE=Europe/Paris
 APP_SECRET=abc
+APP_GACS_BASE_URL=https://eudonet.apps.paris.fr
 DATABASE_URL="postgresql://dialog:dialog@database:5432/dialog"
 REDIS_URL="redis://redis:6379"
 API_ADRESSE_BASE_URL=https://api-adresse.data.gouv.fr

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -23,6 +23,8 @@ framework:
         scoped_clients:
             api.adresse.client:
                 base_uri: '%env(API_ADRESSE_BASE_URL)%'
+            gacs.http.client:
+                base_uri: '%env(APP_GACS_BASE_URL)%'
 
 when@test:
     framework:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,6 +6,7 @@
 parameters:
     server_timezone: '%env(APP_SERVER_TIMEZONE)%'
     client_timezone: '%env(APP_CLIENT_TIMEZONE)%'
+    gacs_credentials: '%env(APP_GACS_CREDENTIALS)%'
 
 services:
     # default configuration for services in *this* file
@@ -48,6 +49,10 @@ services:
 
     App\Infrastructure\Adapter\CommandBus:
         $commandBus: '@messenger.bus.commands'
+
+    App\Infrastructure\Integrations\Gacs\Client\GacsClient:
+        arguments:
+            $credentials: '%gacs_credentials%'
 
     command_handlers:
         namespace: App\Application\

--- a/src/Application/User/Query/GetOrganizationByUuidQuery.php
+++ b/src/Application/User/Query/GetOrganizationByUuidQuery.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Query;
+
+use App\Application\QueryInterface;
+
+final class GetOrganizationByUuidQuery implements QueryInterface
+{
+    public function __construct(
+        public readonly string $uuid,
+    ) {
+    }
+}

--- a/src/Application/User/Query/GetOrganizationByUuidQueryHandler.php
+++ b/src/Application/User/Query/GetOrganizationByUuidQueryHandler.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Query;
+
+use App\Domain\User\Exception\OrganizationNotFoundException;
+use App\Domain\User\Organization;
+use App\Domain\User\Repository\OrganizationRepositoryInterface;
+
+final class GetOrganizationByUuidQueryHandler
+{
+    public function __construct(
+        private OrganizationRepositoryInterface $organizationRepository,
+    ) {
+    }
+
+    public function __invoke(GetOrganizationByUuidQuery $query): Organization
+    {
+        $organization = $this->organizationRepository->findOneByUuid(
+            $query->uuid,
+        );
+
+        if (!$organization instanceof Organization) {
+            throw new OrganizationNotFoundException();
+        }
+
+        return $organization;
+    }
+}

--- a/src/Domain/User/Exception/OrganizationNotFoundException.php
+++ b/src/Domain/User/Exception/OrganizationNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Exception;
+
+final class OrganizationNotFoundException extends \Exception
+{
+}

--- a/src/Domain/User/Repository/OrganizationRepositoryInterface.php
+++ b/src/Domain/User/Repository/OrganizationRepositoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Repository;
+
+use App\Domain\User\Organization;
+
+interface OrganizationRepositoryInterface
+{
+    public function findOneByUuid(string $uuid): ?Organization;
+}

--- a/src/Infrastructure/Integrations/Gacs/Client/GacsClient.php
+++ b/src/Infrastructure/Integrations/Gacs/Client/GacsClient.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Integrations\Gacs\Client;
+
+use App\Infrastructure\Integrations\Gacs\Models\GacsArrete;
+use App\Infrastructure\Integrations\Gacs\Models\GacsLocalisation;
+use App\Infrastructure\Integrations\Gacs\Models\GacsMesure;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class GacsClient
+{
+    // See: https://eudonet.apps.paris.fr/eudoapi/eudoapidoc/lexique_FR.html
+    private const EQUALS = 0;
+    private const GREATER_THAN = 3;
+    private const AND = 1;
+    private const TEMPORAIRE = 8;
+
+    private string|null $token;
+    private \DateTimeInterface|null $tokenExpiryDate;
+
+    public function __construct(
+        private HttpClientInterface $gacsHttpClient,
+        private string $credentials,
+    ) {
+        $this->token = null;
+        $this->tokenExpiryDate = null;
+    }
+
+    private function ensureAuthenticated(): void
+    {
+        if (null !== $this->token && $this->tokenExpiryDate > new \DateTimeImmutable('now')) {
+            return;
+        }
+
+        $this->token = null;
+        $this->tokenExpiryDate = null;
+
+        $response = $this->gacsHttpClient->request('POST', '/EudoAPI/Authenticate/Token', [
+            'headers' => ['Content-Type: application/json'],
+            'body' => $this->credentials,
+        ]);
+
+        $data = $response->toArray();
+        $this->token = $data['ResultData']['Token'];
+        $this->tokenExpiryDate = \DateTimeImmutable::createFromFormat('Y/m/d H:i:s', $data['ResultData']['ExpirationDate'], new \DateTimeZone('Europe/Paris'));
+    }
+
+    private function request(string $method, string $url, array $options = []): ResponseInterface
+    {
+        $this->ensureAuthenticated();
+        $headers = array_merge($options['headers'], ["X-Auth: $this->token"]);
+        $options = array_merge($options, ['headers' => $headers]);
+
+        return $this->gacsHttpClient->request($method, $url, $options);
+    }
+
+    private function search(int $tabId, array $listCols, array $whereCustom = [], int $maxPages = 1): array
+    {
+        $pageNumber = 1;
+        $rows = [];
+
+        for ($pageNumber = 1; $pageNumber <= $maxPages; ++$pageNumber) {
+            $response = $this->request('POST', sprintf('/EudoAPI/Search/%s', $tabId), [
+                'headers' => ['Content-Type: application/json'],
+                'body' => json_encode([
+                    'ShowMetadata' => true,
+                    'RowsPerPage' => 50,
+                    'NumPage' => $pageNumber,
+                    'ListCols' => $listCols,
+                    'WhereCustom' => $whereCustom,
+                ]),
+            ]);
+
+            $data = $response->toArray();
+
+            foreach ($data['ResultData']['Rows'] as $row) {
+                $fields = [];
+
+                foreach ($row['Fields'] as $field) {
+                    $fields[$field['DescId']] = $field['Value'];
+                }
+
+                $rows[] = ['fileId' => $row['FileId'], 'fields' => $fields];
+            }
+        }
+
+        return $rows;
+    }
+
+    public function findActiveTemporaryArreteRows(): array
+    {
+        return $this->search(
+            tabId: GacsArrete::TAB_ID,
+            listCols: GacsArrete::listCols(),
+            whereCustom: [
+                'WhereCustoms' => [
+                    [
+                        'Criteria' => [
+                            'Field' => GacsArrete::TYPE,
+                            'Operator' => self::EQUALS,
+                            'Value' => self::TEMPORAIRE,
+                        ],
+                    ],
+                    [
+                        'Criteria' => [
+                            'Field' => GacsArrete::DATE_FIN,
+                            'Operator' => self::GREATER_THAN,
+                            'Value' => (new \DateTimeImmutable('now'))->setTimezone(new \DateTimeZone('Europe/Paris'))->format('Y/m/d H:i:s'),
+                        ],
+                        'InterOperator' => self::AND,
+                    ],
+                ],
+            ],
+            maxPages: 5,
+        );
+    }
+
+    public function findMesureRowsByArreteFileId(int $fileId): array
+    {
+        return $this->search(
+            tabId: GacsMesure::TAB_ID,
+            listCols: GacsMesure::listCols(),
+            whereCustom: [
+                'Criteria' => [
+                    'Field' => GacsArrete::TAB_ID,
+                    'Operator' => self::EQUALS,
+                    'Value' => $fileId,
+                ],
+            ],
+        );
+    }
+
+    public function findLocalisationRowsByMesureFileId(int $fileId): array
+    {
+        return $this->search(
+            tabId: GacsLocalisation::TAB_ID,
+            listCols: GacsLocalisation::listCols(),
+            whereCustom: [
+                'Criteria' => [
+                    'Field' => GacsMesure::TAB_ID,
+                    'Operator' => self::EQUALS,
+                    'Value' => $fileId,
+                ],
+            ],
+        );
+    }
+}

--- a/src/Infrastructure/Integrations/Gacs/Exception/SkipException.php
+++ b/src/Infrastructure/Integrations/Gacs/Exception/SkipException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Integrations\Gacs\Exception;
+
+final class SkipException extends \Exception
+{
+}

--- a/src/Infrastructure/Integrations/Gacs/Models/GacsArrete.php
+++ b/src/Infrastructure/Integrations/Gacs/Models/GacsArrete.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Integrations\Gacs\Models;
+
+use App\Application\Regulation\Command\SaveRegulationGeneralInfoCommand;
+use App\Domain\Regulation\Enum\RegulationOrderCategoryEnum;
+use App\Domain\User\Organization;
+use App\Infrastructure\Integrations\Gacs\Exception\SkipException;
+
+final class GacsArrete
+{
+    public const TAB_ID = 1100;
+    public const ID = 1101;
+    public const COMPLEMENT_DE_TITRE = 1102;
+    public const TYPE = 1108;
+    public const DATE_DEBUT = 1109;
+    public const DATE_FIN = 1110;
+    public const SIGNE_LE = 1111;
+    public const CREE_LE = 1195;
+
+    public function __construct(
+        public readonly int $fileId,
+        public readonly string $id,
+        public readonly string $complementDeTitre,
+        public readonly string $type,
+        public readonly \DateTimeInterface $dateDebut,
+        public readonly ?\DateTimeInterface $dateFin,
+    ) {
+    }
+
+    public static function listCols(): array
+    {
+        return [
+            self::ID,
+            self::COMPLEMENT_DE_TITRE,
+            self::TYPE,
+            self::DATE_DEBUT,
+            self::DATE_FIN,
+            self::SIGNE_LE,
+        ];
+    }
+
+    public static function fromRow(array $row): self
+    {
+        $dateDebutSource = $row['fields'][self::DATE_DEBUT] ?: $row['fields'][self::SIGNE_LE] ?: null;
+
+        if ($dateDebutSource === null) {
+            throw new SkipException('DATE_DEBUT is empty');
+        }
+
+        $dateDebut = \DateTimeImmutable::createFromFormat(
+            'Y/m/d H:i:s',
+            $dateDebutSource,
+            new \DateTimeZone('Europe/Paris'),
+        );
+
+        if ($row['fields'][self::DATE_FIN]) {
+            $dateFin = \DateTimeImmutable::createFromFormat(
+                'Y/m/d H:i:s', $row['fields'][self::DATE_FIN],
+                new \DateTimeZone('Europe/Paris'),
+            );
+        } else {
+            $dateFin = null;
+        }
+
+        return new self(
+            fileId: $row['fileId'],
+            id: $row['fields'][self::ID],
+            // TODO: increase character limit?
+            // TODO: handle HTML
+            complementDeTitre: mb_substr($row['fields'][self::COMPLEMENT_DE_TITRE], 0, 255),
+            type: $row['fields'][self::TYPE],
+            dateDebut: $dateDebut,
+            dateFin: $dateFin,
+        );
+    }
+
+    public function asCommand(Organization $organization): SaveRegulationGeneralInfoCommand
+    {
+        $command = new SaveRegulationGeneralInfoCommand();
+
+        // TODO: status
+
+        $command->identifier = $this->id;
+        $command->description = $this->complementDeTitre;
+        $command->organization = $organization;
+        $command->startDate = $this->dateDebut;
+        $command->endDate = $this->dateFin;
+
+        if (($type = $this->type) === 'Permanent') {
+            $command->category = RegulationOrderCategoryEnum::PERMANENT_REGULATION->value;
+        } else {
+            $command->category = RegulationOrderCategoryEnum::OTHER->value;
+            $command->otherCategoryText = $type;
+        }
+
+        return $command;
+    }
+}

--- a/src/Infrastructure/Integrations/Gacs/Models/GacsLocalisation.php
+++ b/src/Infrastructure/Integrations/Gacs/Models/GacsLocalisation.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Integrations\Gacs\Models;
+
+use App\Application\Regulation\Command\SaveMeasureCommand;
+use App\Application\Regulation\Command\SaveRegulationLocationCommand;
+use App\Domain\Regulation\LocationAddress;
+use App\Domain\Regulation\RegulationOrderRecord;
+use App\Infrastructure\Integrations\Gacs\Exception\SkipException;
+
+final class GacsLocalisation
+{
+    public const TAB_ID = 2700;
+    public const PORTE_SUR = 2705;
+    public const ARRONDISSEMENT = 2708;
+    public const LIBELLE_VOIE = 2710;
+    public const LIBELLE_VOIE_DEBUT = 2730;
+    public const LIBELLE_VOIE_FIN = 2740;
+    public const N_ADRESSE = 2755;
+    public const N_ADRESSE_DEBUT = 2720;
+    public const N_ADRESSE_FIN = 2737;
+    public const LIBELLE_ADRESSE_DEBUT = 2736;
+    public const LIBELLE_ADRESSE_FIN = 2751;
+
+    private const ARRONDISSEMENT_REGEX = '/^(?<value>\d+)(er|e|ème|eme)\s+arrondissement$/i';
+    private const LIBELLE_ADRESSE_ROAD_NAME_REGEX = '/^(?<houseNumber>\d+\s*(bis|b|ter|t|quater|q)?)\s+(?<roadName>.*)$/i';
+    private const POINT_HOUSE_NUMBERS_REGEX = '/([nN°]\s*)?(?<fromHouseNumber>\d+\s*(bis|b|ter|t|quater|q)?)(\s+(au|à|et)\s+([nN]°\s*)?(<?toHouseNumber>\d+\s*(bis|b|ter|t|quater|q)?))?$/i';
+
+    public function __construct(
+        public readonly int $fileId,
+        public readonly string $porteSur,
+        public readonly ?int $arrondissement,
+        public readonly ?string $libelleVoie,
+        public readonly ?string $libelleVoieDebut,
+        public readonly ?string $libelleVoieFin,
+        public readonly ?string $libelleAdresseDebut,
+        public readonly ?string $libelleAdresseFin,
+        public readonly ?string $numAdresse,
+        public readonly ?string $numAdresseDebut,
+        public readonly ?string $numAdresseFin,
+    ) {
+    }
+
+    public static function listCols(): array
+    {
+        return [
+            self::PORTE_SUR,
+            self::ARRONDISSEMENT,
+            self::LIBELLE_VOIE,
+            self::LIBELLE_VOIE_DEBUT,
+            self::LIBELLE_VOIE_FIN,
+            self::LIBELLE_ADRESSE_DEBUT,
+            self::LIBELLE_ADRESSE_FIN,
+            self::N_ADRESSE,
+            self::N_ADRESSE_DEBUT,
+            self::N_ADRESSE_FIN,
+        ];
+    }
+
+    private static function parseArrondissement(?string $value): int
+    {
+        if (!$value) {
+            throw new SkipException('ARRONDISSEMENT is empty');
+        }
+
+        $matches = [];
+
+        if (!preg_match(self::ARRONDISSEMENT_REGEX, $value, $matches)) {
+            $msg = sprintf("ARRONDISSEMENT value '%s' did not have expected format '%s'", $value, self::ARRONDISSEMENT_REGEX);
+            throw new SkipException($msg);
+        }
+
+        return (int) $matches['value'];
+    }
+
+    public static function fromRow(array $row): self
+    {
+        return new self(
+            fileId: $row['fileId'],
+            porteSur: $row['fields'][self::PORTE_SUR],
+            arrondissement: self::parseArrondissement($row['fields'][self::ARRONDISSEMENT]),
+            libelleVoie: $row['fields'][self::LIBELLE_VOIE],
+            libelleVoieDebut: $row['fields'][self::LIBELLE_VOIE_DEBUT],
+            libelleVoieFin: $row['fields'][self::LIBELLE_VOIE_FIN],
+            libelleAdresseDebut: $row['fields'][self::LIBELLE_ADRESSE_DEBUT],
+            libelleAdresseFin: $row['fields'][self::LIBELLE_ADRESSE_FIN],
+            numAdresse: $row['fields'][self::N_ADRESSE],
+            numAdresseDebut: $row['fields'][self::N_ADRESSE_DEBUT],
+            numAdresseFin: $row['fields'][self::N_ADRESSE_FIN],
+        );
+    }
+
+    private function getRoadInfo(): array
+    {
+        if (
+            $this->porteSur === 'La totalité de la voie'
+            && $this->libelleVoie
+        ) {
+            return [
+                'roadName' => $this->libelleVoie,
+                'fromHouseNumber' => null,
+                'toHouseNumber' => null,
+            ];
+        }
+
+        if (
+            $this->porteSur === 'Une section'
+            && $this->libelleVoie
+            && (!$this->libelleVoieDebut || ($this->libelleVoieDebut === $this->libelleVoie))
+            && (!$this->libelleVoieFin || ($this->libelleVoieFin === $this->libelleVoie))
+            && (!$this->libelleAdresseDebut || (
+                preg_match(self::LIBELLE_ADRESSE_ROAD_NAME_REGEX, $this->libelleAdresseDebut, $debutMatches)
+                && $debutMatches['roadName'] === $this->libelleVoie
+            ))
+            && (!$this->libelleAdresseFin || (
+                preg_match(self::LIBELLE_ADRESSE_ROAD_NAME_REGEX, $this->libelleAdresseFin, $finMatches)
+                && $finMatches['roadName'] === $this->libelleVoie
+            ))
+        ) {
+            return [
+                'roadName' => $this->libelleVoie,
+                'fromHouseNumber' => $this->numAdresseDebut ?? null,
+                'toHouseNumber' => $this->numAdresseFin ?? null,
+            ];
+        }
+
+        if (
+            $this->libelleAdresseDebut
+            && $this->libelleAdresseFin
+            && preg_match(self::LIBELLE_ADRESSE_ROAD_NAME_REGEX, $this->libelleAdresseDebut, $debutMatches)
+            && preg_match(self::LIBELLE_ADRESSE_ROAD_NAME_REGEX, $this->libelleAdresseFin, $finMatches)
+            && $debutMatches['roadName']
+            && $finMatches['roadName']
+            && ($debutMatches['roadName'] === $finMatches['roadName'])
+            && (
+                $this->porteSur === 'Une section'
+                || (
+                    $this->porteSur === 'Une zone'
+                    && strtolower($this->libelleVoie) === strtolower($debutMatches['roadName'])
+                )
+            )
+        ) {
+            return [
+                'roadName' => $debutMatches['roadName'],
+                'fromHouseNumber' => $debutMatches['houseNumber'] ?? null,
+                'toHouseNumber' => $finMatches['houseNumber'] ?? null,
+            ];
+        }
+
+        if (
+            $this->porteSur === 'Un point'
+            && $this->libelleVoie
+            && $this->numAdresse
+            && preg_match(self::POINT_HOUSE_NUMBERS_REGEX, $this->numAdresse, $pointMatches)
+        ) {
+            return [
+                'roadName' => $this->libelleVoie,
+                'fromHouseNumber' => $pointMatches['fromHouseNumber'],
+                'toHouseNumber' => empty($pointMatches['toHouseNumber']) ? $pointMatches['fromHouseNumber'] : $pointMatches['toHouseNumber'],
+            ];
+        }
+
+        throw new SkipException(sprintf('Could not extract road info from: %s', var_export($this, return: true)));
+    }
+
+    public function asCommand(RegulationOrderRecord $regulationOrderRecord, SaveMeasureCommand $measureCommand): SaveRegulationLocationCommand
+    {
+        $command = new SaveRegulationLocationCommand($regulationOrderRecord);
+
+        $roadInfo = $this->getRoadInfo();
+
+        $locationAddress = new LocationAddress(
+            postCode: sprintf('750%s', str_pad((string) $this->arrondissement, 2, '0', STR_PAD_LEFT)),
+            city: 'Paris',
+            roadName: $roadInfo['roadName'],
+        );
+
+        $command->address = (string) $locationAddress;
+        $command->fromHouseNumber = $roadInfo['fromHouseNumber'];
+        $command->toHouseNumber = $roadInfo['toHouseNumber'];
+        $command->measures[] = $measureCommand;
+
+        return $command;
+    }
+}

--- a/src/Infrastructure/Integrations/Gacs/Models/GacsMesure.php
+++ b/src/Infrastructure/Integrations/Gacs/Models/GacsMesure.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Integrations\Gacs\Models;
+
+use App\Application\Regulation\Command\SaveMeasureCommand;
+use App\Domain\Regulation\Enum\MeasureTypeEnum;
+use App\Infrastructure\Integrations\Gacs\Exception\SkipException;
+
+final class GacsMesure
+{
+    public const TAB_ID = 1200;
+    public const NOM = 1202;
+
+    private const CIRCULATION_ALTERNEE = 102;
+    private const CIRCULATION_INTERDITE = 103;
+    private const LIMITATION_DE_VITESSE = 113;
+    private const SENS_INTERDIT_OU_SENS_UNIQUE = 125;
+
+    public function __construct(
+        public readonly int $fileId,
+        public readonly string $nom,
+    ) {
+    }
+
+    public static function listCols(): array
+    {
+        return [
+            self::NOM,
+        ];
+    }
+
+    public static function getNomChoices(): array
+    {
+        return [
+            self::CIRCULATION_ALTERNEE,
+            self::CIRCULATION_INTERDITE,
+            self::LIMITATION_DE_VITESSE,
+            self::SENS_INTERDIT_OU_SENS_UNIQUE,
+        ];
+    }
+
+    public static function fromRow(array $row): self
+    {
+        return new self(
+            fileId: $row['fileId'],
+            nom: $row['fields'][self::NOM],
+        );
+    }
+
+    public function asCommand(): SaveMeasureCommand
+    {
+        $command = new SaveMeasureCommand();
+
+        $command->type = match ($this->nom) {
+            'circulation alternée' => MeasureTypeEnum::ALTERNATE_ROAD->value,
+            'circulation interdite' => MeasureTypeEnum::NO_ENTRY->value,
+            'limitation de vitesse' => MeasureTypeEnum::SPEED_LIMITATION->value,
+            'sens interdit (ou sens unique)' => MeasureTypeEnum::ONE_WAY_TRAFFIC->value,
+            default => throw new SkipException(sprintf("Unexpected measure type name: '%s'", $this->nom)),
+        };
+
+        return $command;
+    }
+}

--- a/src/Infrastructure/Integrations/Gacs/README.md
+++ b/src/Infrastructure/Integrations/Gacs/README.md
@@ -1,0 +1,10 @@
+# Intégration GACS
+
+GACS est le système de gestion des arrêtés de circulation de la Ville de Paris.
+
+Il est propulsé par le logiciel Eudonet.
+
+* Documentation de l'API : https://eudonet.apps.paris.fr/eudoapi/eudoapidoc/swaggerui/
+* Lexique : https://eudonet.apps.paris.fr/eudoapi/eudoapidoc/lexique_FR.html
+
+DiaLog propose une intégration avec ce système.

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Organization/OrganizationRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Organization/OrganizationRepository.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Repository\Organization;
+
+use App\Domain\User\Organization;
+use App\Domain\User\Repository\OrganizationRepositoryInterface;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class OrganizationRepository extends ServiceEntityRepository implements OrganizationRepositoryInterface
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, Organization::class);
+    }
+
+    public function findOneByUuid(string $uuid): ?Organization
+    {
+        return $this->createQueryBuilder('o')
+            ->where('o.uuid = :uuid')
+            ->setParameter('uuid', $uuid)
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult()
+        ;
+    }
+}

--- a/src/Infrastructure/Symfony/Command/SyncGacsCommand.php
+++ b/src/Infrastructure/Symfony/Command/SyncGacsCommand.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Symfony\Command;
+
+use App\Application\CommandBusInterface;
+use App\Application\QueryBusInterface;
+use App\Application\User\Query\GetOrganizationByUuidQuery;
+use App\Infrastructure\Integrations\Gacs\Client\GacsClient;
+use App\Infrastructure\Integrations\Gacs\Exception\SkipException;
+use App\Infrastructure\Integrations\Gacs\Models\GacsArrete;
+use App\Infrastructure\Integrations\Gacs\Models\GacsLocalisation;
+use App\Infrastructure\Integrations\Gacs\Models\GacsMesure;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(
+    name: 'app:integrations:gacs:sync',
+    description: 'Sync data from the GACS database',
+    hidden: false,
+)]
+class SyncGacsCommand extends Command
+{
+    public function __construct(
+        private CommandBusInterface $commandBus,
+        private QueryBusInterface $queryBus,
+        private GacsClient $gacsClient,
+        private EntityManagerInterface $entityManager,
+    ) {
+        parent::__construct();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $numRows = 0;
+        $numAdded = 0;
+        $numAddedPartially = 0;
+        $numSkipped = 0;
+
+        $log = function (string $event, array $data) use ($output) {
+            $output->writeln(json_encode([
+                'event' => $event,
+                'data' => $data,
+            ], JSON_UNESCAPED_UNICODE));
+        };
+
+        // TODO: Use organization of Ville de Paris
+        $organization = $this->queryBus->handle(new GetOrganizationByUuidQuery('e0d93630-acf7-4722-81e8-ff7d5fa64b66'));
+
+        try {
+            $arreteRows = $this->gacsClient->findActiveTemporaryArreteRows();
+            $numRows = \count($arreteRows);
+
+            foreach ($arreteRows as $arreteRow) {
+                $this->entityManager->getConnection()->beginTransaction();
+
+                try {
+                    $arrete = GacsArrete::fromRow($arreteRow);
+
+                    $regulationOrderRecord = $this->commandBus->handle($arrete->asCommand($organization));
+
+                    $mesureRows = $this->gacsClient->findMesureRowsByArreteFileId($arrete->fileId);
+
+                    $log('fetch.mesures', [
+                        'arreteId' => $arrete->id,
+                        'num_mesures' => \count($mesureRows),
+                    ]);
+
+                    $wereLocationsCreated = false;
+                    $hasPartialSkips = false;
+
+                    foreach ($mesureRows as $mesureIndex => $mesureRow) {
+                        $mesureLoc = ['index' => $mesureIndex, 'fileId' => $mesureRow['fileId']];
+
+                        try {
+                            $mesure = GacsMesure::fromRow($mesureRow);
+                            $measureCommand = $mesure->asCommand();
+                        } catch (SkipException $exc) {
+                            $hasPartialSkips = true;
+                            $log('skip.mesure', [
+                                'loc' => [
+                                    $arreteRow['fields'][GacsArrete::ID],
+                                    'mesures',
+                                    $mesureLoc,
+                                ],
+                                'message' => $exc->getMessage(),
+                            ]);
+                            continue;
+                        }
+
+                        $localisationRowsForMesure = $this->gacsClient->findLocalisationRowsByMesureFileId($mesure->fileId);
+
+                        foreach ($localisationRowsForMesure as $localisationIndex => $localisationRow) {
+                            $localisationLoc = ['index' => $localisationIndex, 'fileId' => $localisationRow['fileId']];
+
+                            try {
+                                $localisation = GacsLocalisation::fromRow($localisationRow);
+                                $locationCommand = $localisation->asCommand($regulationOrderRecord, $measureCommand);
+                            } catch (SkipException $exc) {
+                                $hasPartialSkips = true;
+                                $log('skip.localisation', [
+                                    'loc' => [
+                                        $arreteRow['fields'][GacsArrete::ID],
+                                        'mesures',
+                                        $mesureLoc,
+                                        'localisations',
+                                        $localisationLoc,
+                                    ],
+                                    'message' => $exc->getMessage(),
+                                ]);
+                                continue;
+                            }
+
+                            $this->commandBus->handle($locationCommand);
+                            $wereLocationsCreated = true;
+                        }
+                    }
+
+                    if ($wereLocationsCreated) {
+                        $this->entityManager->getConnection()->commit();
+
+                        if ($hasPartialSkips) {
+                            ++$numAddedPartially;
+                        } else {
+                            ++$numAdded;
+                        }
+                    } else {
+                        // Don't create empty regulation orders, e.g. if content was skipped.
+                        $log('skip.arrete.empty', [
+                            'loc' => [
+                                $arreteRow['fields'][GacsArrete::ID],
+                            ],
+                        ]);
+                        ++$numSkipped;
+                        $this->entityManager->getConnection()->rollBack();
+                    }
+                } catch (SkipException $exc) {
+                    $this->entityManager->getConnection()->rollBack();
+                    $log('skip.arrete', [
+                        'loc' => [
+                            $arreteRow['fields'][GacsArrete::ID],
+                        ],
+                        'message' => $exc->getMessage(),
+                    ]);
+                    ++$numSkipped;
+                    continue;
+                } catch (\Exception $exc) {
+                    $this->entityManager->getConnection()->rollBack();
+                    throw $exc;
+                }
+            }
+        } catch (\Exception $exc) {
+            $log('failure', [
+                'message' => $exc->getMessage(),
+            ]);
+
+            return Command::FAILURE;
+        }
+
+        $log('success', [
+            'num_rows' => $numRows,
+            'num_added' => $numAdded,
+            'num_added_partially' => $numAddedPartially,
+            'num_skipped' => $numSkipped,
+            'percent_added' => round(100 * $numAdded / $numRows, 2),
+            'percent_added_partially' => round(100 * $numAddedPartially / $numRows, 2),
+            'percent_total_added' => round(100 * ($numAdded + $numAddedPartially) / $numRows, 2),
+            'percent_skipped' => round(100 * $numSkipped / $numRows, 2),
+        ]);
+
+        return Command::SUCCESS;
+    }
+}


### PR DESCRIPTION
* Refs #343 

Cette PR implémente une commande Symfony qui va récupérer les 50 premiers arrêtés créés après le 01/01/2022 dans la base GACS de recette, et les importer dans DiaLog.

L'objectif est principalement la preuve de concept.

* [x] Informations générales
* [x] Localisations et leurs mesures

## Aperçu

![Screenshot 2023-05-24 at 17-15-32 Arrêtés de circulation - DiaLog](https://github.com/MTES-MCT/dialog/assets/15911462/4cbf4ba4-0cae-4198-86c4-80f1dc546a6a)

![Screenshot 2023-05-24 at 17-15-56 Arrêté temporaire 2022T13339 - DiaLog](https://github.com/MTES-MCT/dialog/assets/15911462/86b67904-6eec-46ae-b62e-3086af448a2b)


## Pour essayer

* Ajouter une variable `APP_GACS_CREDENTIALS` à `.env.local`, avec les identifiants de l'utilisateur API sous format JSON
* Créer une DB séparée, pour pouvoir facilement la réinitialiser
  * Modifier le nom de la DB utilisé par `DATABASE_URL`, par ex `dialog_eudonet`
  * Lancer `docker-compose exec database createdb dialog_eudonet -T dialog -U dialog`
  * Pour supprimer la DB : `docker-compose exec database dropdb dialog_eudonet -U dialog`
* Lancer `make console CMD="app:integrations:gacs:sync"`
