### PR TITLE
Fix svg rendering

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -63,6 +63,7 @@ label.required > .fr-x-label-content::after, legend.required > .fr-x-label-conte
 @each $extraIcon in ('bus', 'ambulance', 'bicycle', 'pedestrians', 'critair', 'heavy-goods-vehicle') {
     .fr-icon-x-#{$extraIcon}::before {
         mask-image: url('../../public/images/icons/#{$extraIcon}.svg');
+        -webkit-mask-image: url('../../public/images/icons/#{$extraIcon}.svg');
     }
 }
 


### PR DESCRIPTION
Problème : 
La propriété css `mask-image` ne fonctionne pas sur chrome (webkit)

Avant : 
![image](https://github.com/MTES-MCT/dialog/assets/2683379/26dba2ed-90fc-4e78-823e-81450846b328)

Après :
![image](https://github.com/MTES-MCT/dialog/assets/2683379/c9fe7681-ab4e-476a-a9de-c1f4a5305b7f)
