### PR TITLE
Perform local date formatting on the client

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,6 @@
 
 APP_ENV=dev
 APP_SERVER_TIMEZONE=UTC
-APP_CLIENT_TIMEZONE=Europe/Paris
 APP_SECRET=abc
 DATABASE_URL="postgresql://dialog:dialog@database:5432/dialog"
 API_ADRESSE_BASE_URL=https://api-adresse.data.gouv.fr

--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,6 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
 APP_SERVER_TIMEZONE=UTC
-APP_CLIENT_TIMEZONE=Europe/Paris
 APP_SECRET='$ecretf0rt3st'
 SYMFONY_DEPRECATIONS_HELPER=999999
 PANTHER_APP_ENV=panther

--- a/assets/controllers/local_date_controller.js
+++ b/assets/controllers/local_date_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static values = {
+        format: String,
+    };
+
+    connect() {
+        this.element.textContent = this._format(this.formatValue, this.element.dateTime);
+        this.element.dataset.localized = true;
+    }
+
+    _format(format, /** @type {string} */ value) {
+        const date = new Date(value);
+
+        if (format === '%d/%m/%Y') {
+            return (
+                `${String(date.getDate()).padStart(2, '0')}/${String(date.getMonth() + 1).padStart(2, '0')}/${date.getFullYear()}`
+            );
+        }
+
+        throw new Error(`Unknown date format: ${format}`);
+    }
+}

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -5,15 +5,12 @@
 # https://symfony.com/doc/current/best_practices.html#use-parameters-for-application-configuration
 parameters:
     server_timezone: '%env(APP_SERVER_TIMEZONE)%'
-    client_timezone: '%env(APP_CLIENT_TIMEZONE)%'
 
 services:
     # default configuration for services in *this* file
     _defaults:
         autowire: true      # Automatically injects dependencies in your services.
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
-        bind:
-            $clientTimezone: '%client_timezone%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Infrastructure/Adapter/DateUtils.php
+++ b/src/Infrastructure/Adapter/DateUtils.php
@@ -8,25 +8,17 @@ use App\Application\DateUtilsInterface;
 
 final class DateUtils implements DateUtilsInterface
 {
-    private \DateTimeZone $clientTimezone;
-
-    public function __construct(
-        string $clientTimezone,
-    ) {
-        $this->clientTimezone = new \DateTimeZone($clientTimezone);
-    }
-
     public function getNow(): \DateTimeImmutable
     {
         return \DateTimeImmutable::createFromInterface(
             new \DateTime('now'),
-        )->setTimeZone($this->clientTimezone);
+        );
     }
 
     public function getTomorrow(): \DateTimeImmutable
     {
         return \DateTimeImmutable::createFromInterface(
             new \DateTime('tomorrow'),
-        )->setTimeZone($this->clientTimezone);
+        );
     }
 }

--- a/src/Infrastructure/Form/Regulation/GeneralInfoFormType.php
+++ b/src/Infrastructure/Form/Regulation/GeneralInfoFormType.php
@@ -16,11 +16,6 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class GeneralInfoFormType extends AbstractType
 {
-    public function __construct(
-        private string $clientTimezone,
-    ) {
-    }
-
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -39,7 +34,6 @@ final class GeneralInfoFormType extends AbstractType
                     'label' => 'regulation.general_info.start_date',
                     'help' => 'regulation.general_info.start_date.help',
                     'widget' => 'single_text',
-                    'view_timezone' => $this->clientTimezone,
                 ],
             )
             ->add(
@@ -49,7 +43,6 @@ final class GeneralInfoFormType extends AbstractType
                     'label' => 'regulation.general_info.end_date',
                     'help' => 'regulation.general_info.end_date.help',
                     'widget' => 'single_text',
-                    'view_timezone' => $this->clientTimezone,
                     'required' => false,
                 ],
             )

--- a/src/Infrastructure/Twig/AppExtension.php
+++ b/src/Infrastructure/Twig/AppExtension.php
@@ -8,58 +8,36 @@ use App\Application\StringUtilsInterface;
 
 class AppExtension extends \Twig\Extension\AbstractExtension
 {
-    private \DateTimeZone $clientTimezone;
-
     public function __construct(
-        string $clientTimezone,
         private StringUtilsInterface $stringUtils,
     ) {
-        $this->clientTimezone = new \DateTimeZone($clientTimezone);
     }
 
     public function getFunctions(): array
     {
         return [
-            new \Twig\TwigFunction('app_datetime', [$this, 'formatDateTime']),
-            new \Twig\TwigFunction('app_is_client_past_day', [$this, 'isClientPastDay']),
-            new \Twig\TwigFunction('app_is_client_future_day', [$this, 'isClientFutureDay']),
+            new \Twig\TwigFunction('app_is_past_day', [$this, 'isPastDay']),
+            new \Twig\TwigFunction('app_is_future_day', [$this, 'isFutureDay']),
             new \Twig\TwigFunction('app_vehicle_type_icon_name', [$this, 'getVehicleTypeIconName']),
         ];
     }
 
-    /**
-     * Format a $date with an optional $time
-     */
-    public function formatDateTime(\DateTimeInterface $date, \DateTimeInterface $time = null): string
-    {
-        $dateTime = \DateTimeImmutable::createFromInterface($date)->setTimeZone($this->clientTimezone);
-        $format = 'd/m/Y';
-
-        if ($time) {
-            $time = \DateTimeImmutable::createFromInterface($time)->setTimezone($this->clientTimezone);
-            $dateTime = $dateTime->setTime((int) $time->format('H'), (int) $time->format('i'), (int) $time->format('s'));
-            $format = 'd/m/Y à H\hi';
-        }
-
-        return $dateTime->format($format);
-    }
-
-    public function isClientPastDay(\DateTimeInterface $date, \DateTimeInterface $today = null): bool
+    public function isPastDay(\DateTimeInterface $date, \DateTimeInterface $today = null): bool
     {
         $today = $today ? \DateTimeImmutable::createFromInterface($today) : new \DateTimeImmutable('now');
-        $today = $today->setTimeZone($this->clientTimezone)->setTime(0, 0, 0, 0);
+        $today = $today->setTime(0, 0, 0, 0);
 
-        $day = \DateTimeImmutable::createFromInterface($date)->setTimeZone($this->clientTimezone)->setTime(0, 0, 0, 0);
+        $day = \DateTimeImmutable::createFromInterface($date)->setTime(0, 0, 0, 0);
 
         return $day < $today;
     }
 
-    public function isClientFutureDay(\DateTimeInterface $date, \DateTimeInterface $today = null): bool
+    public function isFutureDay(\DateTimeInterface $date, \DateTimeInterface $today = null): bool
     {
         $today = $today ? \DateTimeImmutable::createFromInterface($today) : new \DateTimeImmutable('now');
-        $today = $today->setTimeZone($this->clientTimezone)->setTime(0, 0, 0, 0);
+        $today = $today->setTime(0, 0, 0, 0);
 
-        $day = \DateTimeImmutable::createFromInterface($date)->setTimeZone($this->clientTimezone)->setTime(0, 0, 0, 0);
+        $day = \DateTimeImmutable::createFromInterface($date)->setTime(0, 0, 0, 0);
 
         return $today < $day;
     }

--- a/src/Infrastructure/Validator/SaveRegulationGeneralInfoCommandConstraintValidator.php
+++ b/src/Infrastructure/Validator/SaveRegulationGeneralInfoCommandConstraintValidator.php
@@ -11,11 +11,6 @@ use Symfony\Component\Validator\Exception\UnexpectedValueException;
 
 final class SaveRegulationGeneralInfoCommandConstraintValidator extends ConstraintValidator
 {
-    public function __construct(
-        private string $clientTimezone,
-    ) {
-    }
-
     public function validate(mixed $command, Constraint $constraint): void
     {
         if (!$command instanceof SaveRegulationGeneralInfoCommand) {
@@ -23,9 +18,7 @@ final class SaveRegulationGeneralInfoCommandConstraintValidator extends Constrai
         }
 
         if ($command->endDate !== null && $command->endDate < $command->startDate) {
-            $viewStartDate = \DateTimeImmutable::createFromInterface($command->startDate)
-                ->setTimezone(new \DateTimeZone($this->clientTimezone))
-                ->format('d/m/Y');
+            $viewStartDate = \DateTimeImmutable::createFromInterface($command->startDate)->format('d/m/Y');
 
             $this->context->buildViolation('regulation.error.end_date_before_start_date')
                 ->setParameter('{{ compared_value }}', $viewStartDate)

--- a/templates/common/date.html.twig
+++ b/templates/common/date.html.twig
@@ -1,0 +1,3 @@
+<time data-controller="local-date" data-local-date-format-value="%d/%m/%Y" datetime="{{ date|date('Y-m-d\\TH:i:s\\Z') }}">
+    {{ date|date('Y-m-d') }}
+</time>

--- a/templates/regulation/_items.html.twig
+++ b/templates/regulation/_items.html.twig
@@ -15,8 +15,8 @@
         </thead>
         <tbody>
             {% for regulation in pagination.items %}
-                {% set isUpcoming = regulation.startDate ? app_is_client_future_day(regulation.startDate) : null %}
-                {% set hasPassed = regulation.endDate ? app_is_client_past_day(regulation.endDate) : null %}
+                {% set isUpcoming = regulation.startDate ? app_is_future_day(regulation.startDate) : null %}
+                {% set hasPassed = regulation.endDate ? app_is_past_day(regulation.endDate) : null %}
                 <tr>
                     <td>
                         {{ regulation.identifier }}
@@ -35,10 +35,12 @@
                             {% set startDate = regulation.startDate %}
                             {% set endDate = regulation.endDate %}
                             {% if startDate and endDate %}
-                                {{ 'common.date.from'|trans({ '%date%': app_datetime(startDate) }) }}
-                                {{ 'common.date.to'|trans({ '%date%': app_datetime(endDate) }) }}
+                                {{ 'common.date.from'|trans }}
+                                {% include 'common/date.html.twig' with { date: startDate } only %}
+                                {{ 'common.date.to'|trans }}
+                                {% include 'common/date.html.twig' with { date: endDate } only %}
                             {% else %}
-                                {{ 'common.date.starting'|trans({ '%date%': app_datetime(startDate) }) }}
+                                {% include 'common/date.html.twig' with { date: startDate } only %}
                             {% endif %}
                             <br />
                             <b>

--- a/templates/regulation/fragments/_general_info.html.twig
+++ b/templates/regulation/fragments/_general_info.html.twig
@@ -19,15 +19,19 @@
                 <li>{{ regulationOrderRecord.description }}</li>
                 {% set startDate = regulationOrderRecord.startDate %}
                 {% set endDate = regulationOrderRecord.endDate %}
-                {% set isFuture = app_is_client_future_day(startDate) %}
+                {% set isFuture = app_is_future_day(startDate) %}
                 <li>
                     {% if startDate and endDate %}
-                        {{ 'common.date.from'|trans({ '%date%': app_datetime(startDate) })|capitalize }}
-                        {{ 'common.date.to'|trans({ '%date%': app_datetime(endDate) }) }}
+                        {{ 'common.date.from'|trans|capitalize }}
+                        {% include 'common/date.html.twig' with { date: startDate } only %}
+                        {{ 'common.date.to'|trans }}
+                        {% include 'common/date.html.twig' with { date: endDate } only %}
                     {% elseif isFuture %}
-                        {{ 'common.date.starting'|trans({'%date%': app_datetime(startDate) })|capitalize }}
+                        {{ 'common.date.starting'|trans|capitalize }}
+                        {% include 'common/date.html.twig' with { date: startDate } only %}
                     {% else %}
-                        {{ 'common.date.since'|trans({'%date%': app_datetime(startDate) })|capitalize }}
+                        {{ 'common.date.since'|trans|capitalize }}
+                        {% include 'common/date.html.twig' with { date: startDate } only %}
                     {% endif %}
                 </li>
             </ul>

--- a/tests/Unit/Infrastructure/Symfony/DependencyInjectionTest.php
+++ b/tests/Unit/Infrastructure/Symfony/DependencyInjectionTest.php
@@ -11,6 +11,5 @@ class DependencyInjectionTest extends KernelTestCase
     public function testTimezoneParameters(): void
     {
         $this->assertSame('UTC', $this->getContainer()->getParameter('server_timezone'));
-        $this->assertSame('Europe/Paris', $this->getContainer()->getParameter('client_timezone'));
     }
 }

--- a/tests/Unit/Infrastructure/Validation/SaveRegulationOrderCommandConstraintValidatorTest.php
+++ b/tests/Unit/Infrastructure/Validation/SaveRegulationOrderCommandConstraintValidatorTest.php
@@ -28,7 +28,7 @@ class SaveRegulationGeneralInfoCommandConstraintValidatorTest extends Constraint
 
     protected function createValidator(): ConstraintValidatorInterface
     {
-        return new SaveRegulationGeneralInfoCommandConstraintValidator(clientTimezone: 'Europe/Paris');
+        return new SaveRegulationGeneralInfoCommandConstraintValidator();
     }
 
     public function testUnexpectedValue(): void

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -148,11 +148,11 @@
             </trans-unit>
             <trans-unit id="common.date.from">
                 <source>common.date.from</source>
-                <target>du %date%</target>
+                <target>du</target>
             </trans-unit>
             <trans-unit id="common.date.to">
                 <source>common.date.to</source>
-                <target>au %date%</target>
+                <target>au</target>
             </trans-unit>
             <trans-unit id="common.date.starting">
                 <source>common.date.starting</source>

--- a/translations/validators.fr.xlf
+++ b/translations/validators.fr.xlf
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="file.ext">
+    <file source-language="fr" datatype="plaintext" original="file.ext">
         <body>
             <trans-unit id="common.error.not_blank">
                 <source>common.error.not_blank</source>


### PR DESCRIPTION
**Motivation**

Actuellement on fait le formatage des dates côté serveur en PHP via une timezone fixe (Europe/Paris)

Ça ne permet pas de supporter d'autres timezones, en particulier pour les DOM-TOM

**Que fait cette PR**

Cette PR déplace le formattage dans le navigateur, en utilisant une approche cache-friendly inspirée de https://github.com/basecamp/local_time