### PR TITLE
Fix redis on production

### DIFF
--- a/.env
+++ b/.env
@@ -19,8 +19,7 @@ APP_SERVER_TIMEZONE=UTC
 APP_CLIENT_TIMEZONE=Europe/Paris
 APP_SECRET=abc
 DATABASE_URL="postgresql://dialog:dialog@database:5432/dialog"
-REDIS_HOST="redis"
-REDIS_PORT=6379
+REDIS_URL="redis://redis:6379"
 API_ADRESSE_BASE_URL=https://api-adresse.data.gouv.fr
 
 ###> symfony/messenger ###

--- a/.env.ci
+++ b/.env.ci
@@ -1,3 +1,2 @@
 DATABASE_URL="postgresql://dialog:dialog@localhost:5432/dialog"
-REDIS_HOST="localhost"
-REDIS_PORT=6379
+REDIS_URL="redis://localhost:6379"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,7 @@ jobs:
         # .env directly.
         run: |
           echo "DATABASE_URL=postgresql://dialog:dialog@localhost:5432/dialog" >> .env
-          echo "REDIS_HOST=localhost" >> .env
-          echo "REDIS_PORT=6379" >> .env
+          echo "REDIS_URL=redis://localhost:6379" >> .env
 
       - name: Install Symfony CLI
         # Required for E2E testing

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -9,9 +9,10 @@ framework:
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.
     session:
-        handler_id: Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler
+        handler_id: '%env(REDIS_URL)%'
         cookie_secure: auto
         cookie_samesite: lax
+        cookie_lifetime: 86400
         storage_factory_id: session.storage.factory.native
 
     #esi: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -68,20 +68,6 @@ services:
     DateTimeInterface:
         class: DateTimeImmutable
 
-    # ------------
-    # Redis
-    # ------------
-    Symfony\Component\HttpFoundation\Session\Storage\Handler\RedisSessionHandler:
-        arguments:
-            - '@Redis'
-            - { 'ttl': 86400 }
-    Redis:
-        class: Redis
-        calls:
-           - connect:
-                - '%env(REDIS_HOST)%'
-                - '%env(int:REDIS_PORT)%'
-
 when@test:
     services:
         App\Tests\Mock\APIAdresseMockClient:


### PR DESCRIPTION
:warning:  La production est en 500


Redis nécessite de se configurer via un DSN en environnement de production pour pouvoir y setter en plus de l'host et du port, le username et le password.