### PR TITLE
Improve date fields

### DIFF
--- a/assets/controllers/datepicker_toggle_controller.js
+++ b/assets/controllers/datepicker_toggle_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from '@hotwired/stimulus';
+
+/**
+ * Toggle the date picker when user clicks anywhere on the input, handling browser compatibility.
+ */
+export default class extends Controller {
+    connect() {
+        this.element.addEventListener('click', this.#onClick);
+    }
+
+    disconnect() {
+        this.element.addEventListener('click', this.#onClick);
+    }
+
+    #onClick = (event) => {
+        if (!('showPicker' in HTMLInputElement.prototype)) {
+            // E.g. Safari. Can't really do much in this case.
+            // See: https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/showPicker#browser_compatibility
+            return;
+        }
+
+        /** @type {HTMLInputElement} */
+        const el = event.currentTarget;
+
+        // By default, browsers show a native picker button, which toggles the picker.
+        // In most cases, DSFR will hide it, and we can safely toggle the picker ourselves.
+        const isNativeButtonHiddenByDSFR = CSS.supports('selector(::-webkit-calendar-picker-indicator)');
+
+        if (isNativeButtonHiddenByDSFR) {
+            el.showPicker();
+            return;
+        }
+
+        // Sometimes DSFR won't be able to hide the native button (due to https://github.com/GouvernementFR/dsfr/issues/411).
+        // Then, we should only call showPicker() if the user hasn't clicked on the native button.
+        // Otherwise showPicker() would effectively close the picker back and the picker wouldn't be toggled at all.
+
+        // Determine whether the user has clicked on the native picker.
+        // NOTE: This relies on a visual estimation of the relative position of the native picker on Firefox,
+        // in terms of multiples of the amount of right padding on .fr-input elements.
+        const rect = el.getBoundingClientRect();
+        const baseSize = parseInt(getComputedStyle(el).paddingRight);
+        const nativePickerX = rect.right - 2.5 * baseSize; // Visual estimation
+        const nativePickerWidth = 1.5 * baseSize; // Visual estimation
+        const hasClickedOnNativePicker = nativePickerX < event.clientX && event.clientX < nativePickerX + nativePickerWidth;
+
+        if (hasClickedOnNativePicker) {
+            // Let the browser open the picker.
+            return;
+        }
+
+        // Otherwise, show the picker ourselves.
+        el.showPicker();
+    };
+}

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -12,6 +12,17 @@ label.required > .fr-x-label-content::after, legend.required > .fr-x-label-conte
     content: ' *';
 }
 
+@supports not selector(::-webkit-calendar-picker-indicator) {
+    // Partial FIX for: https://github.com/GouvernementFR/dsfr/issues/411
+    // Hide duplicate calendar icon and restore padding when DSFR fails to hide the native calendar icon
+    .fr-input-wrap.fr-fi-calendar-line::before {
+        display: none;
+    }
+    .fr-input-wrap .fr-input[type=date] {
+        padding-right: 1rem;
+    }
+}
+
 [hidden] {
     // Ensure elements with a non-block or non-inline 'display' (such as DSFR buttons with become, or an element with display: grid) effectively become hidden when the 'hidden' HTML attribute is set.
     display: none !important;

--- a/templates/common/form/dsfr_theme.html.twig
+++ b/templates/common/form/dsfr_theme.html.twig
@@ -77,6 +77,7 @@ https://github.com/symfony/symfony/blob/6.3/src/Symfony/Bridge/Twig/Resources/vi
 {% endblock %}
 
 {% block date_widget %}
+  {% set attr = attr|merge({'data-controller': ('datepicker-toggle ' ~ attr['data-controller']|default(''))|trim}) %}
   {%- if widget == 'single_text' -%}
     <div class="fr-input-wrap fr-fi-calendar-line">
       {{ parent() }}

--- a/templates/regulation/_general_info_form.html.twig
+++ b/templates/regulation/_general_info_form.html.twig
@@ -25,8 +25,8 @@
                 </div>
             </div>
             {{ form_row(form.description, {group_class: 'fr-input-group', attr: {class: 'fr-input'}, help_attr: {class: 'fr-hint-text'}}) }}
-            {{ form_row(form.startDate, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
-            {{ form_row(form.endDate, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
+            {{ form_row(form.startDate, {group_class: 'fr-input-group', widget_class: 'fr-input', row_attr: {class: 'fr-col-12 fr-col-sm-6 fr-col-lg-5'}}) }}
+            {{ form_row(form.endDate, {group_class: 'fr-input-group', widget_class: 'fr-input', row_attr: {class: 'fr-col-12 fr-col-sm-6 fr-col-lg-5'}}) }}
             <a href="{{ cancelUrl }}" class="fr-btn fr-btn--tertiary fr-mr-3w">
                 {{ "common.cancel"|trans }}
             </a>


### PR DESCRIPTION
* Closes #371

Cette PR traite les 3 problèmes relevés dans #371 

* Désormais on peut activer le calendrier en cliquant n'importe où sur le champ (pas juste sur l'icône calendrier)
* La taille des champ a été réduite
* La double icône sous Firefox a été retirée

Je n'ai pas vraiment pu écrire de tests pour ça, ça m'embête un peu. Peut-être qu'il faudrait configurer de quoi [tester les contrôleurs Stimulus unitairement](https://shime.sh/til/testing-stimulus).

## Aperçu

![Screenshot 2023-06-27 at 11-31-48 Arrêté temporaire F01_2023 - DiaLog](https://github.com/MTES-MCT/dialog/assets/15911462/f1e92895-ed7f-4ca0-9ef1-d54db82660db)
