### PR TITLE
Handle possibly null vehicleTypes fields

### DIFF
--- a/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
@@ -24,11 +24,11 @@ final class GetRegulationOrdersToDatexFormatQueryHandler
         foreach ($regulationOrders as $regulationOrder) {
             $vehicleConditions = [];
 
-            foreach ($regulationOrder['restrictedVehicleTypes'] as $restrictedVehicleType) {
+            foreach ($regulationOrder['restrictedVehicleTypes'] ?: [] as $restrictedVehicleType) {
                 $vehicleConditions[] = new DatexVehicleConditionView($restrictedVehicleType);
             }
 
-            foreach ($regulationOrder['exemptedVehicleTypes'] as $exemptedVehicleType) {
+            foreach ($regulationOrder['exemptedVehicleTypes'] ?: [] as $exemptedVehicleType) {
                 $vehicleConditions[] = new DatexVehicleConditionView($exemptedVehicleType, isExempted: true);
             }
 

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
@@ -55,7 +55,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
             'toLatitude' => $location1->toLatitude,
             'toLongitude' => $location1->toLongitude,
             'restrictedVehicleTypes' => [],
-            'exemptedVehicleTypes' => [],
+            'exemptedVehicleTypes' => null,
         ];
         $regulationOrder2 = [
             'uuid' => '247edaa2-58d1-43de-9d33-9753bf6f4d30',


### PR DESCRIPTION
* Signalé par #392 
* Vu sur Sentry

Pour les arrêtés existants, il n'y aura pas encore de restrictedVehicleTypes ou exemptedVehicleTypes (la migration les laisse à NULL) donc il faut gérer ces cas