### PR TITLE
Avoid error responses from APIAdresse on short searches

### DIFF
--- a/src/Infrastructure/Adapter/APIAdresseGeocoder.php
+++ b/src/Infrastructure/Adapter/APIAdresseGeocoder.php
@@ -107,6 +107,11 @@ final class APIAdresseGeocoder implements GeocoderInterface
     {
         $search = preg_replace(self::HOUSENUMBER_FILTER_REGEX, '', $search);
 
+        if (\strlen($search) < 3) {
+            // APIAdresse returns error if search string has length strictly less than 3.
+            return [];
+        }
+
         $response = $this->apiAdresseClient->request('GET', '/search/', [
             'headers' => [
                 'Accept' => 'application/json',

--- a/tests/Unit/Infrastructure/Adapter/APIAdresseGeocoderTest.php
+++ b/tests/Unit/Infrastructure/Adapter/APIAdresseGeocoderTest.php
@@ -193,4 +193,24 @@ final class APIAdresseGeocoderTest extends TestCase
         $addresses = $geocoder->findAddresses('Test');
         $this->assertEquals([], $addresses);
     }
+
+    public function testFindAddressesSearchTooShort(): void
+    {
+        $response = new MockResponse(
+            json_encode([
+                'features' => [['properties' => ['name' => 'Rue Eugene Berthoud', 'postcode' => '75018', 'city' => 'Paris', 'type' => 'street']]],
+            ]),
+            ['http_code' => 200],
+        );
+        $http = new MockHttpClient([$response]);
+        $geocoder = new APIAdresseGeocoder($http);
+
+        $addresses = $geocoder->findAddresses('aa');
+        $this->assertEquals([], $addresses);
+        $this->assertEquals(0, $http->getRequestsCount());
+
+        $addresses = $geocoder->findAddresses('aaa');
+        $this->assertEquals(['Rue Eugene Berthoud, 75018 Paris'], $addresses);
+        $this->assertEquals(1, $http->getRequestsCount());
+    }
 }


### PR DESCRIPTION
* Découvert via les erreurs signalées par #392 

L'API Adresse refuse de traiter les requêtes de strictement moins de 3 caractères

On peut donc traiter ce cas comme une erreur prévisible et éviter la requête (qui est loggée dans Sentry sinon).