### PR TITLE
Reduce useless autocomplete requests

### DIFF
--- a/templates/common/form/dsfr_theme.html.twig
+++ b/templates/common/form/dsfr_theme.html.twig
@@ -20,8 +20,7 @@ https://github.com/symfony/symfony/blob/6.3/src/Symfony/Bridge/Twig/Resources/vi
     {% set row_attr = row_attr|merge({
         class: ('fr-x-autocomplete-wrapper ' ~ row_attr.class|default(''))|trim,
         'data-controller': 'autocomplete',
-        'data-autocomplete-url-value': autocomplete_url,
-    }) %}
+    })|merge(autocomplete_controller_options|default({})) %}
   {% endif %}
   {%- set row_class = (group_class|default('') ~ ' ' ~ row_attr.class|default(''))|trim -%}
 

--- a/templates/regulation/fragments/_location_form.html.twig
+++ b/templates/regulation/fragments/_location_form.html.twig
@@ -151,7 +151,11 @@
                     group_class: 'fr-input-group',
                     widget_class: 'fr-input',
                     autocomplete: true,
-                    autocomplete_url: path('fragment_address_completion'),
+                    autocomplete_controller_options: {
+                        'data-autocomplete-url-value': path('fragment_address_completion'),
+                        'data-autocomplete-min-length-value': 3,
+                        'data-autocomplete-delay-value': 500,
+                    },
                     autocomplete_results_label: 'regulation.location.address.results_label'|trans,
                 }) }}
                 <div class="fr-container--fluid">


### PR DESCRIPTION
**Description**

Grâce à cette PR

* On n'envoie des requêtes d'autocomplétion que s'il y a 3 caractères ou plus dans le champ
* Augmentation du délai de debounce : le composant attend qu'on ai fini de taper même si on tape assez lentement

**Motivation**

Amélioration du critère 4.11 du RGESN https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/critere/4.11/