### PR TITLE
Add cache-control for static assets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,6 +110,9 @@
         "paas": {
             "php-config": [
                 "session.gc_maxlifetime = 86400"
+            ],
+            "nginx-includes": [
+                "paas/server.locations"
             ]
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,7 @@ services:
     volumes:
       - ./:/var/www/dialog
       - ./docker/nginx/default.conf:/etc/nginx/conf.d/default.conf
+      - ./paas/server.locations:/etc/nginx/server.locations
     depends_on:
       - php
       - database

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -6,6 +6,8 @@ server {
     error_log /var/log/nginx/project_error.log;
     access_log /var/log/nginx/project_access.log;
 
+    include server.locations;
+
     location / {
         try_files $uri /index.php$is_args$args;
     }

--- a/paas/server.locations
+++ b/paas/server.locations
@@ -1,0 +1,7 @@
+location ~* \.(css|js|jpg|jpeg|png|svg|webp|ico|woff2|woff|eot|ttf) {
+    # Cache for 1 year.
+    # Caching JS and CSS is safe too, as Symfony includes hashes in build filenames.
+    # So, new versions will be consistently downloaded by clients.
+    # See: https://symfony.com/doc/current/frontend/encore/versioning.html
+    add_header Cache-Control "public, max-age=31536000";
+}


### PR DESCRIPTION
Refs #353 

**Description**

Cette PR fait en sorte que Nginx renvoie un header Cache-Control pour les fichiers statiques (identifiés par leur extension) de façon à les mettre en cache pendant 1 an.

Puisque Symfony ajoute une [version](https://symfony.com/doc/current/frontend/encore/versioning.html) (un hash du fichier) aux noms de fichier quand ceux-ci changent, les fichiers restent en cache jusqu'à ce qu'ils changent, sans problème de réutilisation infinie du cache par le navigateur.

Pour Scalingo, le Nginx est configuré en suivant la doc https://doc.scalingo.com/languages/php/start#buildpack-custom-configuration

**Motivation**

L'objectif est d'avoir une mise en cache précise et explicitement contrôlée

Actuellement on n'envoie que les headers Last-Modified et ETag, et je ne sais pas exactement d'où ils viennent (peut-être Symfony ? peut-être Nginx ?)

```bash
curl https://dialog.beta.gouv.fr/images/landing/illustration-gps.webp -I
```

```http
HTTP/2 200 
date: Thu, 20 Jul 2023 12:02:56 GMT
content-type: image/webp
content-length: 21036
x-request-id: 622d1cd1-beea-4a57-b6b7-e53a7fb3e30b
strict-transport-security: max-age=31536000
last-modified: Wed, 19 Jul 2023 14:49:54 GMT
etag: "64b7f812-522c"
accept-ranges: bytes
```

D'après la [documentation MDN](https://developer.mozilla.org/fr/docs/Web/HTTP/Caching), la présence de `ETag` permet au navigateur de valider une entrée de cache, mais cela nécessite une requête au serveur (vraisemblablement -- dans Firefox, on dirait que le navigateur ne fait pas de requête supplémentaire ; peut-être garde-t-il en cache indéfiniment ?).

Cache-Control est utilisé en priorité s'il est présent
