### PR TITLE
Add matomo

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -5,3 +5,10 @@ twig:
 when@test:
     twig:
         strict_variables: true
+
+when@prod:
+    twig:
+        globals:
+            matomo:
+                url: https://stats.data.gouv.fr/
+                site_id: 288

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -24,6 +24,7 @@
         <script type="module" src="{{ asset('build/dsfr/dsfr.module.min.js') }}" defer></script>
         <script type="text/javascript" nomodule src="{{ asset('build/dsfr/dsfr.nomodule.min.js') }}" defer></script>
     {% endblock %}
+    {% include 'common/analytics.html.twig' with { _nonce } only %}
   </head>
   <body>
     {% include 'common/header.html.twig' %}

--- a/templates/common/analytics.html.twig
+++ b/templates/common/analytics.html.twig
@@ -1,0 +1,17 @@
+{% if matomo is defined %}
+    <!-- Matomo -->
+    <script nonce="{{ _nonce }}">
+        var _paq = window._paq = window._paq || [];
+        /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+        _paq.push(['trackPageView']);
+        _paq.push(['enableLinkTracking']);
+        (function() {
+            var u="{{ matomo.url }}";
+            _paq.push(['setTrackerUrl', u+'piwik.php']);
+            _paq.push(['setSiteId', '{{ matomo.site_id }}']);
+            var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+            g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+        })();
+    </script>
+    <!-- End Matomo Code -->
+{% endif %}


### PR DESCRIPTION
L'instance Matomo utilisé pour DiaLog est https://stats.data.gouv.fr. Son identifiant de site est 288.