### PR TITLE
Fix DATEX location start/end definition

### DIFF
--- a/templates/api/regulations.xml.twig
+++ b/templates/api/regulations.xml.twig
@@ -62,46 +62,50 @@
                             <loc:linearWithinLinearElement>
                                 <loc:directionRelativeOnLinearSection>both</loc:directionRelativeOnLinearSection>
                                 <loc:heightGradeOfLinearSection>atGrade</loc:heightGradeOfLinearSection>
-                                {% if location.fromHouseNumber or location.toHouseNumber %}
-                                    <loc:linearElement xsi:type="loc:LinearElementByPoints">
-                                        <loc:roadName>
-                                            <com:values>
-                                                <com:value>{{ location.address }}</com:value>
-                                            </com:values>
-                                        </loc:roadName>
-                                        {% if location.fromHouseNumber %}
-                                            <loc:startPointOfLinearElement>
-                                                <loc:referentIdentifier>start</loc:referentIdentifier>
-                                                <loc:referentName>{{ location.fromHouseNumber }}</loc:referentName>
-                                                <loc:referentType>referenceMarker</loc:referentType>
-                                                <loc:pointCoordinates>
-                                                    <loc:latitude>{{ location.fromLatitude }}</loc:latitude>
-                                                    <loc:longitude>{{ location.fromLongitude }}</loc:longitude>
-                                                </loc:pointCoordinates>
-                                            </loc:startPointOfLinearElement>
-                                        {% endif %}
-                                        {% if location.toHouseNumber %}
-                                            <loc:endPointOfLinearElement>
-                                                <loc:referentIdentifier>end</loc:referentIdentifier>
-                                                <loc:referentName>{{ location.toHouseNumber }}</loc:referentName>
-                                                <loc:referentType>referenceMarker</loc:referentType>
-                                                <loc:pointCoordinates>
-                                                    <loc:latitude>{{ location.toLatitude }}</loc:latitude>
-                                                    <loc:longitude>{{ location.toLongitude }}</loc:longitude>
-                                                </loc:pointCoordinates>
-                                            </loc:endPointOfLinearElement>
-                                        {% endif %}
-                                    </loc:linearElement>
+                                <loc:linearElement xsi:type="loc:LinearElement">
+                                    <loc:roadName>
+                                        <com:values>
+                                            <com:value lang="fr">{{ location.address }}</com:value>
+                                        </com:values>
+                                    </loc:roadName>
+                                </loc:linearElement>
+
+                                {% if location.fromHouseNumber %}
+                                    <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                        <loc:distanceAlong>0</loc:distanceAlong>
+                                        <loc:fromReferent>
+                                            <loc:referentIdentifier>start</loc:referentIdentifier>
+                                            <loc:referentName>{{ location.fromHouseNumber }}</loc:referentName>
+                                            <loc:referentType>referenceMarker</loc:referentType>
+                                            <loc:pointCoordinates>
+                                                <loc:latitude>{{ location.fromLatitude }}</loc:latitude>
+                                                <loc:longitude>{{ location.fromLongitude }}</loc:longitude>
+                                            </loc:pointCoordinates>
+                                        </loc:fromReferent>
+                                    </loc:fromPoint>
+                                {% else %}
                                     <loc:fromPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
                                         <loc:percentageDistanceAlong>0</loc:percentageDistanceAlong>
                                     </loc:fromPoint>
+                                {% endif %}
+
+                                {% if location.toHouseNumber %}
+                                    <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                        <loc:distanceAlong>0</loc:distanceAlong>
+                                        <loc:fromReferent>
+                                            <loc:referentIdentifier>end</loc:referentIdentifier>
+                                            <loc:referentName>{{ location.toHouseNumber }}</loc:referentName>
+                                            <loc:referentType>referenceMarker</loc:referentType>
+                                            <loc:pointCoordinates>
+                                                <loc:latitude>{{ location.toLatitude }}</loc:latitude>
+                                                <loc:longitude>{{ location.toLongitude }}</loc:longitude>
+                                            </loc:pointCoordinates>
+                                        </loc:fromReferent>
+                                    </loc:toPoint>
+                                {% else %}
                                     <loc:toPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
                                         <loc:percentageDistanceAlong>100</loc:percentageDistanceAlong>
                                     </loc:toPoint>
-                                {% else %}
-                                    <loc:linearElement xsi:type="loc:LinearElement">
-                                        <loc:roadName>{{ location.address }}</loc:roadName>
-                                    </loc:linearElement>
                                 {% endif %}
                             </loc:linearWithinLinearElement>
                         </locationByOrder>
@@ -110,7 +114,7 @@
                         {% if vehicle.nonVehicularRoadUser %}
                             <conditions xsi:type="NonVehicularRoadUserCondition">
                                 <negate>{{ vehicle.isExempted ? 'true' : 'false' }}</negate>
-                                <com:nonVehicularRoadUser>{{ vehicle.nonVehicularRoadUser }}</com:nonVehicularRoadUser>
+                                <nonVehicularRoadUser>{{ vehicle.nonVehicularRoadUser }}</nonVehicularRoadUser>
                             </conditions>
                         {% else %}
                             <conditions xsi:type="VehicleCondition">

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -40,13 +40,17 @@
                             <loc:linearWithinLinearElement>
                                 <loc:directionRelativeOnLinearSection>both</loc:directionRelativeOnLinearSection>
                                 <loc:heightGradeOfLinearSection>atGrade</loc:heightGradeOfLinearSection>
-                                <loc:linearElement xsi:type="loc:LinearElementByPoints">
+                                <loc:linearElement xsi:type="loc:LinearElement">
                                     <loc:roadName>
                                         <com:values>
-                                            <com:value>Avenue de Fonneuve 82000 Montauban</com:value>
+                                            <com:value lang="fr">Avenue de Fonneuve 82000 Montauban</com:value>
                                         </com:values>
                                     </loc:roadName>
-                                    <loc:startPointOfLinearElement>
+                                </loc:linearElement>
+
+                                <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                    <loc:distanceAlong>0</loc:distanceAlong>
+                                    <loc:fromReferent>
                                         <loc:referentIdentifier>start</loc:referentIdentifier>
                                         <loc:referentName>695</loc:referentName>
                                         <loc:referentType>referenceMarker</loc:referentType>
@@ -54,8 +58,12 @@
                                             <loc:latitude>44.028996</loc:latitude>
                                             <loc:longitude>1.362275</loc:longitude>
                                         </loc:pointCoordinates>
-                                    </loc:startPointOfLinearElement>
-                                    <loc:endPointOfLinearElement>
+                                    </loc:fromReferent>
+                                </loc:fromPoint>
+
+                                <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                    <loc:distanceAlong>0</loc:distanceAlong>
+                                    <loc:fromReferent>
                                         <loc:referentIdentifier>end</loc:referentIdentifier>
                                         <loc:referentName>253</loc:referentName>
                                         <loc:referentType>referenceMarker</loc:referentType>
@@ -63,13 +71,7 @@
                                             <loc:latitude>44.025665</loc:latitude>
                                             <loc:longitude>1.35931</loc:longitude>
                                         </loc:pointCoordinates>
-                                    </loc:endPointOfLinearElement>
-                                </loc:linearElement>
-                                <loc:fromPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
-                                    <loc:percentageDistanceAlong>0</loc:percentageDistanceAlong>
-                                </loc:fromPoint>
-                                <loc:toPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
-                                    <loc:percentageDistanceAlong>100</loc:percentageDistanceAlong>
+                                    </loc:fromReferent>
                                 </loc:toPoint>
                             </loc:linearWithinLinearElement>
                         </locationByOrder>
@@ -90,7 +92,7 @@
                     </conditions>
                     <conditions xsi:type="NonVehicularRoadUserCondition">
                         <negate>true</negate>
-                        <com:nonVehicularRoadUser>pedestrians</com:nonVehicularRoadUser>
+                        <nonVehicularRoadUser>pedestrians</nonVehicularRoadUser>
                     </conditions>
                     <conditions xsi:type="VehicleCondition">
                         <negate>true</negate>


### PR DESCRIPTION
* Vu la parenthèse à la fin de https://github.com/MTES-MCT/dialog/issues/419#issuecomment-1658668089

Dans DATEX II, un `linearWithinLinearElement` (section de route) doit obligatoirement avoir un `linearElement`, un `fromPoint` et un `toPoint`

Jusqu'ici dans le cas où des N° de rue sont définis, ces 2 dernières propriétés étaient manquantes, car on définissait le début et la fin dans `linearElement`. L'export DATEX II n'était donc pas conforme. Les propriétés `startPointOfLinearElement` et `endPointOfLinearElement` servent à _préciser_ le début et la fin de la route, et non pas la section en elle-même.

Il y avait aussi une non-conformité dans l'utilisation de `nonVehicularRoadUser` (qui est dans le package courant et non dans `com`).

Cette PR corrige cela et améliore ainsi notre conformité au DATEX II.

(Cela relance l'idée d'une validation de l'export DATEX II à partir des schémas XSD...)