### PR TITLE
Fix purging of fr-alert--* classes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,6 +89,7 @@ Encore
                 // Dynamic classes
                 /^fr-icon-x-/,
                 /^fr-modal--/,
+                /^fr-alert--/,
             ],
             greedy: [
                 // Source of complex selectors


### PR DESCRIPTION
Cette PR corrige un bug qui faisait que l'alerte "Arrêté copié avec succès" n'était plus en couleur verte

Pour reproduire le bug : aller sur https://dialog.incubateur.net, dupliquer un arrêté, constater que l'alerte est grise (classe fr-alert--success pas appliquée car purgée de la feuille de styles)