### PR TITLE
Ajoute restrictions de circulation à Saint-Denis en format brut

### DIFF
--- a/templates/api/_regulations_raw.xml.twig
+++ b/templates/api/_regulations_raw.xml.twig
@@ -343,6 +343,15 @@
 
             <conditions xsi:type="LocationCondition">
                 <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                    <loc:supplementaryPositionalDescription>
+                        <loc:carriageway>
+                            <loc:carriageway>mainCarriageway</loc:carriageway>
+                            <loc:lane>
+                                <loc:laneUsage>rightLane</loc:laneUsage>
+                            </loc:lane>
+                        </loc:carriageway>
+                    </loc:supplementaryPositionalDescription>
+
                     <loc:linearWithinLinearElement>
                         <loc:linearElement xsi:type="loc:LinearElement">
                             <loc:roadName>

--- a/templates/api/_regulations_raw.xml.twig
+++ b/templates/api/_regulations_raw.xml.twig
@@ -1,0 +1,384 @@
+<trafficRegulationOrder id="064ca240-2b58-73ea-8000-2d03faf5d44c" version="1">
+    <description>
+        <com:values>
+            <com:value lang="fr">ARRETE TEMPORAIRE ACT2023STD - 619-MB</com:value>
+        </com:values>
+    </description>
+
+    <issuingAuthority>
+        <com:values>
+            <com:value lang="fr">Mairie de Saint-Denis</com:value>
+        </com:values>
+    </issuingAuthority>
+
+    <regulationId>064ca240-2b58-73ea-8000-2d03faf5d44c</regulationId>
+    <status>madeAndImplemented</status>
+
+    <trafficRegulation>
+        <status>active</status>
+
+        <typeOfRegulation xsi:type="AccessRestriction">
+            <accessRestrictionType>noEntry</accessRestrictionType>
+        </typeOfRegulation>
+
+        <condition xsi:type="ConditionSet">
+            <operator>and</operator>
+
+            <conditions xsi:type="ValidityCondition">
+                <validityByOrder>
+                    <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                    <com:validityTimeSpecification>
+                        <com:overallStartTime>2023-08-11T18:00:00+02:00</com:overallStartTime>
+                        <com:overallEndTime>2023-08-15T06:00:00+02:00</com:overallEndTime>
+                    </com:validityTimeSpecification>
+                </validityByOrder>
+            </conditions>
+
+            <conditions xsi:type="LocationCondition">
+                <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                    <loc:linearWithinLinearElement>
+                        <loc:linearElement xsi:type="loc:LinearElement">
+                            <loc:roadName>
+                                <com:values>
+                                    <com:value lang="fr">Avenue du Stade de France, 93210 Saint-Denis</com:value>
+                                </com:values>
+                            </loc:roadName>
+                        </loc:linearElement>
+
+                        <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                            <loc:distanceAlong>0</loc:distanceAlong>
+                            <loc:fromReferent>
+                                <loc:referentIdentifier>start</loc:referentIdentifier>
+                                <loc:referentName>Pont SNCF</loc:referentName>
+                                <loc:referentType>landmark</loc:referentType>
+                                <loc:pointCoordinates>
+                                    <loc:latitude>48.917709</loc:latitude>
+                                    <loc:longitude>2.361931</loc:longitude>
+                                </loc:pointCoordinates>
+                            </loc:fromReferent>
+                        </loc:fromPoint>
+                        <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                            <loc:distanceAlong>0</loc:distanceAlong>
+                            <loc:fromReferent>
+                                <loc:referentIdentifier>end</loc:referentIdentifier>
+                                <loc:referentName>Rue Francis de Préssensé</loc:referentName>
+                                <loc:referentType>intersection</loc:referentType>
+                                <loc:pointCoordinates>
+                                    <loc:latitude>48.919612</loc:latitude>
+                                    <loc:longitude>2.361700</loc:longitude>
+                                </loc:pointCoordinates>
+                            </loc:fromReferent>
+                        </loc:toPoint>
+                    </loc:linearWithinLinearElement>
+                </locationByOrder>
+            </conditions>
+        </condition>
+    </trafficRegulation>
+</trafficRegulationOrder>
+
+<trafficRegulationOrder id="064ca247-fb24-7cf8-8000-0cf1af53270c" version="1">
+    <description>
+        <com:values>
+            <com:value lang="fr">ARRETE TEMPORAIRE ACT2023STD - 365 SM</com:value>
+        </com:values>
+    </description>
+
+    <issuingAuthority>
+        <com:values>
+            <com:value lang="fr">Mairie de Saint-Denis</com:value>
+        </com:values>
+    </issuingAuthority>
+
+    <regulationId>064ca247-fb24-7cf8-8000-0cf1af53270c</regulationId>
+    <status>madeAndImplemented</status>
+
+    <trafficRegulation>
+        <status>active</status>
+
+        <typeOfRegulation xsi:type="AccessRestriction">
+            <accessRestrictionType>noEntry</accessRestrictionType>
+        </typeOfRegulation>
+
+        <condition xsi:type="ConditionSet">
+            <operator>and</operator>
+
+            <conditions xsi:type="ConditionSet">
+                <operator>or</operator>
+                <conditions xsi:type="ValidityCondition">
+                    <validityByOrder>
+                        <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                        <com:validityTimeSpecification>
+                            <com:overallStartTime>2023-05-17T18:00:00+02:00</com:overallStartTime>
+                            <com:overallEndTime>2023-05-19T06:00:00+02:00</com:overallEndTime>
+                        </com:validityTimeSpecification>
+                    </validityByOrder>
+                </conditions>
+                <conditions xsi:type="ValidityCondition">
+                    <validityByOrder>
+                        <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                        <com:validityTimeSpecification>
+                            <com:overallStartTime>2023-05-19T18:00:00+02:00</com:overallStartTime>
+                            <com:overallEndTime>2023-05-23T06:00:00+02:00</com:overallEndTime>
+                        </com:validityTimeSpecification>
+                    </validityByOrder>
+                </conditions>
+                <conditions xsi:type="ValidityCondition">
+                    <validityByOrder>
+                        <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                        <com:validityTimeSpecification>
+                            <com:overallStartTime>2023-06-02T18:00:00+02:00</com:overallStartTime>
+                            <com:overallEndTime>2023-06-05T06:00:00+02:00</com:overallEndTime>
+                        </com:validityTimeSpecification>
+                    </validityByOrder>
+                </conditions>
+                <conditions xsi:type="ValidityCondition">
+                    <validityByOrder>
+                        <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                        <com:validityTimeSpecification>
+                            <com:overallStartTime>2023-06-09T18:00:00+02:00</com:overallStartTime>
+                            <com:overallEndTime>2023-06-12T06:00:00+02:00</com:overallEndTime>
+                        </com:validityTimeSpecification>
+                    </validityByOrder>
+                </conditions>
+                <conditions xsi:type="ValidityCondition">
+                    <validityByOrder>
+                        <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                        <com:validityTimeSpecification>
+                            <com:overallStartTime>2023-08-11T18:00:00+02:00</com:overallStartTime>
+                            <com:overallEndTime>2023-08-15T06:00:00+02:00</com:overallEndTime>
+                        </com:validityTimeSpecification>
+                    </validityByOrder>
+                </conditions>
+                <conditions xsi:type="ValidityCondition">
+                    <validityByOrder>
+                        <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                        <com:validityTimeSpecification>
+                            <com:overallStartTime>2023-11-03T18:00:00+02:00</com:overallStartTime>
+                            <com:overallEndTime>2023-11-06T06:00:00+02:00</com:overallEndTime>
+                        </com:validityTimeSpecification>
+                    </validityByOrder>
+                </conditions>
+            </conditions>
+
+            <conditions xsi:type="ConditionSet">
+                <operator>or</operator>
+                <conditions xsi:type="LocationCondition">
+                    <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                        <loc:linearWithinLinearElement>
+                            <loc:linearElement xsi:type="loc:LinearElement">
+                                <loc:roadName>
+                                    <com:values>
+                                        <com:value lang="fr">Avenue des Fruitiers, 93210 Saint-Denis</com:value>
+                                    </com:values>
+                                </loc:roadName>
+                            </loc:linearElement>
+                            <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                <loc:distanceAlong>0</loc:distanceAlong>
+                                <loc:fromReferent>
+                                    <loc:referentIdentifier>start</loc:referentIdentifier>
+                                    <loc:referentName>33</loc:referentName>
+                                    <loc:referentType>referenceMarker</loc:referentType>
+                                    <loc:pointCoordinates>
+                                        <loc:latitude>48.919245</loc:latitude>
+                                        <loc:longitude>2.354415</loc:longitude>
+                                    </loc:pointCoordinates>
+                                </loc:fromReferent>
+                            </loc:fromPoint>
+                            <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                <loc:distanceAlong>0</loc:distanceAlong>
+                                <loc:fromReferent>
+                                    <loc:referentIdentifier>end</loc:referentIdentifier>
+                                    <loc:referentName>5</loc:referentName>
+                                    <loc:referentType>referenceMarker</loc:referentType>
+                                    <loc:pointCoordinates>
+                                        <loc:latitude>48.916503</loc:latitude>
+                                        <loc:longitude>2.354752</loc:longitude>
+                                    </loc:pointCoordinates>
+                                </loc:fromReferent>
+                            </loc:toPoint>
+                        </loc:linearWithinLinearElement>
+                    </locationByOrder>
+                </conditions>
+
+                <conditions xsi:type="LocationCondition">
+                    <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                        <loc:linearWithinLinearElement>
+                            <loc:linearElement xsi:type="loc:LinearElement">
+                                <loc:roadName>
+                                    <com:values>
+                                        <com:value lang="fr">Rue des Cheminots, 93210 Saint-Denis</com:value>
+                                    </com:values>
+                                </loc:roadName>
+                            </loc:linearElement>
+                            <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                <loc:distanceAlong>0</loc:distanceAlong>
+                                <loc:fromReferent>
+                                    <loc:referentIdentifier>start</loc:referentIdentifier>
+                                    <loc:referentName>24</loc:referentName>
+                                    <loc:referentType>referenceMarker</loc:referentType>
+                                    <loc:pointCoordinates>
+                                        <loc:latitude>48.917786</loc:latitude>
+                                        <loc:longitude>2.352652</loc:longitude>
+                                    </loc:pointCoordinates>
+                                </loc:fromReferent>
+                            </loc:fromPoint>
+                            <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                <loc:distanceAlong>0</loc:distanceAlong>
+                                <loc:fromReferent>
+                                    <loc:referentIdentifier>end</loc:referentIdentifier>
+                                    <loc:referentName>10</loc:referentName>
+                                    <loc:referentType>referenceMarker</loc:referentType>
+                                    <loc:pointCoordinates>
+                                        <loc:latitude>48.916110</loc:latitude>
+                                        <loc:longitude>2.352746</loc:longitude>
+                                    </loc:pointCoordinates>
+                                </loc:fromReferent>
+                            </loc:toPoint>
+                        </loc:linearWithinLinearElement>
+                    </locationByOrder>
+                </conditions>
+
+                <conditions xsi:type="LocationCondition">
+                    <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                        <loc:linearWithinLinearElement>
+                            <loc:linearElement xsi:type="loc:LinearElement">
+                                <loc:roadName>
+                                    <com:values>
+                                        <com:value lang="fr">Avenue François Mitterand, 93210 Saint-Denis</com:value>
+                                    </com:values>
+                                </loc:roadName>
+                            </loc:linearElement>
+                            <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                <loc:distanceAlong>0</loc:distanceAlong>
+                                <loc:fromReferent>
+                                    <loc:referentIdentifier>start</loc:referentIdentifier>
+                                    <loc:referentName>17</loc:referentName>
+                                    <loc:referentType>referenceMarker</loc:referentType>
+                                    <loc:pointCoordinates>
+                                        <loc:latitude>48.918139</loc:latitude>
+                                        <loc:longitude>2.352316</loc:longitude>
+                                    </loc:pointCoordinates>
+                                </loc:fromReferent>
+                            </loc:fromPoint>
+                            <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                <loc:distanceAlong>0</loc:distanceAlong>
+                                <loc:fromReferent>
+                                    <loc:referentIdentifier>end</loc:referentIdentifier>
+                                    <loc:referentName>1</loc:referentName>
+                                    <loc:referentType>referenceMarker</loc:referentType>
+                                    <loc:pointCoordinates>
+                                        <loc:latitude>48.918037</loc:latitude>
+                                        <loc:longitude>2.356793</loc:longitude>
+                                    </loc:pointCoordinates>
+                                </loc:fromReferent>
+                            </loc:toPoint>
+                        </loc:linearWithinLinearElement>
+                    </locationByOrder>
+                </conditions>
+
+                <conditions xsi:type="LocationCondition">
+                    <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                        <loc:linearWithinLinearElement>
+                            <loc:linearElement xsi:type="loc:LinearElement">
+                                <loc:roadName>
+                                    <com:values>
+                                        <com:value lang="fr">Rue Federico Fellini, 93210 Saint-Denis</com:value>
+                                    </com:values>
+                                </loc:roadName>
+                            </loc:linearElement>
+                            <loc:fromPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
+                                <loc:percentageDistanceAlong>0</loc:percentageDistanceAlong>
+                            </loc:fromPoint>
+                            <loc:toPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
+                                <loc:percentageDistanceAlong>100</loc:percentageDistanceAlong>
+                            </loc:toPoint>
+                        </loc:linearWithinLinearElement>
+                    </locationByOrder>
+                </conditions>
+            </conditions>
+
+            <conditions xsi:type="DriverCondition">
+                <negate>true</negate>
+                <driverCharacteristicsType>localResident</driverCharacteristicsType>
+            </conditions>
+        </condition>
+    </trafficRegulation>
+</trafficRegulationOrder>
+
+<trafficRegulationOrder id="064ca50b-428d-7810-8000-9b78885e357b" version="1">
+    <description>
+        <com:values>
+            <com:value lang="fr">Arrêté portant dérogation temporaire des conditions de circulation et de stationnement des véhicules de toutes catégories, sur places existantes ou sur voie de circulation (route, piste cyclable, voie de bus ou trottoir), pour manifestation</com:value>
+        </com:values>
+    </description>
+
+    <issuingAuthority>
+        <com:values>
+            <com:value lang="fr">Préfecture de Seine-Saint-Denis</com:value>
+        </com:values>
+    </issuingAuthority>
+
+    <regulationId>064ca50b-428d-7810-8000-9b78885e357b</regulationId>
+    <status>madeAndImplemented</status>
+
+    <trafficRegulation>
+        <status>active</status>
+
+        <typeOfRegulation xsi:type="AccessRestriction">
+            <accessRestrictionType>noEntry</accessRestrictionType>
+        </typeOfRegulation>
+
+        <condition xsi:type="ConditionSet">
+            <operator>and</operator>
+
+            <conditions xsi:type="ValidityCondition">
+                <validityByOrder>
+                    <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                    <com:validityTimeSpecification>
+                        <com:overallStartTime>2023-08-11T16:00:00+02:00</com:overallStartTime>
+                        <com:overallEndTime>2023-08-15T05:00:00+02:00</com:overallEndTime>
+                    </com:validityTimeSpecification>
+                </validityByOrder>
+            </conditions>
+
+            <conditions xsi:type="LocationCondition">
+                <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                    <loc:linearWithinLinearElement>
+                        <loc:linearElement xsi:type="loc:LinearElement">
+                            <loc:roadName>
+                                <com:values>
+                                    <com:value lang="fr">Rue Francis de Pressensé, 93210 Saint-Denis</com:value>
+                                </com:values>
+                            </loc:roadName>
+                        </loc:linearElement>
+
+                        <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                            <loc:distanceAlong>0</loc:distanceAlong>
+                            <loc:fromReferent>
+                                <loc:referentIdentifier>start</loc:referentIdentifier>
+                                <loc:referentName>Avenue du Président Wilson</loc:referentName>
+                                <loc:referentType>intersection</loc:referentType>
+                                <loc:pointCoordinates>
+                                    <loc:latitude>48.918157</loc:latitude>
+                                    <loc:longitude>2.357865</loc:longitude>
+                                </loc:pointCoordinates>
+                            </loc:fromReferent>
+                        </loc:fromPoint>
+                        <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                            <loc:distanceAlong>0</loc:distanceAlong>
+                            <loc:fromReferent>
+                                <loc:referentIdentifier>end</loc:referentIdentifier>
+                                <loc:referentName>Avenue du Stade de France</loc:referentName>
+                                <loc:referentType>intersection</loc:referentType>
+                                <loc:pointCoordinates>
+                                    <loc:latitude>48.919687</loc:latitude>
+                                    <loc:longitude>2.361726</loc:longitude>
+                                </loc:pointCoordinates>
+                            </loc:fromReferent>
+                        </loc:toPoint>
+                    </loc:linearWithinLinearElement>
+                </locationByOrder>
+            </conditions>
+        </condition>
+    </trafficRegulation>
+</trafficRegulationOrder>

--- a/templates/api/regulations.xml.twig
+++ b/templates/api/regulations.xml.twig
@@ -20,128 +20,130 @@
     </com:publicationCreator>
 
     <trafficRegulationsFromCompetentAuthorities>
-    {% for regulationOrder in regulationOrders %}
-        {% set startDate = regulationOrder.startDate %}
-        {% set endDate = regulationOrder.endDate %}
-        {% set location = regulationOrder.location %}
-        {% set vehicleConditions = regulationOrder.vehicleConditions %}
-        <trafficRegulationOrder id="{{ regulationOrder.uuid }}" version="1">
-            <description>
-                <com:values>
-                    <com:value>{{ regulationOrder.description }}</com:value>
-                </com:values>
-            </description>
-            <issuingAuthority>
-                <com:values>
-                    <com:value>{{ regulationOrder.organization }}</com:value>
-                </com:values>
-            </issuingAuthority>
-            <regulationId>{{ regulationOrder.uuid }}</regulationId>
-            <status>madeAndImplemented</status>
-            <trafficRegulation>
-                <status>active</status>
-                <typeOfRegulation xsi:type="AccessRestriction">
-                    <accessRestrictionType>noEntry</accessRestrictionType>
-                </typeOfRegulation>
-                <condition xsi:type="ConditionSet">
-                    <operator>and</operator>
-                    <conditions xsi:type="ValidityCondition">
-                        <negate>false</negate>
-                        <validityByOrder>
-                            <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
-                            <com:validityTimeSpecification>
-                                <com:overallStartTime>{{ startDate|date('Y-m-d') }}T00:00:00.000Z</com:overallStartTime>
-                                {% if endDate %}
-                                    <com:overallEndTime>{{ endDate|date('Y-m-d') }}T23:59:59.000Z</com:overallEndTime>
-                                {% endif %}
-                            </com:validityTimeSpecification>
-                        </validityByOrder>
-                    </conditions>
-                    <conditions xsi:type="LocationCondition">
-                        <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
-                            <loc:linearWithinLinearElement>
-                                <loc:directionRelativeOnLinearSection>both</loc:directionRelativeOnLinearSection>
-                                <loc:heightGradeOfLinearSection>atGrade</loc:heightGradeOfLinearSection>
-                                <loc:linearElement xsi:type="loc:LinearElement">
-                                    <loc:roadName>
-                                        <com:values>
-                                            <com:value lang="fr">{{ location.address }}</com:value>
-                                        </com:values>
-                                    </loc:roadName>
-                                </loc:linearElement>
+        {% include "api/_regulations_raw.xml.twig" %}
 
-                                {% if location.fromHouseNumber %}
-                                    <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
-                                        <loc:distanceAlong>0</loc:distanceAlong>
-                                        <loc:fromReferent>
-                                            <loc:referentIdentifier>start</loc:referentIdentifier>
-                                            <loc:referentName>{{ location.fromHouseNumber }}</loc:referentName>
-                                            <loc:referentType>referenceMarker</loc:referentType>
-                                            <loc:pointCoordinates>
-                                                <loc:latitude>{{ location.fromLatitude }}</loc:latitude>
-                                                <loc:longitude>{{ location.fromLongitude }}</loc:longitude>
-                                            </loc:pointCoordinates>
-                                        </loc:fromReferent>
-                                    </loc:fromPoint>
-                                {% else %}
-                                    <loc:fromPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
-                                        <loc:percentageDistanceAlong>0</loc:percentageDistanceAlong>
-                                    </loc:fromPoint>
-                                {% endif %}
-
-                                {% if location.toHouseNumber %}
-                                    <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
-                                        <loc:distanceAlong>0</loc:distanceAlong>
-                                        <loc:fromReferent>
-                                            <loc:referentIdentifier>end</loc:referentIdentifier>
-                                            <loc:referentName>{{ location.toHouseNumber }}</loc:referentName>
-                                            <loc:referentType>referenceMarker</loc:referentType>
-                                            <loc:pointCoordinates>
-                                                <loc:latitude>{{ location.toLatitude }}</loc:latitude>
-                                                <loc:longitude>{{ location.toLongitude }}</loc:longitude>
-                                            </loc:pointCoordinates>
-                                        </loc:fromReferent>
-                                    </loc:toPoint>
-                                {% else %}
-                                    <loc:toPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
-                                        <loc:percentageDistanceAlong>100</loc:percentageDistanceAlong>
-                                    </loc:toPoint>
-                                {% endif %}
-                            </loc:linearWithinLinearElement>
-                        </locationByOrder>
-                    </conditions>
-                    {% for vehicle in vehicleConditions|filter(v => not v.isOther) %}
-                        {% if vehicle.nonVehicularRoadUser %}
-                            <conditions xsi:type="NonVehicularRoadUserCondition">
-                                <negate>{{ vehicle.isExempted ? 'true' : 'false' }}</negate>
-                                <nonVehicularRoadUser>{{ vehicle.nonVehicularRoadUser }}</nonVehicularRoadUser>
-                            </conditions>
-                        {% else %}
-                            <conditions xsi:type="VehicleCondition">
-                                <negate>{{ vehicle.isExempted ? 'true' : 'false' }}</negate>
-                                <vehicleCharacteristics>
-                                    {% if vehicle.euSpecialPurposeVehicle %}
-                                        <com:_vehicleCharacteristicsExtension>
-                                            <com:vehicleCharacteristicsExtended>
-                                                <comx:regulatedCharacteristics>
-                                                    <comx:euSpecialPurposeVehicle>{{ vehicle.euSpecialPurposeVehicle }}</comx:euSpecialPurposeVehicle>
-                                                </comx:regulatedCharacteristics>
-                                            </com:vehicleCharacteristicsExtended>
-                                        </com:_vehicleCharacteristicsExtension>
-                                    {% elseif vehicle.emissionClassificationOther %}
-                                        <com:emissions>
-                                            <com:emissionClassificationOther>{{ vehicle.emissionClassificationOther }}</com:emissionClassificationOther>
-                                        </com:emissions>
-                                    {% else %}
-                                        <com:vehicleType>{{ vehicle.type }}</com:vehicleType>
+        {% for regulationOrder in regulationOrders %}
+            {% set startDate = regulationOrder.startDate %}
+            {% set endDate = regulationOrder.endDate %}
+            {% set location = regulationOrder.location %}
+            {% set vehicleConditions = regulationOrder.vehicleConditions %}
+            <trafficRegulationOrder id="{{ regulationOrder.uuid }}" version="1">
+                <description>
+                    <com:values>
+                        <com:value>{{ regulationOrder.description }}</com:value>
+                    </com:values>
+                </description>
+                <issuingAuthority>
+                    <com:values>
+                        <com:value>{{ regulationOrder.organization }}</com:value>
+                    </com:values>
+                </issuingAuthority>
+                <regulationId>{{ regulationOrder.uuid }}</regulationId>
+                <status>madeAndImplemented</status>
+                <trafficRegulation>
+                    <status>active</status>
+                    <typeOfRegulation xsi:type="AccessRestriction">
+                        <accessRestrictionType>noEntry</accessRestrictionType>
+                    </typeOfRegulation>
+                    <condition xsi:type="ConditionSet">
+                        <operator>and</operator>
+                        <conditions xsi:type="ValidityCondition">
+                            <negate>false</negate>
+                            <validityByOrder>
+                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                                <com:validityTimeSpecification>
+                                    <com:overallStartTime>{{ startDate|date('Y-m-d') }}T00:00:00.000Z</com:overallStartTime>
+                                    {% if endDate %}
+                                        <com:overallEndTime>{{ endDate|date('Y-m-d') }}T23:59:59.000Z</com:overallEndTime>
                                     {% endif %}
-                                </vehicleCharacteristics>
-                            </conditions>
-                        {% endif %}
-                    {% endfor %}
-                </condition>
-            </trafficRegulation>
-        </trafficRegulationOrder>
-    {% endfor %}
+                                </com:validityTimeSpecification>
+                            </validityByOrder>
+                        </conditions>
+                        <conditions xsi:type="LocationCondition">
+                            <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                                <loc:linearWithinLinearElement>
+                                    <loc:directionRelativeOnLinearSection>both</loc:directionRelativeOnLinearSection>
+                                    <loc:heightGradeOfLinearSection>atGrade</loc:heightGradeOfLinearSection>
+                                    <loc:linearElement xsi:type="loc:LinearElement">
+                                        <loc:roadName>
+                                            <com:values>
+                                                <com:value lang="fr">{{ location.address }}</com:value>
+                                            </com:values>
+                                        </loc:roadName>
+                                    </loc:linearElement>
+
+                                    {% if location.fromHouseNumber %}
+                                        <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                            <loc:distanceAlong>0</loc:distanceAlong>
+                                            <loc:fromReferent>
+                                                <loc:referentIdentifier>start</loc:referentIdentifier>
+                                                <loc:referentName>{{ location.fromHouseNumber }}</loc:referentName>
+                                                <loc:referentType>referenceMarker</loc:referentType>
+                                                <loc:pointCoordinates>
+                                                    <loc:latitude>{{ location.fromLatitude }}</loc:latitude>
+                                                    <loc:longitude>{{ location.fromLongitude }}</loc:longitude>
+                                                </loc:pointCoordinates>
+                                            </loc:fromReferent>
+                                        </loc:fromPoint>
+                                    {% else %}
+                                        <loc:fromPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
+                                            <loc:percentageDistanceAlong>0</loc:percentageDistanceAlong>
+                                        </loc:fromPoint>
+                                    {% endif %}
+
+                                    {% if location.toHouseNumber %}
+                                        <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                            <loc:distanceAlong>0</loc:distanceAlong>
+                                            <loc:fromReferent>
+                                                <loc:referentIdentifier>end</loc:referentIdentifier>
+                                                <loc:referentName>{{ location.toHouseNumber }}</loc:referentName>
+                                                <loc:referentType>referenceMarker</loc:referentType>
+                                                <loc:pointCoordinates>
+                                                    <loc:latitude>{{ location.toLatitude }}</loc:latitude>
+                                                    <loc:longitude>{{ location.toLongitude }}</loc:longitude>
+                                                </loc:pointCoordinates>
+                                            </loc:fromReferent>
+                                        </loc:toPoint>
+                                    {% else %}
+                                        <loc:toPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
+                                            <loc:percentageDistanceAlong>100</loc:percentageDistanceAlong>
+                                        </loc:toPoint>
+                                    {% endif %}
+                                </loc:linearWithinLinearElement>
+                            </locationByOrder>
+                        </conditions>
+                        {% for vehicle in vehicleConditions|filter(v => not v.isOther) %}
+                            {% if vehicle.nonVehicularRoadUser %}
+                                <conditions xsi:type="NonVehicularRoadUserCondition">
+                                    <negate>{{ vehicle.isExempted ? 'true' : 'false' }}</negate>
+                                    <nonVehicularRoadUser>{{ vehicle.nonVehicularRoadUser }}</nonVehicularRoadUser>
+                                </conditions>
+                            {% else %}
+                                <conditions xsi:type="VehicleCondition">
+                                    <negate>{{ vehicle.isExempted ? 'true' : 'false' }}</negate>
+                                    <vehicleCharacteristics>
+                                        {% if vehicle.euSpecialPurposeVehicle %}
+                                            <com:_vehicleCharacteristicsExtension>
+                                                <com:vehicleCharacteristicsExtended>
+                                                    <comx:regulatedCharacteristics>
+                                                        <comx:euSpecialPurposeVehicle>{{ vehicle.euSpecialPurposeVehicle }}</comx:euSpecialPurposeVehicle>
+                                                    </comx:regulatedCharacteristics>
+                                                </com:vehicleCharacteristicsExtended>
+                                            </com:_vehicleCharacteristicsExtension>
+                                        {% elseif vehicle.emissionClassificationOther %}
+                                            <com:emissions>
+                                                <com:emissionClassificationOther>{{ vehicle.emissionClassificationOther }}</com:emissionClassificationOther>
+                                            </com:emissions>
+                                        {% else %}
+                                            <com:vehicleType>{{ vehicle.type }}</com:vehicleType>
+                                        {% endif %}
+                                    </vehicleCharacteristics>
+                                </conditions>
+                            {% endif %}
+                        {% endfor %}
+                    </condition>
+                </trafficRegulation>
+            </trafficRegulationOrder>
+        {% endfor %}
     </trafficRegulationsFromCompetentAuthorities>
 </d2:payload>

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -350,6 +350,15 @@
         
                     <conditions xsi:type="LocationCondition">
                         <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                            <loc:supplementaryPositionalDescription>
+                                <loc:carriageway>
+                                    <loc:carriageway>mainCarriageway</loc:carriageway>
+                                    <loc:lane>
+                                        <loc:laneUsage>rightLane</loc:laneUsage>
+                                    </loc:lane>
+                                </loc:carriageway>
+                            </loc:supplementaryPositionalDescription>
+
                             <loc:linearWithinLinearElement>
                                 <loc:linearElement xsi:type="loc:LinearElement">
                                     <loc:roadName>

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -5,6 +5,391 @@
         <com:nationalIdentifier>DiaLog</com:nationalIdentifier>
     </com:publicationCreator>
     <trafficRegulationsFromCompetentAuthorities>
+        <trafficRegulationOrder id="064ca240-2b58-73ea-8000-2d03faf5d44c" version="1">
+            <description>
+                <com:values>
+                    <com:value lang="fr">ARRETE TEMPORAIRE ACT2023STD - 619-MB</com:value>
+                </com:values>
+            </description>
+        
+            <issuingAuthority>
+                <com:values>
+                    <com:value lang="fr">Mairie de Saint-Denis</com:value>
+                </com:values>
+            </issuingAuthority>
+        
+            <regulationId>064ca240-2b58-73ea-8000-2d03faf5d44c</regulationId>
+            <status>madeAndImplemented</status>
+        
+            <trafficRegulation>
+                <status>active</status>
+        
+                <typeOfRegulation xsi:type="AccessRestriction">
+                    <accessRestrictionType>noEntry</accessRestrictionType>
+                </typeOfRegulation>
+        
+                <condition xsi:type="ConditionSet">
+                    <operator>and</operator>
+        
+                    <conditions xsi:type="ValidityCondition">
+                        <validityByOrder>
+                            <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                            <com:validityTimeSpecification>
+                                <com:overallStartTime>2023-08-11T18:00:00+02:00</com:overallStartTime>
+                                <com:overallEndTime>2023-08-15T06:00:00+02:00</com:overallEndTime>
+                            </com:validityTimeSpecification>
+                        </validityByOrder>
+                    </conditions>
+        
+                    <conditions xsi:type="LocationCondition">
+                        <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                            <loc:linearWithinLinearElement>
+                                <loc:linearElement xsi:type="loc:LinearElement">
+                                    <loc:roadName>
+                                        <com:values>
+                                            <com:value lang="fr">Avenue du Stade de France, 93210 Saint-Denis</com:value>
+                                        </com:values>
+                                    </loc:roadName>
+                                </loc:linearElement>
+        
+                                <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                    <loc:distanceAlong>0</loc:distanceAlong>
+                                    <loc:fromReferent>
+                                        <loc:referentIdentifier>start</loc:referentIdentifier>
+                                        <loc:referentName>Pont SNCF</loc:referentName>
+                                        <loc:referentType>landmark</loc:referentType>
+                                        <loc:pointCoordinates>
+                                            <loc:latitude>48.917709</loc:latitude>
+                                            <loc:longitude>2.361931</loc:longitude>
+                                        </loc:pointCoordinates>
+                                    </loc:fromReferent>
+                                </loc:fromPoint>
+                                <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                    <loc:distanceAlong>0</loc:distanceAlong>
+                                    <loc:fromReferent>
+                                        <loc:referentIdentifier>end</loc:referentIdentifier>
+                                        <loc:referentName>Rue Francis de Préssensé</loc:referentName>
+                                        <loc:referentType>intersection</loc:referentType>
+                                        <loc:pointCoordinates>
+                                            <loc:latitude>48.919612</loc:latitude>
+                                            <loc:longitude>2.361700</loc:longitude>
+                                        </loc:pointCoordinates>
+                                    </loc:fromReferent>
+                                </loc:toPoint>
+                            </loc:linearWithinLinearElement>
+                        </locationByOrder>
+                    </conditions>
+                </condition>
+            </trafficRegulation>
+        </trafficRegulationOrder>
+        
+        <trafficRegulationOrder id="064ca247-fb24-7cf8-8000-0cf1af53270c" version="1">
+            <description>
+                <com:values>
+                    <com:value lang="fr">ARRETE TEMPORAIRE ACT2023STD - 365 SM</com:value>
+                </com:values>
+            </description>
+        
+            <issuingAuthority>
+                <com:values>
+                    <com:value lang="fr">Mairie de Saint-Denis</com:value>
+                </com:values>
+            </issuingAuthority>
+        
+            <regulationId>064ca247-fb24-7cf8-8000-0cf1af53270c</regulationId>
+            <status>madeAndImplemented</status>
+        
+            <trafficRegulation>
+                <status>active</status>
+        
+                <typeOfRegulation xsi:type="AccessRestriction">
+                    <accessRestrictionType>noEntry</accessRestrictionType>
+                </typeOfRegulation>
+        
+                <condition xsi:type="ConditionSet">
+                    <operator>and</operator>
+        
+                    <conditions xsi:type="ConditionSet">
+                        <operator>or</operator>
+                        <conditions xsi:type="ValidityCondition">
+                            <validityByOrder>
+                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                                <com:validityTimeSpecification>
+                                    <com:overallStartTime>2023-05-17T18:00:00+02:00</com:overallStartTime>
+                                    <com:overallEndTime>2023-05-19T06:00:00+02:00</com:overallEndTime>
+                                </com:validityTimeSpecification>
+                            </validityByOrder>
+                        </conditions>
+                        <conditions xsi:type="ValidityCondition">
+                            <validityByOrder>
+                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                                <com:validityTimeSpecification>
+                                    <com:overallStartTime>2023-05-19T18:00:00+02:00</com:overallStartTime>
+                                    <com:overallEndTime>2023-05-23T06:00:00+02:00</com:overallEndTime>
+                                </com:validityTimeSpecification>
+                            </validityByOrder>
+                        </conditions>
+                        <conditions xsi:type="ValidityCondition">
+                            <validityByOrder>
+                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                                <com:validityTimeSpecification>
+                                    <com:overallStartTime>2023-06-02T18:00:00+02:00</com:overallStartTime>
+                                    <com:overallEndTime>2023-06-05T06:00:00+02:00</com:overallEndTime>
+                                </com:validityTimeSpecification>
+                            </validityByOrder>
+                        </conditions>
+                        <conditions xsi:type="ValidityCondition">
+                            <validityByOrder>
+                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                                <com:validityTimeSpecification>
+                                    <com:overallStartTime>2023-06-09T18:00:00+02:00</com:overallStartTime>
+                                    <com:overallEndTime>2023-06-12T06:00:00+02:00</com:overallEndTime>
+                                </com:validityTimeSpecification>
+                            </validityByOrder>
+                        </conditions>
+                        <conditions xsi:type="ValidityCondition">
+                            <validityByOrder>
+                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                                <com:validityTimeSpecification>
+                                    <com:overallStartTime>2023-08-11T18:00:00+02:00</com:overallStartTime>
+                                    <com:overallEndTime>2023-08-15T06:00:00+02:00</com:overallEndTime>
+                                </com:validityTimeSpecification>
+                            </validityByOrder>
+                        </conditions>
+                        <conditions xsi:type="ValidityCondition">
+                            <validityByOrder>
+                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                                <com:validityTimeSpecification>
+                                    <com:overallStartTime>2023-11-03T18:00:00+02:00</com:overallStartTime>
+                                    <com:overallEndTime>2023-11-06T06:00:00+02:00</com:overallEndTime>
+                                </com:validityTimeSpecification>
+                            </validityByOrder>
+                        </conditions>
+                    </conditions>
+        
+                    <conditions xsi:type="ConditionSet">
+                        <operator>or</operator>
+                        <conditions xsi:type="LocationCondition">
+                            <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                                <loc:linearWithinLinearElement>
+                                    <loc:linearElement xsi:type="loc:LinearElement">
+                                        <loc:roadName>
+                                            <com:values>
+                                                <com:value lang="fr">Avenue des Fruitiers, 93210 Saint-Denis</com:value>
+                                            </com:values>
+                                        </loc:roadName>
+                                    </loc:linearElement>
+                                    <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                        <loc:distanceAlong>0</loc:distanceAlong>
+                                        <loc:fromReferent>
+                                            <loc:referentIdentifier>start</loc:referentIdentifier>
+                                            <loc:referentName>33</loc:referentName>
+                                            <loc:referentType>referenceMarker</loc:referentType>
+                                            <loc:pointCoordinates>
+                                                <loc:latitude>48.919245</loc:latitude>
+                                                <loc:longitude>2.354415</loc:longitude>
+                                            </loc:pointCoordinates>
+                                        </loc:fromReferent>
+                                    </loc:fromPoint>
+                                    <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                        <loc:distanceAlong>0</loc:distanceAlong>
+                                        <loc:fromReferent>
+                                            <loc:referentIdentifier>end</loc:referentIdentifier>
+                                            <loc:referentName>5</loc:referentName>
+                                            <loc:referentType>referenceMarker</loc:referentType>
+                                            <loc:pointCoordinates>
+                                                <loc:latitude>48.916503</loc:latitude>
+                                                <loc:longitude>2.354752</loc:longitude>
+                                            </loc:pointCoordinates>
+                                        </loc:fromReferent>
+                                    </loc:toPoint>
+                                </loc:linearWithinLinearElement>
+                            </locationByOrder>
+                        </conditions>
+        
+                        <conditions xsi:type="LocationCondition">
+                            <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                                <loc:linearWithinLinearElement>
+                                    <loc:linearElement xsi:type="loc:LinearElement">
+                                        <loc:roadName>
+                                            <com:values>
+                                                <com:value lang="fr">Rue des Cheminots, 93210 Saint-Denis</com:value>
+                                            </com:values>
+                                        </loc:roadName>
+                                    </loc:linearElement>
+                                    <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                        <loc:distanceAlong>0</loc:distanceAlong>
+                                        <loc:fromReferent>
+                                            <loc:referentIdentifier>start</loc:referentIdentifier>
+                                            <loc:referentName>24</loc:referentName>
+                                            <loc:referentType>referenceMarker</loc:referentType>
+                                            <loc:pointCoordinates>
+                                                <loc:latitude>48.917786</loc:latitude>
+                                                <loc:longitude>2.352652</loc:longitude>
+                                            </loc:pointCoordinates>
+                                        </loc:fromReferent>
+                                    </loc:fromPoint>
+                                    <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                        <loc:distanceAlong>0</loc:distanceAlong>
+                                        <loc:fromReferent>
+                                            <loc:referentIdentifier>end</loc:referentIdentifier>
+                                            <loc:referentName>10</loc:referentName>
+                                            <loc:referentType>referenceMarker</loc:referentType>
+                                            <loc:pointCoordinates>
+                                                <loc:latitude>48.916110</loc:latitude>
+                                                <loc:longitude>2.352746</loc:longitude>
+                                            </loc:pointCoordinates>
+                                        </loc:fromReferent>
+                                    </loc:toPoint>
+                                </loc:linearWithinLinearElement>
+                            </locationByOrder>
+                        </conditions>
+        
+                        <conditions xsi:type="LocationCondition">
+                            <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                                <loc:linearWithinLinearElement>
+                                    <loc:linearElement xsi:type="loc:LinearElement">
+                                        <loc:roadName>
+                                            <com:values>
+                                                <com:value lang="fr">Avenue François Mitterand, 93210 Saint-Denis</com:value>
+                                            </com:values>
+                                        </loc:roadName>
+                                    </loc:linearElement>
+                                    <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                        <loc:distanceAlong>0</loc:distanceAlong>
+                                        <loc:fromReferent>
+                                            <loc:referentIdentifier>start</loc:referentIdentifier>
+                                            <loc:referentName>17</loc:referentName>
+                                            <loc:referentType>referenceMarker</loc:referentType>
+                                            <loc:pointCoordinates>
+                                                <loc:latitude>48.918139</loc:latitude>
+                                                <loc:longitude>2.352316</loc:longitude>
+                                            </loc:pointCoordinates>
+                                        </loc:fromReferent>
+                                    </loc:fromPoint>
+                                    <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                        <loc:distanceAlong>0</loc:distanceAlong>
+                                        <loc:fromReferent>
+                                            <loc:referentIdentifier>end</loc:referentIdentifier>
+                                            <loc:referentName>1</loc:referentName>
+                                            <loc:referentType>referenceMarker</loc:referentType>
+                                            <loc:pointCoordinates>
+                                                <loc:latitude>48.918037</loc:latitude>
+                                                <loc:longitude>2.356793</loc:longitude>
+                                            </loc:pointCoordinates>
+                                        </loc:fromReferent>
+                                    </loc:toPoint>
+                                </loc:linearWithinLinearElement>
+                            </locationByOrder>
+                        </conditions>
+        
+                        <conditions xsi:type="LocationCondition">
+                            <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                                <loc:linearWithinLinearElement>
+                                    <loc:linearElement xsi:type="loc:LinearElement">
+                                        <loc:roadName>
+                                            <com:values>
+                                                <com:value lang="fr">Rue Federico Fellini, 93210 Saint-Denis</com:value>
+                                            </com:values>
+                                        </loc:roadName>
+                                    </loc:linearElement>
+                                    <loc:fromPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
+                                        <loc:percentageDistanceAlong>0</loc:percentageDistanceAlong>
+                                    </loc:fromPoint>
+                                    <loc:toPoint xsi:type="loc:PercentageDistanceAlongLinearElement">
+                                        <loc:percentageDistanceAlong>100</loc:percentageDistanceAlong>
+                                    </loc:toPoint>
+                                </loc:linearWithinLinearElement>
+                            </locationByOrder>
+                        </conditions>
+                    </conditions>
+        
+                    <conditions xsi:type="DriverCondition">
+                        <negate>true</negate>
+                        <driverCharacteristicsType>localResident</driverCharacteristicsType>
+                    </conditions>
+                </condition>
+            </trafficRegulation>
+        </trafficRegulationOrder>
+        
+        <trafficRegulationOrder id="064ca50b-428d-7810-8000-9b78885e357b" version="1">
+            <description>
+                <com:values>
+                    <com:value lang="fr">Arrêté portant dérogation temporaire des conditions de circulation et de stationnement des véhicules de toutes catégories, sur places existantes ou sur voie de circulation (route, piste cyclable, voie de bus ou trottoir), pour manifestation</com:value>
+                </com:values>
+            </description>
+        
+            <issuingAuthority>
+                <com:values>
+                    <com:value lang="fr">Préfecture de Seine-Saint-Denis</com:value>
+                </com:values>
+            </issuingAuthority>
+        
+            <regulationId>064ca50b-428d-7810-8000-9b78885e357b</regulationId>
+            <status>madeAndImplemented</status>
+        
+            <trafficRegulation>
+                <status>active</status>
+        
+                <typeOfRegulation xsi:type="AccessRestriction">
+                    <accessRestrictionType>noEntry</accessRestrictionType>
+                </typeOfRegulation>
+        
+                <condition xsi:type="ConditionSet">
+                    <operator>and</operator>
+        
+                    <conditions xsi:type="ValidityCondition">
+                        <validityByOrder>
+                            <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                            <com:validityTimeSpecification>
+                                <com:overallStartTime>2023-08-11T16:00:00+02:00</com:overallStartTime>
+                                <com:overallEndTime>2023-08-15T05:00:00+02:00</com:overallEndTime>
+                            </com:validityTimeSpecification>
+                        </validityByOrder>
+                    </conditions>
+        
+                    <conditions xsi:type="LocationCondition">
+                        <locationByOrder xsi:type="loc:SingleRoadLinearLocation">
+                            <loc:linearWithinLinearElement>
+                                <loc:linearElement xsi:type="loc:LinearElement">
+                                    <loc:roadName>
+                                        <com:values>
+                                            <com:value lang="fr">Rue Francis de Pressensé, 93210 Saint-Denis</com:value>
+                                        </com:values>
+                                    </loc:roadName>
+                                </loc:linearElement>
+        
+                                <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                    <loc:distanceAlong>0</loc:distanceAlong>
+                                    <loc:fromReferent>
+                                        <loc:referentIdentifier>start</loc:referentIdentifier>
+                                        <loc:referentName>Avenue du Président Wilson</loc:referentName>
+                                        <loc:referentType>intersection</loc:referentType>
+                                        <loc:pointCoordinates>
+                                            <loc:latitude>48.918157</loc:latitude>
+                                            <loc:longitude>2.357865</loc:longitude>
+                                        </loc:pointCoordinates>
+                                    </loc:fromReferent>
+                                </loc:fromPoint>
+                                <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+                                    <loc:distanceAlong>0</loc:distanceAlong>
+                                    <loc:fromReferent>
+                                        <loc:referentIdentifier>end</loc:referentIdentifier>
+                                        <loc:referentName>Avenue du Stade de France</loc:referentName>
+                                        <loc:referentType>intersection</loc:referentType>
+                                        <loc:pointCoordinates>
+                                            <loc:latitude>48.919687</loc:latitude>
+                                            <loc:longitude>2.361726</loc:longitude>
+                                        </loc:pointCoordinates>
+                                    </loc:fromReferent>
+                                </loc:toPoint>
+                            </loc:linearWithinLinearElement>
+                        </locationByOrder>
+                    </conditions>
+                </condition>
+            </trafficRegulation>
+        </trafficRegulationOrder>
+        
         <trafficRegulationOrder id="2e5eb289-90c8-4c3f-8e7c-2e9e7de8948c" version="1">
             <description>
                 <com:values>


### PR DESCRIPTION
* Refs #425 

Cette PR intègre les restrictions de circulation (pas celles de stationnement) contenues dans les arrêtés à Saint-Denis

Les restrictions sont intégrées "en brut" dans l'export DATEX II.

L'intégration de l'arrêté de la Préfecture de Seine-Saint-Denis (Rue Francis de Pressensé) est encore en discussion, car son interprétation est un peu ambigue.

La présence de multiples créneaux et de multiples localisations pour une même restriction (interdiction de circuler) m'a fait apparaître un problème technique dans notre utilisation du DATEX. Je vais ouvrir des tickets pour clarifier de quoi il s'agit.

**Note pour la relecture**
Activer "Hide whitespaces"