### PR TITLE
Address Doctrine deprecation warning about partial syntax

### DIFF
--- a/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
@@ -24,8 +24,5 @@ interface RegulationOrderRecordRepositoryInterface
 
     public function findRegulationOrdersForDatexFormat(): array;
 
-    public function findOneByOrganizationAndIdentifier(
-        Organization $organization,
-        string $identifier,
-    ): ?RegulationOrderRecord;
+    public function doesOneExistInOrganizationWithIdentifier(Organization $organization, string $identifier): bool;
 }

--- a/src/Domain/User/Specification/DoesOrganizationAlreadyHaveRegulationOrderWithThisIdentifier.php
+++ b/src/Domain/User/Specification/DoesOrganizationAlreadyHaveRegulationOrderWithThisIdentifier.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Domain\User\Specification;
 
-use App\Domain\Regulation\RegulationOrderRecord;
 use App\Domain\Regulation\Repository\RegulationOrderRecordRepositoryInterface;
 use App\Domain\User\Organization;
 
@@ -17,9 +16,6 @@ class DoesOrganizationAlreadyHaveRegulationOrderWithThisIdentifier
 
     public function isSatisfiedBy(string $newIdentifier, Organization $organization): bool
     {
-        $regulationOrderRecord = $this->regulationOrderRecordRepository
-            ->findOneByOrganizationAndIdentifier($organization, $newIdentifier);
-
-        return $regulationOrderRecord instanceof RegulationOrderRecord;
+        return $this->regulationOrderRecordRepository->doesOneExistInOrganizationWithIdentifier($organization, $newIdentifier);
     }
 }

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -121,12 +121,12 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
         return $regulationOrderRecord;
     }
 
-    public function findOneByOrganizationAndIdentifier(
+    public function doesOneExistInOrganizationWithIdentifier(
         Organization $organization,
         string $identifier,
-    ): ?RegulationOrderRecord {
-        return $this->createQueryBuilder('roc')
-            ->select('partial roc.{uuid}')
+    ): bool {
+        $row = $this->createQueryBuilder('roc')
+            ->select('roc.uuid')
             ->where('roc.organization = :organization')
             ->innerJoin('roc.regulationOrder', 'ro', 'WITH', 'ro.identifier = :identifier')
             ->setParameters([
@@ -135,5 +135,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ])
             ->getQuery()
             ->getOneOrNullResult();
+
+        return $row !== null;
     }
 }

--- a/tests/Unit/Domain/User/Specification/DoesOrganizationAlreadyHaveRegulationOrderWithThisIdentifierTest.php
+++ b/tests/Unit/Domain/User/Specification/DoesOrganizationAlreadyHaveRegulationOrderWithThisIdentifierTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Domain\User\Specification;
 
-use App\Domain\Regulation\RegulationOrderRecord;
 use App\Domain\Regulation\Repository\RegulationOrderRecordRepositoryInterface;
 use App\Domain\User\Organization;
 use App\Domain\User\Specification\DoesOrganizationAlreadyHaveRegulationOrderWithThisIdentifier;
@@ -15,13 +14,12 @@ final class DoesOrganizationAlreadyHaveRegulationOrderWithThisIdentifierTest ext
     public function testOrganizationAlreadyHasRegulationOrder(): void
     {
         $organization = $this->createMock(Organization::class);
-        $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
         $regulationOrderRecordRepository = $this->createMock(RegulationOrderRecordRepositoryInterface::class);
         $regulationOrderRecordRepository
             ->expects(self::once())
-            ->method('findOneByOrganizationAndIdentifier')
+            ->method('doesOneExistInOrganizationWithIdentifier')
             ->with($organization, 'FO1/2023')
-            ->willReturn($regulationOrderRecord);
+            ->willReturn(true);
 
         $specification = new DoesOrganizationAlreadyHaveRegulationOrderWithThisIdentifier($regulationOrderRecordRepository);
         $this->assertTrue($specification->isSatisfiedBy('FO1/2023', $organization));
@@ -33,9 +31,9 @@ final class DoesOrganizationAlreadyHaveRegulationOrderWithThisIdentifierTest ext
         $regulationOrderRecordRepository = $this->createMock(RegulationOrderRecordRepositoryInterface::class);
         $regulationOrderRecordRepository
             ->expects(self::once())
-            ->method('findOneByOrganizationAndIdentifier')
+            ->method('doesOneExistInOrganizationWithIdentifier')
             ->with($organization, 'FO1/2023')
-            ->willReturn(null);
+            ->willReturn(false);
 
         $specification = new DoesOrganizationAlreadyHaveRegulationOrderWithThisIdentifier($regulationOrderRecordRepository);
         $this->assertFalse($specification->isSatisfiedBy('FO1/2023', $organization));


### PR DESCRIPTION
**Motivation**

La syntaxe `partial` est marquée comme dépréciée dans Doctrine

```
  1x: PARTIAL syntax in DQL is deprecated. (Parser.php:1847 called by Parser.php:2281, https://github.com/doctrine/orm/issues/8471, package doctrine/orm)
    1x in AddRegulationControllerTest::testAdd from App\Tests\Integration\Infrastructure\Controller\Regulation
```

Le seul endroit où on l'utilisait était dans une requête où on ne voulait récupérer que l'UUID d'un arrêté s'il existe.

Cette PR refactor cette partie : la méthode "findOne" devient un "doesOneExist".