### PR TITLE
Modifier la présentation du téléchargement

### DIFF
--- a/tests/e2e/regulation_publish.spec.js
+++ b/tests/e2e/regulation_publish.spec.js
@@ -13,13 +13,13 @@ test('Create then publish a regulation order', async ({ page }) => {
     await page.getByRole('button', { name: 'Continuer' }).click();
 
     await page.getByRole('heading', { level: 2, name: 'Arrêté permanent F01/test' }).waitFor();
-    await expect(page.getByRole('link', { name: 'Export format DOC' })).not.toBeVisible();
+    await expect(page.getByRole('link', { name: 'Télécharger le document' })).not.toBeVisible();
     await expect(page.getByRole('button', { name: 'Publier' })).toBeDisabled();
 
     const regPage = new RegulationOrderPage(page);
     const location = await regPage.addLocation({ address: 'Rue Monge, 21000 Dijon', restrictionType: 'Circulation interdite', expectedTitle: 'Rue Monge' }, { doBegin: false });
     await expect(location).toContainText('Circulation interdite tous les jours');
-    await page.getByRole('link', { name: 'Export format DOC' }).waitFor();
+    await page.getByRole('link', { name: 'Télécharger le document' }).waitFor();
     await expect(page.getByRole('button', { name: 'Publier' })).toBeEnabled();
 
     // Clean up

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -216,11 +216,11 @@
             </trans-unit>
             <trans-unit id="regulation.export.doc">
                 <source>regulation.export.doc</source>
-                <target>Export format DOC</target>
+                <target>Télécharger le document</target>
             </trans-unit>
             <trans-unit id="regulation.export.doc.mention">
                 <source>regulation.export.doc.mention</source>
-                <target>DOC - moins de 100ko</target>
+                <target>DOCX - moins de 100ko</target>
             </trans-unit>
             <trans-unit id="regulation.city">
                 <source>regulation.city</source>


### PR DESCRIPTION
* Proposer de "télécharger le document" plutôt qu'un "export", pour coller au [DSFR](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/telechargement-de-fichier)
* Corriger le format du document (DOCX plutôt que DOC)