### PR TITLE
Remove xdebug option to improve execution time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,10 @@ shell: ## Connect to the container
 # Individual tools
 
 phpstan: ## PHP Stan
-	${BIN_PHP} ./vendor/bin/phpstan analyse -l 5 --xdebug src
+	${BIN_PHP} ./vendor/bin/phpstan analyse -l 5 src
 
 phpstan_no_tty: ## PHP Stan without TTY
-	${BIN_PHP_NO_TTY} ./vendor/bin/phpstan analyse -l 5 --xdebug src
+	${BIN_PHP_NO_TTY} ./vendor/bin/phpstan analyse -l 5 src
 
 php_lint: ## PHP linter
 	${BIN_PHP} ./vendor/bin/php-cs-fixer fix -n ${ARGS}


### PR DESCRIPTION
Cette PR permet de supprimer le warning de la command phpstan
```
 ! [NOTE] You are running with "--xdebug" enabled, and the Xdebug PHP extension is active.                              
 !        The process will halt at breakpoints, but PHPStan will run much slower.                                       
 !        Use this only if you are debugging PHPStan itself or your custom extensions. 
 ```