### PR TITLE
Refine landing diagram arrows

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -361,8 +361,8 @@ ol.app-authorities__steplist {
 }
 
 ul.app-landing-diagram {
-    --item-padding: 1rem;
-    --arrow-size: 18px;
+    --item-padding: 0.25rem 1rem 1rem 1rem;
+    --arrow-size: 14px;
     --image-size: 80px;
 
     list-style-type: none;
@@ -395,8 +395,11 @@ ul.app-landing-diagram > li > img {
     // Arrow container
     flex-grow: 1;
     width: 100%;
-    height: 2rem;
+    height: 3rem;
     position: relative;
+    border-width: 0.5rem 0;
+    border-style: solid;
+    border-color: transparent;
 }
 
 .app-landing-diagram__arrow::before {
@@ -414,7 +417,7 @@ ul.app-landing-diagram > li > img {
     content: "▼";
     position: absolute;
     left: calc(50% - (var(--arrow-size) / 2 - 1px));
-    bottom: calc(-1 * var(--arrow-size) / 2);
+    bottom: calc(-1 * var(--arrow-size) / 5);
     font-size: var(--arrow-size);
     line-height: var(--arrow-size);
     color: var(--artwork-minor-blue-france);
@@ -435,6 +438,7 @@ ul.app-landing-diagram > li > img {
         width: unset;
         min-height: unset;
 
+        border-width: 0 1rem;
         height: var(--diagram-height);
     }
 
@@ -454,7 +458,7 @@ ul.app-landing-diagram > li > img {
         bottom: unset;
 
         content: "▶";
-        right: calc(-1 * var(--arrow-size) / 2);
+        right: calc(-1 * var(--arrow-size) / 5);
         top: calc(50% - var(--arrow-size) / 2);
     }
 }


### PR DESCRIPTION
Cette PR améliore la fidélité de l'intégration du diagramme des landing pages au vu de la maquette

* La taille des pointes de flèche est réduite
* Le positionnement des flèches depuis un item non-mis en avant vers un item mis en avant est corrigé (constaté sur #449)
* De l'espace est ajouté autour de la flèche (à l'aide d'une bordure transparente, car padding n'aurait pas d'effet en raison du position: absolute du corps et de la pointe de la flèche)

Les modifs ont lieu sur mobile et sur desktop

Avant :

![image](https://github.com/MTES-MCT/dialog/assets/15911462/fffc7c98-1813-418c-beab-3c78f78c6004)

Après :

![image](https://github.com/MTES-MCT/dialog/assets/15911462/a5719dcc-3f23-4006-9424-cd362ece4dbc)
