### PR TITLE
Add missing empty case to GetRegulationOrdersToDatexFormatQueryHandler

### DIFF
--- a/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
@@ -21,6 +21,10 @@ final class GetRegulationOrdersToDatexFormatQueryHandler
     {
         $rows = $this->repository->findRegulationOrdersForDatexFormat();
 
+        if (empty($rows)) {
+            return [];
+        }
+
         // There is one row per unique combination of (regulationOrder, location, measure).
         // Rows are sorted by regulationOrder uuid.
         // So we iterate over rows, pushing a new regulation order view when the row's regulationOrder uuid changes.

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
@@ -15,6 +15,21 @@ use PHPUnit\Framework\TestCase;
 
 final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
 {
+    public function testGetAllEmpty(): void
+    {
+        $regulationOrderRecordRepository = $this->createMock(RegulationOrderRecordRepositoryInterface::class);
+
+        $regulationOrderRecordRepository
+            ->expects(self::once())
+            ->method('findRegulationOrdersForDatexFormat')
+            ->willReturn([]);
+
+        $handler = new GetRegulationOrdersToDatexFormatQueryHandler($regulationOrderRecordRepository);
+        $regulationOrders = $handler(new GetRegulationOrdersToDatexFormatQuery());
+
+        $this->assertEquals([], $regulationOrders);
+    }
+
     public function testGetAll(): void
     {
         $location1 = new DatexLocationView(


### PR DESCRIPTION
* Correctif suite à #437 

J'avais oublié le cas où aucun arrêté n'avait encore été publié

Dans ce cas l'endpoint renvoyait une erreur car on faisait `$rows[0]` (index error)