### PR TITLE
Cleanup app.scss

### DIFF
--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -82,26 +82,19 @@ label.required > .fr-x-label-content::after, legend.required > .fr-x-label-conte
     font-size: 1.5rem !important; // Override to have the same size as the DSFR. Don't work without !important
 }
 
-.landing-jumbotron__illustration {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    text-align: center;
-}
-
-.fr-text--default-grey {
+.fr-x-text--default-grey {
     color: var(--text-default-grey);
 }
 
-.fr-text-mention--grey {
+.fr-x-text--mention-grey {
     color: var(--text-mention-grey);
 }
 
-.fr-title--blue-france {
+.fr-x-text--blue-france {
     color: var(--blue-france-sun-113-625);
 }
 
-.fr-background-alt--blue-france {
+.fr-x-background-alt--blue-france {
     background-color: var(--blue-france-975-75);
 }
 

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -6,10 +6,10 @@
 
 {% block body %}
     <section class="fr-container fr-py-4w header" aria-labelledby="jumbotron">
-        <div class="fr-grid-row fr-grid-row--gutters">
+        <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
             <div class="fr-col-12 fr-col-md-8">
-                <h1 id="jumbotron" class="fr-title--blue-france">{{ 'landing.jumbotron.title'|trans }}</h1>
-                <ul class="fr-text-mention--grey fr-x-list--checkmarks fr-x-md-stack" style="--stack-spacing: 1rem;">
+                <h1 id="jumbotron" class="fr-x-text--blue-france">{{ 'landing.jumbotron.title'|trans }}</h1>
+                <ul class="fr-x-text--mention-grey fr-x-list--checkmarks fr-x-md-stack" style="--stack-spacing: 1rem;">
                     <li>{{ 'landing.jumbotron.description1'|trans|raw }}
                     </li>
                     <li>{{ 'landing.jumbotron.description2'|trans|raw }}
@@ -18,12 +18,12 @@
                     </li>
                 </ul>
             </div>
-            <div class="fr-col-12 fr-col-md-4 landing-jumbotron__illustration">
+            <div class="fr-col-12 fr-col-md-4 fr-x-text--center">
                 <img src="{{ asset('images/landing/illustration-gps.webp') }}" alt="{{ 'landing.jumbotron.illustration'|trans }}" width="300" height="276"/>
             </div>
         </div>
     </section>
-    <section class="how-it-works fr-background-alt--blue-france" aria-labelledby="how-it-works">
+    <section class="how-it-works fr-x-background-alt--blue-france" aria-labelledby="how-it-works">
         <div class="fr-container fr-py-4w">
             <h2 id="how-it-works">{{ 'landing.for-who.title'|trans }}</h2>
             <div class="fr-grid-row fr-grid-row--gutters fr-grid-row">
@@ -88,12 +88,12 @@
         </div>
     </section>
     <section class="itinerary fr-container fr-py-6w" aria-labelledby="itinerary">
-        <h2 id="itinerary" class="fr-title--blue-france">{{ 'landing.how-it-works.title'|trans }}</h2>
+        <h2 id="itinerary" class="fr-x-text--blue-france">{{ 'landing.how-it-works.title'|trans }}</h2>
         <p class="fr-text--xl fr-m-0">{{ 'landing.how-it-works.description'|trans|raw }}</p>
         {% include '_landing_diagram.html.twig' with {class: 'fr-mt-3w', spotlight: 'dialog'} only %}
     </section>
     <section class="fr-container fr-py-6w">
-                <h2 class="fr-title--blue-france">{{ 'landing.who-are-we.title'|trans }}</h2>
+                <h2 class="fr-x-text--blue-france">{{ 'landing.who-are-we.title'|trans }}</h2>
                 <p class="fr-text--xl">{{ 'landing.who-are-we.description1'|trans|raw }}</p>
                 <p class="fr-text--xl">{{ 'landing.who-are-we.description2'|trans|raw }}</p>
                 <a href="{{ path('app_landing_authorities') }}" class="fr-btn fr-mr-2w">

--- a/templates/landing_authorities.html.twig
+++ b/templates/landing_authorities.html.twig
@@ -8,10 +8,10 @@
     <div class="fr-container fr-pt-4w fr-pb-2w">
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle">
             <div class="fr-col-12 fr-col-md-8">
-                <h1 class="fr-title--blue-france">{{ 'landing.authorities.jumbotron.title'|trans }}</h1>
+                <h1 class="fr-x-text--blue-france">{{ 'landing.authorities.jumbotron.title'|trans }}</h1>
                 <a class="fr-btn" href="mailto:dialog@beta.gouv.fr">{{ 'landing.authorities.jumbotron.cta'|trans }}</a>
             </div>
-            <div class="fr-col-12 fr-col-md-4 landing-jumbotron__illustration">
+            <div class="fr-col-12 fr-col-md-4 fr-x-text--center">
                 <img src="{{ asset('images/landing/illustration-gps.webp') }}" aria-hidden="true" width="300" height="276"/>
             </div>
         </div>
@@ -31,21 +31,21 @@
         </div>
     </div>
 
-    <div class="fr-container fr-x-container--fluid fr-py-4w fr-background-alt--blue-france">
+    <div class="fr-container fr-x-container--fluid fr-py-4w fr-x-background-alt--blue-france">
         <div class="fr-container">
-            <h2 class="fr-title--blue-france">{{ 'landing.authorities.value_prop'|trans }}</h2>
+            <h2 class="fr-x-text--blue-france">{{ 'landing.authorities.value_prop'|trans }}</h2>
 
             <div class="fr-grid-row fr-grid-row--gutters fr-text--lg">
                 <div class="fr-col-12 fr-col-md-6 fr-pr-md-5w">
                     <h3>{{ 'landing.authorities.save_time'|trans }}</h3>
-                    <ul class="fr-text-mention--grey fr-x-list--checkmarks fr-x-md-stack" style="--stack-spacing: 1rem;">
+                    <ul class="fr-x-text--mention-grey fr-x-list--checkmarks fr-x-md-stack" style="--stack-spacing: 1rem;">
                         <li>{{ 'landing.authorities.save_time.create_orders'|trans|raw }}</li>
                         <li>{{ 'landing.authorities.save_time.send_to_gps'|trans|raw }}</li>
                     </ul>
                 </div>
                 <div class="fr-col-12 fr-col-md-6 fr-pl-md-5w">
                     <h3>{{ 'landing.authorities.simpler_interactions'|trans }}</h3>
-                    <ul class="fr-text-mention--grey fr-x-list--checkmarks fr-x-md-stack" style="--stack-spacing: 1rem;">
+                    <ul class="fr-x-text--mention-grey fr-x-list--checkmarks fr-x-md-stack" style="--stack-spacing: 1rem;">
                         <li>{{ 'landing.authorities.simpler_interactions.other_authorities'|trans|raw }}</li>
                         <li>{{ 'landing.authorities.simpler_interactions.other_services'|trans|raw }}</li>
                     </ul>
@@ -55,7 +55,7 @@
     </div>
 
     <div class="fr-container fr-py-4w">
-        <h2 class="fr-title--blue-france">{{ 'landing.authorities.how_it_works'|trans }}</h2>
+        <h2 class="fr-x-text--blue-france">{{ 'landing.authorities.how_it_works'|trans }}</h2>
         <p class="fr-text--xl fr-m-0">{{ 'landing.authorities.how_it_works.description'|trans }}</p>
         {% include '_landing_diagram.html.twig' with {class: 'fr-mt-3w', spotlight: ['authorities', 'dialog']} only %}
     </div>
@@ -63,7 +63,7 @@
     <div class="fr-container fr-x-container--fluid fr-py-4w">
         <div class="fr-container fr-container--fluid">
             <div class="fr-grid-row fr-grid-row--middle">
-                <div class="fr-col-12 fr-col-md-8 fr-px-3w fr-py-4w fr-background-alt--blue-france">
+                <div class="fr-col-12 fr-col-md-8 fr-px-3w fr-py-4w fr-x-background-alt--blue-france">
                     <ol class="app-authorities__steplist">
                         <li>
                             <h3 class="fr-text--xl fr-my-0">

--- a/templates/regulation/_status_badge.html.twig
+++ b/templates/regulation/_status_badge.html.twig
@@ -6,7 +6,7 @@
 </span>
 
 {% if withHint|default(false) %}
-    <p class="fr-text--sm fr-text-mention--grey fr-mt-1v">
+    <p class="fr-text--sm fr-x-text--mention-grey fr-mt-1v">
         {{ hint|trans }}
     </p>
 {% endif %}

--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -28,7 +28,7 @@
                     </div>
 
                     <section aria-labelledby="locations-title">
-                        <h3 id="locations-title" class="fr-h5 fr-text--default-grey fr-mt-5w">
+                        <h3 id="locations-title" class="fr-h5 fr-x-text--default-grey fr-mt-5w">
                             {{ 'regulation.locations'|trans }}
                         </h3>
 

--- a/templates/regulation/fragments/_export_section.html.twig
+++ b/templates/regulation/fragments/_export_section.html.twig
@@ -6,7 +6,7 @@
     <a target="_top" download class="fr-link fr-icon-download-line fr-link--icon-left" href="{{ path('app_regulation_export', { uuid: regulationOrderRecordUuid })}}">
         {{ 'regulation.export.doc'|trans }}
     </a>
-    <div class="fr-mt-1v fr-text--sm fr-text-mention--grey">
+    <div class="fr-mt-1v fr-text--sm fr-x-text--mention-grey">
         {{ 'regulation.export.doc.mention'|trans }}
     </div>
 </div>

--- a/templates/regulation/fragments/_location_form.html.twig
+++ b/templates/regulation/fragments/_location_form.html.twig
@@ -79,7 +79,7 @@
                 <h4 class="fr-h6 fr-mb-0" data-form-collection-position-template="{{ 'regulation.measure'|trans }}">
                     {{ 'regulation.measure'|trans }} {{ position }}
                 </h4>
-                <p class="fr-text-sm fr-text-mention--grey fr-m-0">
+                <p class="fr-text-sm fr-x-text--mention-grey fr-m-0">
                     {{ 'regulation.measure_list_item.help'|trans }}
                 </p>
             </div>


### PR DESCRIPTION
Cette PR fait un peu de ménage dans les classes définies dans `app.scss` :

* `fr-text-mention--grey` devient `fr-x-text--mention-grey`
* `fr-title--blue-france` devient `fr-x-text--blue-france`
* `fr-text--default-grey` devient `fr-x-text--default-grey`
* `landing-jumbotron__illustration` disparaît car on peut utiliser `fr-x-text--center` là où elle était utilisée

L'objectif est de garder toutes les classes "dans le style du DSFR" en `fr-x-*`