### PR TITLE
Fix page update after publish

### DIFF
--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -66,9 +66,9 @@
                             <ul class="fr-btns-group fr-btns-group--icon-left">
                                 {% if isDraft %}
                                     <li>
-                                        <turbo-frame id="block_publication">
+                                        <div id="block_publication">
                                             {% include 'regulation/fragments/_publication_button.html.twig' with { canPublish, regulationOrderRecord } only %}
-                                        </turbo-frame>
+                                        </div>
                                     </li>
                                 {% endif %}
                                 <li>

--- a/templates/regulation/fragments/_location.added.stream.html.twig
+++ b/templates/regulation/fragments/_location.added.stream.html.twig
@@ -31,7 +31,7 @@
     </template>
 </turbo-frame>
 
-<turbo-stream action="replace" target="block_publication">
+<turbo-stream action="update" target="block_publication">
     <template>
         {% include 'regulation/fragments/_publication_button.html.twig' with { canPublish: true, regulationOrderRecord } only %}
     </template>

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddLocationControllerTest.php
@@ -59,13 +59,18 @@ final class AddLocationControllerTest extends AbstractWebTestCase
 
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
         $this->assertResponseStatusCodeSame(200);
-        $streams = $crawler->filter('turbo-stream');
-        $this->assertSame($streams->first()->attr('target'), 'location_f15ed802-fa9b-4d75-ab04-d62ea46597e9_delete_button');
-        $this->assertSame($streams->first()->attr('action'), 'replace');
 
-        $this->assertSame($streams->last()->attr('action'), 'replace');
-        $form = $streams->last()->selectButton('Ajouter une localisation');
-        $this->assertSame('http://localhost/_fragment/regulations/4ce75a1f-82f3-40ee-8f95-48d0f04446aa/location/add', $form->getUri());
+        $streams = $crawler->filter('turbo-stream')->extract(['action', 'target']);
+        $this->assertEquals([
+            ['replace', 'location_f15ed802-fa9b-4d75-ab04-d62ea46597e9_delete_button'],
+            ['append', 'location_list'],
+            ['replace', 'block_location'],
+            ['replace', 'block_export'],
+            ['update', 'block_publication'],
+        ], $streams);
+
+        $addLocationBtn = $crawler->filter('turbo-stream[target=block_location]')->selectButton('Ajouter une localisation');
+        $this->assertSame('http://localhost/_fragment/regulations/4ce75a1f-82f3-40ee-8f95-48d0f04446aa/location/add', $addLocationBtn->form()->getUri());
     }
 
     public function testInvalidVehicleSetBlankRestrictedTypes(): void

--- a/tests/e2e/regulation_publish.spec.js
+++ b/tests/e2e/regulation_publish.spec.js
@@ -7,20 +7,32 @@ test.use({ storageState: 'playwright/.auth/mathieu.json' });
 test('Create then publish a regulation order', async ({ page }) => {
     await page.goto('/regulations/add');
 
+    // Create a regulation order
     await page.getByRole('textbox', { name: 'Identifiant' }).fill('F01/test');
     await page.getByRole('combobox', { name: 'Nature de l\'arrêté' }).selectOption('Travaux');
     await page.getByRole('textbox', { name: 'Description' }).fill('Example');
     await page.getByRole('button', { name: 'Continuer' }).click();
 
+    // Inspect initial state
     await page.getByRole('heading', { level: 2, name: 'Arrêté permanent F01/test' }).waitFor();
+    await expect(page.getByTestId('status-badge')).toHaveText('Brouillon');
     await expect(page.getByRole('link', { name: 'Télécharger le document' })).not.toBeVisible();
     await expect(page.getByRole('button', { name: 'Publier' })).toBeDisabled();
 
+    // Add a location
     const regPage = new RegulationOrderPage(page);
     const location = await regPage.addLocation({ address: 'Rue Monge, 21000 Dijon', restrictionType: 'Circulation interdite', expectedTitle: 'Rue Monge' }, { doBegin: false });
     await expect(location).toContainText('Circulation interdite tous les jours');
+
+    // Regulation order can now be downloaded and published
     await page.getByRole('link', { name: 'Télécharger le document' }).waitFor();
     await expect(page.getByRole('button', { name: 'Publier' })).toBeEnabled();
+
+    // Publish for real
+    await page.getByRole('button', { name: 'Publier' }).click();
+    await page.getByRole('dialog', { name: 'Publier cet arrêté ?' }).getByRole('button', { name: 'Publier', exact: true }).click();
+    await expect(page.getByTestId('status-badge')).toHaveText('Publié');
+    await expect(page.getByRole('button', { name: 'Publier' })).not.toBeVisible();
 
     // Clean up
     await regPage.delete();


### PR DESCRIPTION
Closes #468 

Le bug avait été introduit par #410 

Le problème est qu'on avait entouré le bouton "Publier" par un turbo-frame pour pouvoir le remplacer par sa version active quand une localisation est créée...

Or l'endpoint /publish renvoie la nouvelle page de détail qui, une fois l'arrêté publié, ne contient plus le bouton "Publier" et donc ne contient plus la frame `block_publication` : d'où le "Content missing".

En ajoutant `data-turbo-target="_top"` au formulaire entourant le bouton "Publier", Turbo ne cherchait plus à remplacer la frame mais remplaçait d'office la page entière. Ça aurait pu constituer un correctif légitime.

Mais en fait, **il n'est pas obligatoire qu'une action stream cible un turbo-frame.** Je pense qu'on ne le savait pas ! C'est écrit dans la doc Turbo https://turbo.hotwired.dev/handbook/streams :

> It is not necessary to change targeted elements into [`<turbo-frame> `elements](https://turbo.hotwired.dev/handbook/frames). If your application utilizes <turbo-frame> elements for the sake of a `<turbo-stream> `element, change the `<turbo-frame>` into another [built-in element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element).

Donc cette PR applique ce conseil : le `<turbo-frame id="...">` devient un `<div id="...">`. L'action `replace` est aussi remplacée par `update` pour changer le contenu de la div, et non pas remplacer la div entière (ça faisait d'ailleurs qu'auparavant la turbo-frame disparaissait, je ne sais pas si c'était voulu).

J'ai aussi amélioré les tests : test d'intégration qui vérifie le contenu des streams, et test E2E qui maintenant vérifie aussi qu'on peut effectivement publier, que le badge devient "Publié", que le bouton "Publier" disparaît, etc.