### PR TITLE
Drop target="_self" in navbar links

### DIFF
--- a/templates/layouts/public.html.twig
+++ b/templates/layouts/public.html.twig
@@ -6,18 +6,24 @@
             <nav class="fr-nav" id="header-navigation" role="navigation" aria-label="Menu principal">
                 <ul class="fr-nav__list">
                     <li class="fr-nav__item">
-                        <a class="fr-nav__link" href="{{ path ('app_landing') }}" target="_self" {% if 'app_landing' == app.current_route %} aria-current="page" {% endif %}>{{ 'landing.menu.button.home'|trans }}
+                        <a class="fr-nav__link" href="{{ path('app_landing') }}" {% if 'app_landing' == app.current_route %}aria-current="page"{% endif %}>
+                            {{ 'landing.menu.button.home'|trans }}
                         </a>
                     </li>
                     <li>
-                        <a class="fr-nav__link" href="{{ path ('app_landing_authorities') }}" target="_self" {% if 'app_landing_authorities' == app.current_route %} aria-current="page" {% endif %}>{{ 'landing.menu.button.authorities'|trans }}
+                        <a class="fr-nav__link" href="{{ path('app_landing_authorities') }}" {% if 'app_landing_authorities' == app.current_route %}aria-current="page"{% endif %}>
+                            {{ 'landing.menu.button.authorities'|trans }}
                         </a>
                     </li>
                     <li class="fr-nav__item">
-                        <a class="fr-nav__link" href="{{ path ('app_landing_digital_services') }}" target="_self" {% if 'app_landing_digital_services' == app.current_route %} aria-current="page" {% endif %}>{{ 'landing.menu.button.digital_services'|trans }}</a>
+                        <a class="fr-nav__link" href="{{ path('app_landing_digital_services') }}" {% if 'app_landing_digital_services' == app.current_route %}aria-current="page"{% endif %}>
+                            {{ 'landing.menu.button.digital_services'|trans }}
+                        </a>
                     </li>
                     <li class="fr-nav__item">
-                        <a class="fr-nav__link" href="{{ path ('app_landing_road_users') }}" target="_self" {% if 'app_landing_road_users' == app.current_route %} aria-current="page" {% endif %}>{{ 'landing.menu.button.road_users'|trans }}</a>
+                        <a class="fr-nav__link" href="{{ path('app_landing_road_users') }}" {% if 'app_landing_road_users' == app.current_route %}aria-current="page"{% endif %}>
+                            {{ 'landing.menu.button.road_users'|trans }}
+                        </a>
                     </li>
                 </ul>
             </nav>


### PR DESCRIPTION
Fixes #477 

Mon interprétation est que Turbo ne lit que `data-turbo-target`, et pas `target` (l'attribut natif).

https://turbo.hotwired.dev/reference/frames

Donc à mon avis il interprète `target="_self"` comme étant "je laisse faire le navigateur", d'où le rechargement full page au lieu d'un chargement par Turbo.

Mettre `data-turbo-frame="_self"` serait inutile car c'est le comportement par défaut, et on n'a pas de turbo-frame parent qui justifierait un override

Donc cette PR retire `target="_self"` (et fait un peu de formatage du HTML)