### PR TITLE
Add docs: "Bien démarrer"

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,7 @@ Les pages contenues dans ce dossier sont à destination de toute personne souhai
 
 Table des matières :
 
+- [Bien démarrer](./getting-started.md) - À lire en premier si vous venez d'arriver sur le projet.
 - [Déploiement](./deployment/README.md) - Un guide pour vous permettre de deployer le projet.
 - [Outils](./tools/README.md) - Description des outils de développement.
 - [Architecture Decision Record (_ADR_)](./adr/README.md) - Documentation des décisions d'architecture importantes.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -18,7 +18,7 @@ Vous arrivez à accéder à un DiaLog local sur http://localhost:8000 ? Bravo !
 
 Nous utilisons un processus de contribution classique basé sur git et des pull requests (PR).
 
-Pour contribuer du code ou de la documentation :
+Pour contribuer au code ou à la documentation :
 
 1. Créez une nouvelle branche dans votre dépôt git local
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,73 @@
+# Bien démarrer
+
+Vous venez d'arriver sur le projet ? Voici quelques indications pour vous mettre en route.
+
+Table des matières
+
+* [Lancer DiaLog en local](#lancer-dialog-en-local)
+* [Contribuer au projet](#contribuer-au-projet)
+* [Prise en main des technologies utilisées](#prise-en-main-des-technologies-utilisées)
+
+## Lancer DiaLog en local
+
+Pour lancer DiaLog en local, suivez les instructions du [README](../README.md#démarrage-du-projet). Hormis l'installation de Docker, il n'y a normalement pas d'autre prérequis.
+
+Vous arrivez à accéder à un DiaLog local sur http://localhost:8000 ? Bravo !
+
+## Contribuer au projet
+
+Nous utilisons un processus de contribution classique basé sur git et des pull requests (PR).
+
+Pour contribuer du code ou de la documentation :
+
+1. Créez une nouvelle branche dans votre dépôt git local
+2. Faites vos modifications
+3. Ouvrez une PR.
+
+La PR devra être relue et approuvée avant d'être mergée dans `main`.
+
+Le déploiement se fait automatiquement après un merge dans `main`. Un déploiement est aussi créé pour chaque PR. Pour en savoir plus, voir la [documentation de déploiement](./deployment/README.md).
+
+## Prise en main des technologies utilisées
+
+Pour contribuer du code, vous allez probablement avoir besoin de vous familiariser avec les technologies utilisées dans ce dépôt. Voici quelques indications à cet effet.
+
+**En bref** : DiaLog utilise le langage PHP avec le framework Symfony. Il n'y a pas de frontend JS séparé. À la place, DiaLog utilise des templates Twig (Twig est à PHP ce que Jinja2 est à Python) combinés aux outils de la suite Hotwire (Turbo, Stimulus) pour l'interactivité UI. Pour en savoir plus, consultez l'[ADR-003 - Environnement technique](./adr/003_technical_stack.md).
+
+### PHP et Symfony
+
+Pour démarrer avec Symfony, nous recommandons de parcourir à son rythme la [documentation Symfony](https://symfony.com/doc/current/index.html).
+
+Si vous avez déjà développé avec un framework "full-stack / MVC" comme Django, vous devriez vite trouver vos repères. N'hésitez pas à consulter des comparatifs, par exemple [Django vs Symfony, slant.co](https://www.slant.co/versus/1746/3758/~django_vs_symfony).
+
+Passez un peu de temps sur la partie [Configuration](https://symfony.com/doc/current/configuration.html) pour comprendre le dossier `config/` et son contenu. De même, essayez d'appréhender la partie [Services / DI](https://symfony.com/doc/current/service_container.html) car le système d'injection de dépendances (DI) est important dans Symfony.
+
+### Turbo et Stimulus
+
+Pour démarrer avec Turbo et Stimulus, nous recommandons de :
+
+* Consulter la [page d'accueil de Hotwire](https://hotwired.dev/). Elle présente la philosophie générale de l'approche "HTML Over the Wire".
+* Parcourir à son rythme la [documentation Turbo](https://turbo.hotwired.dev/), en particulier le [handbook Turbo](https://turbo.hotwired.dev/handbook/introduction). Intéressez-vous en particulier à ces notions : Drive, Frames, Streams.
+* Parcourir à son rythme la [documentation Stimulus](https://stimulus.hotwired.dev/), en particulier le [handbook Stimulus](https://stimulus.hotwired.dev/handbook/introduction). Intéressez-vous en particulier à ces notions : Controllers, Values, Targets, Actions, Outlets.
+* Consulter la [documentation de Symfony UX Turbo](https://symfony.com/bundles/ux-turbo/current/index.html) pour vous familiariser avec l'intégration de Turbo / Stimulus dans Symfony.
+
+Pour appréhender les aspects plus philosophiques des approches qui sous-tendent ces outils, vous pouvez aussi consulter :
+
+* Le e-book [Modest JS Works](https://modestjs.works/) : apporte une critique raisonnée du tout-SPA et promeut l'idée d'un "Gradient du JS" pour la réalisation des parties interactives d'une UI Web.
+* Le e-book [Hypermedia Systems](https://hypermedia.systems/) : invite à revisiter les fondements du Web pour simplifier l'architecture des applications grâce à une approche "hypermedia" capable d'assouvir la plupart des besoins. Les principes généraux qui y sont présentés sont illustrés avec [htmx](https://htmx.org), une technologie [similaire à Turbo mais plus bas niveau](https://www.reddit.com/r/django/comments/ppuguf/how_does_htmx_compare_to_turbo_hotwired/hd7rs3h/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button).
+
+### DATEX II
+
+DATEX II est le standard choisi comme format d'échange pour les données mises à disposition des GPS en open data. Pour en savoir plus, voir l'[ADR-002 - Format d'échanges de données](./adr/001_exchangeformat.md).
+
+Pour appréhender DATEX II et ses définitions XML, vous pouvez consulter le [tutoriel "Comment utiliser DATEX II"](./tutorials/datex2.md).
+
+### Architecture du code
+
+Le code de DiaLog suit une structure particulière, inspirée du Domain-Driven Design, de la Clean Architecture et de l'Architecture Hexagonale. Pour en savoir plus et en appréhender les principes généraux, consultez l'[ADR-004 - Architecture hexagonale](./adr/004_hexagonal_architecture.md).
+
+**Conséquences pour l'utilisation de Symfony**
+
+Notre utilisation de Symfony s'accompagne de bonnes pratiques de découplage, telles que la configuration de l'ORM Doctrine ou de la validation dans des fichiers XML plutôt que directement dans le code PHP sous forme d'annotations.
+
+Le code peut donc différer de ce qui est généralement présenté par défaut dans la documentation Symfony.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,8 +21,26 @@ Nous utilisons un processus de contribution classique basé sur git et des pull 
 Pour contribuer du code ou de la documentation :
 
 1. Créez une nouvelle branche dans votre dépôt git local
+
+    Par convention, le nom de branche devrait utiliser un préfixe :
+
+    * `feat/` : pour les nouvelles fonctionnalités
+    * `fix/` ou `bug/` : pour les correctifs
+    * `refactor/` : pour le refactoring (modifications du code qui améliore sa qualité sans modifier le comportement)
+    * `docs/` : pour la documentation
+    * `chore/` : pour la maintenance technique tel que la mise à jour des dépendances
+
 2. Faites vos modifications
-3. Ouvrez une PR.
+3. Créez un commit sur votre branche.
+    
+    Si la PR vise à résoudre une issue, incluez son numéro dans le message de commit.
+
+    Par exemple :
+
+    ```bash
+    git commit -m 'Improve docs for contributors' -m 'Closes #9081' 
+    ``` 
+4. Ouvrez une PR.
 
 La PR devra être relue et approuvée avant d'être mergée dans `main`.
 
@@ -30,13 +48,13 @@ Le déploiement se fait automatiquement après un merge dans `main`. Un déploie
 
 ## Prise en main des technologies utilisées
 
-Pour contribuer du code, vous allez probablement avoir besoin de vous familiariser avec les technologies utilisées dans ce dépôt. Voici quelques indications à cet effet.
+Pour contribuer au code, vous allez probablement avoir besoin de vous familiariser avec les technologies utilisées dans ce dépôt. Voici quelques indications à cet effet.
 
-**En bref** : DiaLog utilise le langage PHP avec le framework Symfony. Il n'y a pas de frontend JS séparé. À la place, DiaLog utilise des templates Twig (Twig est à PHP ce que Jinja2 est à Python) combinés aux outils de la suite Hotwire (Turbo, Stimulus) pour l'interactivité UI. Pour en savoir plus, consultez l'[ADR-003 - Environnement technique](./adr/003_technical_stack.md).
+**En bref** : DiaLog utilise le langage PHP avec le framework Symfony. Il n'y a pas de frontend JS séparé. À la place, DiaLog utilise des templates Twig combinés aux outils de la suite Hotwire (Turbo, Stimulus) pour l'interactivité UI. Pour en savoir plus, consultez l'[ADR-003 - Environnement technique](./adr/003_technical_stack.md).
 
 ### PHP et Symfony
 
-Pour démarrer avec Symfony, nous recommandons de parcourir à son rythme la [documentation Symfony](https://symfony.com/doc/current/index.html).
+Pour démarrer avec Symfony, nous recommandons de parcourir à son rythme la [documentation officielle](https://symfony.com/doc/current/index.html).
 
 Si vous avez déjà développé avec un framework "full-stack / MVC" comme Django, vous devriez vite trouver vos repères. N'hésitez pas à consulter des comparatifs, par exemple [Django vs Symfony, slant.co](https://www.slant.co/versus/1746/3758/~django_vs_symfony).
 

--- a/docs/tutorials/README.md
+++ b/docs/tutorials/README.md
@@ -1,0 +1,7 @@
+# Tutoriels
+
+Ce dossier contient des tutoriels qui vous guident pas-à-pas dans l'apprentissage de divers sujets.
+
+Table des matières :
+
+- [Comment utiliser DATEX II](./datex2.md)

--- a/docs/tutorials/datex2.md
+++ b/docs/tutorials/datex2.md
@@ -1,0 +1,368 @@
+# Comment utiliser DATEX II
+
+Le standard [DATEX II](https://docs.datex2.eu/) peut être un peu intimidant à première vue. Cette documentation a pour objectif de vous l'approprier.
+
+## Généralités
+
+DATEX II est un standard de format d'échange de données au format XML pour le trafic routier.
+
+La version 3.2 du standard a ajouté un schéma de réglementation routière : [TrafficRegulation](https://docs.datex2.eu/trafficregulation/index.html).
+
+DiaLog utilise ce schéma comme format d'échange de données avec les services numériques d'aide au déplacement. Pour en savoir plus, voir [ADR-001 - Format d'échange de données](../adr/001_exchangeformat.md).
+
+## Démarrer avec le XML
+
+On l'a dit, DATEX II est un format XML.
+
+Si, comme nous, vous aviez plutôt l'habitude d'échanger des données JSON, cela pourrait vous intimider : allez-vous devoir vous plonger dans le monde de SOAP, J2E, et autre bus MOM ? Restons calmes. Certes, DATEX II baigne dans cet environnement-là : la documentation [Developers' corner](https://docs.datex2.eu/developers/) ne mentionne que JAXB, l'outil Java pour lier son code à du XML. Mais pour nos besoins, vous n'aurez pas besoin de vous reconvertir au Java.
+
+Il va en revanche vous falloir quelques **bases sur le XML**.
+
+### Les bases de XML
+
+Commencez par ici : [Learn XML in Y Minutes](https://learnxinyminutes.com/docs/xml).
+
+Cette petite page vous montrera les bases de la syntaxe XML.
+
+Vous devriez en sortir à l'aise sur ces notions :
+
+* Elément
+* Attribut
+* Noeuds enfants, _nesting_
+* Document bien formé (_wellformed document_).
+
+C'est bon ? Alors voici un exemple de document XML. Que décrit-il ?
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<bookstore>
+  <book category="COOKING">
+    <title lang="en">Everyday Italian</title>
+    <author>Giada De Laurentiis</author>
+    <year>2005</year>
+    <price>30.00</price>
+  </book>
+  <book category="CHILDREN">
+    <title lang="en">Harry Potter</title>
+    <author>J K. Rowling</author>
+    <year>2005</year>
+    <price>29.99</price>
+  </book>
+  <book category="WEB">
+    <title lang="en">Learning XML</title>
+    <author>Erik T. Ray</author>
+    <year>2003</year>
+    <price>39.95</price>
+  </book>
+</bookstore>
+```
+
+On pourrait dire qu'il décrit une bibliothèque contenant 3 livres. Chaque livre a une catégorie, ainsi qu'un titre, un auteur, une année de publication, et un prix.
+
+Vu de loin, XML ressemble à HTML. Mais [XML est différent de HTML](https://www.geeksforgeeks.org/html-vs-xml/). Contrairement à HTML, XML ne décrit pas comment afficher des données ; il décrit les données elles-mêmes.
+
+XML fournit en fait un cadre complet pour le transport de données sur le Web.
+
+### Utiliser XML dans son éditeur de texte
+
+Passons à la pratique :
+
+* Démarrez votre éditeur de texte favori. Assurez-vous qu'il dispose d'outils ou d'extensions adéquates pour travailler avec XML.
+* Collez le XML ci-dessus dans un fichier `bookstore.xml`. 
+
+Voici alors quelques petits exercices :
+
+* Essayez d'ajouter un 4ème livre de votre choix.
+* Comment pourrait-on ajouter une information sur la maison d'édition des livres ?
+
+Pour aller plus loin, parcourez le [tutoriel XML](https://www.w3schools.com/xml/default.asp) du W3C.
+
+### Schémas XSD
+
+Un schéma XSD (pour Schema Definition Language) permettent de définir le schéma auquel doit se conformer un message XML. En quelque sorte, XSD est à XML ce que JSONSchema est à JSON.
+
+Là aussi, le meilleur apprentissage est probablement la pratique.
+
+Alors suivez le [tutoriel XSD](https://www.w3schools.com/xml/schema_schema.asp) du W3C.
+
+Vous devriez en sortir à l'aise sur les notions suivantes :
+
+* Définir un namespace dans le fichier XSD : `xmlns` et `targetNamespace` ;
+* Utiliser un schéma XSD dans un fichier XML : `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`, `xmlns="{namespace}"` et `xsi:schemaLocation="{namespace} {fichier.xsd}"` ;
+* Utiliser un schéma XSD par alias : `xmlns:monalias="{namespace}"` puis référencer les éléments par `<monalias:un-element-exemple>` ;
+* Définir un élément avec `<xs:element>` ;
+* Définir un objet avec `<xs:element>`, `<xs:complexType>` et `<xs:sequence>` ;
+* Définir une liste avec `<xs:element>`, `<xs:complexType>`, `<xs:sequence>` et `<xs:element minOccurs="..." maxOccurs="...">` ;
+* Définir un attribut avec `<xs:attribute>` ;
+  Où faut-il le placer dans un `<xs:complexType>` ?
+  <details>
+  <summary>Réponse</summary>
+  Directement en enfant du xs:complexType, et xs:sequence.
+  </details>
+* Définir un enum avec `<xs:simpleType>`, `<xs:restriction`> et `<xs:enumeration>` ;
+
+Faites alors l'exercice : 
+
+* Quel schéma XSD pourrait-on proposer pour le `bookstore.xml` ?
+* Comment faut-il modifier `bookstore.xml` pour que l'élément racine `<bookstore>` soit validé avec ce schéma ?
+* Modifier `bookstore.xml` pour qu'il utilise les éléments de `bookstore.xsd` avec un alias `b`, par exemple `<b:bookstore>`.
+
+<details>
+<summary>Cliquer pour voir une solution</summary>
+
+`books.xsd` :
+
+```xml
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="https://example.org"
+  targetNamespace="https://example.org"
+  elementFormDefault="qualified"
+>
+  <xs:simpleType name="CategoryEnum">
+    <xs:restriction base="xs:string">
+      <xs:enumeration value="WEB"></xs:enumeration>
+      <xs:enumeration value="COOKING"></xs:enumeration>
+      <xs:enumeration value="CHILDREN"></xs:enumeration>
+      <xs:enumeration value="GEOGRAPHY"></xs:enumeration>
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:complexType name="Book">
+    <xs:sequence>
+      <xs:element name="title">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute name="lang" type="xs:string"></xs:attribute>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="author" type="xs:string"></xs:element>
+      <xs:element name="year" type="xs:gYear"></xs:element>
+      <xs:element name="price" type="xs:float"></xs:element>
+    </xs:sequence>
+    <xs:attribute name="category" type="xs:string"></xs:attribute>
+  </xs:complexType>
+
+  <xs:complexType name="Bookstore">
+    <xs:sequence>
+      <xs:element name="book" type="Book" minOccurs="0" maxOccurs="unbounded"></xs:element>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:element name="bookstore" type="Bookstore"></xs:element>
+</xs:schema>
+```
+
+`bookstore.xml` :
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<bookstore
+  xmlns="https://example.org"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://example.org bookstore.xsd"
+>
+    <!-- ... -->
+</bookstore>
+```
+</details>
+
+## DATEX II
+
+### DATEX II et XML
+
+Une fois les bases du XML assimilées, vous devriez mieux pouvoir naviguer dans le standard DATEX II.
+
+En effet, tout compte fait, DATEX II fournit essentiellement un ensemble de schémas XSD. Ces schémas permettent de valider qu'un contenu XML est conforme au standard.
+
+Nous avons ajouté les schémas XSD que DiaLog utilise dans [spec/datex2](https://github.com/MTES-MCT/dialog/tree/master/spec/datex2).
+
+Voici à nouveau quelques exercices :
+
+* Inspectez `example.xml`. De quel type de publication DATEX II s'agit-il ?
+* Modifiez le fichier pour que les éléments issus de http://datex2.eu/schema/3/common soient utilisés non plus avec `com:{élément}` mais `c:{élément}`.
+* À quoi ressemblerait un fichier XML qui décrit une `SituationPublication` ?
+
+### Obtenir les schémas XSD
+
+Malheureusement, la page [téléchargements](https://docs.datex2.eu/downloads/modelv33.html) de DATEX II ne fournit pas des schémas XSD valides. Arrivez-vous à savoir pourquoi ? Indice : les schémas utilisent des alias non-définis...
+
+Par ailleurs, cette page ne fournit que les fichiers XSD individuels, mais certains schémas dépendent eux-mêmes d'autres schémas.
+
+La solution est de recourir au [Webtool](https://webtool.datex2.eu/wizard/) fourni par DATEX II pour générer la sous-partie de DATEX II qui nous intéresse.
+
+Si d'aventure vous deviez récupérer à nouveau ces schémas, voici comment procéder.
+
+* Ouvrir le [Webtool](https://webtool.datex2.eu/wizard/).
+* Dans "1. Source", choisir V3.3 DATEX II.
+* Cliquer sur "Next" jusqu'à arriver à l'écran "5. Sélection".
+* Dans "5. Selection", vérifier que seul TrafficRegulationPublication est coché, puis cliquer sur "Next".
+* Dans "6. Options", s'assurer que XML est coché, puis cliquer sur "Next" pour télécharger le `.zip` avec les schémas XSD.
+
+### Explorateur UML
+
+La page [DATEX II Model](https://docs.datex2.eu/_static/data/v3.4/umlmodel/html/index.htm) permet de naviguer dans le format de données DATEX II représenté avec le langage de modélisation UML.
+
+## Avec DATEX II, comment représenter...
+
+#### Une circulation interdite
+
+Utiliser une réglementation `AccessRestriction` de type `noEntry`.
+
+```xml
+<trafficRegulation>
+  <typeOfRegulation xsi:type="AccessRestriction">
+    <accessRestrictionType>noEntry</accessRestrictionType>
+  </typeOfRegulation>
+  <!-- ... -->
+</trafficRegulation>
+```
+
+#### Une circulation interdite dans un sens uniquement
+
+[À clarifier]
+
+Deux possibilités pour définir un sens en particulier :
+
+* SingleRoadLinearLocation (extends LinearLocation) > linearWithinLinearElement: LinearElementWithinLinear > directionOnLinearSection: DirectionEnum (aligned, opposite, bothWays, allDirections, ...) 
+* PointLocation (extends NetworkLocation) > pointAlongLinearElement: PointAlongLienarElement > directionAtPoint: DirectionEnum
+* OpenLrPointLocationReference > openlrOrientation: enum (withLineDirection, againstLineDirection, both, noOrientationOrUnknown)
+
+L'enum `DirectionEnum` ne permet de définir qu'un sens par rapport à un autre : "sens normal" ou "sens du _linearElement_"
+
+* Pour `directionOnLinearSection` et `directionAtPoint` :
+  * Par exemple, "_aligned_" signifie "_same direction as the normal direction of flow on the road network_".
+  * Mais quel est alors la "_normal direction of flow_" ?
+  * :point_right: DATEX II semble supposer une connaissance externe du réseau routier. Les GPS en disposent-ils ?
+* Pour les variantes `relative*` : "Direction of traffic flow relative to the direction in which the linear element is defined"
+
+#### Une circulation à sens unique
+
+Utiliser une réglementation `DirectionRestriction` de type `aheadOnly`
+
+```xml
+<trafficRegulation>
+  <typeOfRegulation xsi:type="DirectionRestriction">
+    <directionRestrictionType>aheadOnly</directionRestrictionType>
+  </typeOfRegulation>
+  <!-- ... -->
+</trafficRegulation>
+```
+
+#### Une circulation modifiée
+
+Le type de réglementation `AlternateRoadOrCarriagewayOrLaneLayout` définit "une réglementation où une route / voie a temporairement une autre disposition". Utile en cas de travaux par exemple.
+
+Schéma :
+
+```yaml
+trafficRegulation:
+  typeOfRegulation: # xsi:type="AlternateRoadOrCarriagewayOrLaneLayout"
+    ## This class describes a regulation where a road/carriageway/lane has temporarily another layout.
+    deviationToHardshoulder: bool # Traffic lanes move across to the right [...]
+    deviationToOtherCarrriageway: bool  # The road turns over the oncoming lane
+    mergedToOtherLane: bool # Closure of a traffic lane, two lanes to one.
+    roadOrCarriagewayOrLaneLayoutType: enum (road, lane, carriageway)
+    newLayout: LinearLocation
+```
+
+#### Des informations complémentaires sur la ou les voies concernées
+
+Dans DATEX II, les informations liées au réseau routier peuvent être spécifiées dans `PointLocation` ou `LinearLocation`
+
+```yaml
+# DATEII_3_LocationReferencing.xsd
+PointLocation | LinearLocation (extends NetworkLocation):
+  supplementaryPositionalDescription: # SupplementaryPositionalDescription
+    carriageway: # Carriageway
+      carriageway*: enum
+      originalNumberOfLanes: int?
+      lane: # Lane[]
+        - laneNumber: int?
+          laneUsage: enum? (allLanesCompleteCarriageway, leftLane, middleLane, rightLane, emergencyLane, ...)
+    roadInformation: # RoadInformation[]
+      - roadDestination: str? (ex: "Lille")
+        roadName: str? (ex: "Autoroute du Nord")
+        roadNumber: str? (ex: "A1")
+```
+
+#### Une rue où s'applique une réglementation
+
+À partir d'un nom de rue, numéro de début, numéro de fin
+
+* Là où il faut définir une `LocationReference`, utiliser la variante `SingleRoadLinearLocation` avec `.linearWithinLinearElement` (extends SingleRoadLinearElement, extends LinearElement, extends NetworkLocation, extends Location)
+  * Indiquer le nom de la rue dans `.linearElement.roadName`
+  * Indiquer (le cas échéant) la direction concernée par rapport au sens défini par `.fromPoint -> .toPoint` dans `.directionRelativeOnLinearSection`
+  * Indiquer un début dans `.fromPoint`
+    * Utiliser le type `DistanceFromLinearElementReferent`
+    * Géocoder le numéro de début (obtenir ses coordonnées GPS lat-lon)
+    * Définir `.fromReferent` 
+      * Placer les coodonnées GPS dans `.pointCoordinates`
+    * Définir `.distanceAlong: 0` (0 mètres à partir du point ainsi défini, c'est-à-dire le point lui-même)
+  * Indiquer une fin dans `.toPoint`, même format que `fromPoint`
+* Ajouter d'éventuelles informations "humaines" (nom de rue, identifiant de rue (D123, N122, etc), numéros de début et de fin) dans `.supplementaryPositionalDescription.roadInformation[].roadName/Number`
+
+**Exemple**
+
+```xml
+<implementedLocation xsi:type="loc:SingleRoadLinearLocation">
+  <loc:linearWithinLinearElement>
+    <loc:linearElement></loc:linearElement>
+    <loc:fromPoint xsi:type="loc:DistanceFromLinearElementReferent">
+      <loc:distanceAlong>0</loc:distanceAlong>
+      <loc:fromReferent>
+        <!-- DATEX II exige un identifiant unique sur ce segment, on utilise 'lat,lon' -->
+        <loc:referentIdentifier>47.366334,-1.944703</loc:referentIdentifier>
+        <loc:referentType>referenceMarker</loc:referentType>
+        <loc:pointCoordinates>
+          <loc:latitude>47.366334</loc:latitude>
+          <loc:longitude>-1.944703</loc:longitude>
+        </loc:pointCoordinates>
+      </loc:fromReferent>
+    </loc:fromPoint>
+    <loc:toPoint xsi:type="loc:DistanceFromLinearElementReferent">
+      <loc:distanceAlong>0</loc:distanceAlong>
+      <loc:fromReferent>
+        <loc:referentIdentifier>47.370631,-1.94021</loc:referentIdentifier>
+        <loc:referentType>referenceMarker</loc:referentType>
+        <loc:pointCoordinates>
+          <loc:latitude>47.370631</loc:latitude>
+          <loc:longitude>-1.94021</loc:longitude>
+        </loc:pointCoordinates>
+      </loc:fromReferent>
+    </loc:toPoint>
+  </loc:linearWithinLinearElement>
+</implementedLocation>
+```
+
+#### Une description humaine des lieux
+
+Par exemple, "Au coin de la pharmacie", ou "À partir du  parking à vélo"
+
+C'est possible avec le champ `locationDescription (String)` de `SupplementaryPositionalDescription`.
+
+A priori trop humain pour être utilisé par un calculateur d'itinéraire... Mais peut tout de même être affiché ?
+
+## Références
+
+Ces différentes ressources vous permettront d'en savoir plus sur DATEX II et les composants utilisés dans le cadre de DiaLog.
+
+### XML
+
+Tutoriels
+
+* [XML Tutorial](https://www.w3schools.com/xml/default.asp), w3chools.com. (Notamment les sections "XML Tutorial", "XSD Schema" et "XSD Data Type" dans la barre latérale.)
+
+### DATEX II
+
+Introductions
+
+* [La Norme Européenne DATEX II](http://trafic-routier.data.cerema.fr/la-norme-europeenne-datex-ii-a58.html), Cerema, publié le 30/01/2019.
+
+Documentation officielle
+
+* [Documentation de DATEX II](https://docs.datex2.eu/)


### PR DESCRIPTION
En relisant le README je me suis dit qu'il nous manquait une vraie page d'onboarding de contribution

En effet si on clique sur "la documentation de développement" sur le README, on arrive sur une page où on n'a pas d'indication claire d'où commencer si on vient de débarquer : https://github.com/MTES-MCT/dialog/blob/main/docs/README.md

Ce serait utile à la fois pour des contributions extérieures, mais aussi pour les nouveaux membres de l'équipe.

Cette PR:

* Ajoute une page "Bien démarrer" qui contient notamment des indications sur la prise en main des diverses technos (je me mets toujours à la place d'une personne développant habituellement avec Python / Django / un framework SPA comme c'est souvent le cas chez BetaGouv)
* Migre vers le dossier `docs/` la page [Comment utiliser DATEX II](https://github.com/MTES-MCT/dialog/wiki/Comment-utiliser-DATEX-II) actuellement stockée dans le wiki github (je l'ai copiée-collée sans modification, bien que j'imagine qu'elle pourrait être améliorée)