### PR TITLE
Validate compliance to DATEX II XSD

### DIFF
--- a/templates/api/regulations.xml.twig
+++ b/templates/api/regulations.xml.twig
@@ -146,11 +146,11 @@
                                                             <com:typeOfWeight>maximumPermitted</com:typeOfWeight>
                                                         </com:grossWeightCharacteristic>
                                                     {% endif %}
-                                                    {% if vehicle.maxWidth %}
-                                                        <com:widthCharacteristic>
+                                                    {% if vehicle.maxHeight %}
+                                                        <com:heightCharacteristic>
                                                             <com:comparisonOperator>lessThanOrEqualTo</com:comparisonOperator>
-                                                            <com:vehicleWidth>{{ vehicle.maxWidth }}</com:vehicleWidth>
-                                                        </com:widthCharacteristic>
+                                                            <com:vehicleHeight>{{ vehicle.maxHeight }}</com:vehicleHeight>
+                                                        </com:heightCharacteristic>
                                                     {% endif %}
                                                     {% if vehicle.maxLength %}
                                                         <com:lengthCharacteristic>
@@ -158,11 +158,11 @@
                                                             <com:vehicleLength>{{ vehicle.maxLength }}</com:vehicleLength>
                                                         </com:lengthCharacteristic>
                                                     {% endif %}
-                                                    {% if vehicle.maxHeight %}
-                                                        <com:heightCharacteristic>
+                                                    {% if vehicle.maxWidth %}
+                                                        <com:widthCharacteristic>
                                                             <com:comparisonOperator>lessThanOrEqualTo</com:comparisonOperator>
-                                                            <com:vehicleHeight>{{ vehicle.maxHeight }}</com:vehicleHeight>
-                                                        </com:heightCharacteristic>
+                                                            <com:vehicleWidth>{{ vehicle.maxWidth }}</com:vehicleWidth>
+                                                        </com:widthCharacteristic>
                                                     {% endif %}
                                                 {% endif %}
                                             {% endif %}

--- a/tests/Integration/Infrastructure/Controller/Api/GetRegulationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Api/GetRegulationsControllerTest.php
@@ -17,6 +17,11 @@ final class GetRegulationsControllerTest extends AbstractWebTestCase
         $this->assertSame('text/xml; charset=UTF-8', $response->headers->get('content-type'));
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
+
+        $xml = new \DOMDocument();
+        $xml->loadXML($response->getContent(), \LIBXML_NOBLANKS);
+        $this->assertTrue($xml->schemaValidate(self::$kernel->getProjectDir() . '/docs/spec/datex2/DATEXII_3_D2Payload.xsd'));
+
         $this->assertXmlStringEqualsXmlFile(
             __DIR__ . '/get-regulations-expected-result.xml',
             $response->getContent(),

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -468,14 +468,14 @@
                                 <com:grossVehicleWeight>3.5</com:grossVehicleWeight>
                                 <com:typeOfWeight>maximumPermitted</com:typeOfWeight>
                             </com:grossWeightCharacteristic>
-                            <com:lengthCharacteristic>
-                                <com:comparisonOperator>lessThanOrEqualTo</com:comparisonOperator>
-                                <com:vehicleLength>12</com:vehicleLength>
-                            </com:lengthCharacteristic>
                             <com:heightCharacteristic>
                                 <com:comparisonOperator>lessThanOrEqualTo</com:comparisonOperator>
                                 <com:vehicleHeight>2.4</com:vehicleHeight>
                             </com:heightCharacteristic>
+                            <com:lengthCharacteristic>
+                                <com:comparisonOperator>lessThanOrEqualTo</com:comparisonOperator>
+                                <com:vehicleLength>12</com:vehicleLength>
+                            </com:lengthCharacteristic>
                         </vehicleCharacteristics>
                     </conditions>
                     <conditions xsi:type="VehicleCondition">


### PR DESCRIPTION
Closes #486 

Cette PR ajoute une validation de /api/regulations.xml à la spec DATEX II représentée par les fichiers XSD

## Pour tester

* Modifier `regulations.xml.twig`, par ex `com:publicationTime` -> `com:publicationTim`
* Lancer les tests
* Constater une erreur : 

```
1) App\Tests\Integration\Infrastructure\Controller\Api\GetRegulationsControllerTest::testGetRegulationsToDatexFormat
DOMDocument::schemaValidate(): Element '{http://datex2.eu/schema/3/common}publicationTim': This element is not expected. Expected is ( {http://datex2.eu/schema/3/common}publicationTime ).

/var/www/dialog/tests/Integration/Infrastructure/Controller/Api/GetRegulationsControllerTest.php:24
```