### PR TITLE
Drop maxResults on datex query

### DIFF
--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -116,7 +116,6 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->where('roc.status = :status')
             ->setParameter('status', RegulationOrderRecordStatusEnum::PUBLISHED)
             ->orderBy('roc.uuid')
-            ->setMaxResults(20)
             ->getQuery()
             ->getResult()
         ;


### PR DESCRIPTION
Je me demandais pourquoi tous les arrêtés importés dans le cadre de #343 n'apparaissaient pas dans l'export DATEX... Mystère résolu !