### PR TITLE
Add tool to connect to remote Scalingo DB locally

### DIFF
--- a/docs/tools/db.md
+++ b/docs/tools/db.md
@@ -40,3 +40,32 @@ Une configuration est nécéssaire à la première connection pour relier pgAdmi
     - **Password** : dialog
 
 Et c'est tout ! Vous aurez maintenant accès à l'interface graphique pour gérer la base de données.
+
+## Utiliser une DB Scalingo en local
+
+Vous pouvez utiliser en local une base de données hébergée sur Scalingo (staging, PR...) à l'aide d'un utilitaire.
+
+**Prérequis**
+
+* La commande `scalingo` (Scalingo CLI) doit être disponible. Vérifiez avec : `$ which scalingo`. Pour l'installer, voir [Command Line Interface (CLI)](https://doc.scalingo.com/platform/cli/start) dans la doc Scalingo.
+* Vous devez avoir configuré un accès SSH à Scalingo. Vérifiez avec : `$ scalingo keys` -- votre clé SSH doit apparaître dans la liste. Pour configurer l'accès, voir [SSH Key Setup](https://doc.scalingo.com/platform/getting-started/first-steps#ssh-key-setup) dans la doc Scalingo.
+* La commande `sshd` doit être disponible. Vérifiez avec : `$ which sshd`. Pour l'installer sous Linux : `sudo apt install openssh-server`.
+* Enregistrez votre clé SSH auprès du serveur SSH local : `$ ssh-copy-id $(whoami)@localhost`.
+
+**Utilisation**
+
+Lancez la commande suivante :
+
+```
+./tools/scalingodbtunnel APP
+```
+
+Remplacez `APP` par l'application Scalingo cible.
+
+Cette commande démarre un tunnel SSH vers la base de données, et le relaie à Docker pour que le conteneur PHP/Doctrine puisse y accéder.
+
+La commande affiche ensuite une ligne `DATABASE_URL=...`. **Reportez cette ligne** dans `.env.local` pour utiliser la base de données distante. Accédez à http://localhost:8000 comme d'habitude.
+
+Laissez la commande tourner pour garder le tunnel ouvert.
+
+Pour arrêter le tunnel, utilisez <kbd>Ctrl+C</kbd>.

--- a/docs/tools/eudonet_paris.md
+++ b/docs/tools/eudonet_paris.md
@@ -39,11 +39,12 @@ Notes :
 
 ### Pour un import sur staging ou en production
 
-* Dans `.env.prod.local` (créez ce fichier si besoin) :
-  * Définissez `DATABASE_URL` avec l'URL de la base de données cible (peut être récupéré sur Scalingo)
+1. [Démarrez un tunnel SSH vers la base de données cible](./db.md#utiliser-une-db-scalingo-en-local).
+2. Dans `.env.prod.local` :
+  * Reportez la ligne `DATABASE_URL` affichée après avoir démarré le tunnel SSH.
   * Définissez `APP_EUDONET_PARIS_ORG_ID` avec l'ID de l'organisation "Ville de Paris" en prod (peut être récupéré auprès de l'admin)
   * Ajoutez aussi `APP_EUDONET_PARIS_CREDENTIALS` et `API_ADRESSE_BASE_URL` (voir [Préparration](#préparation)).
-* Avant de lancer l'exécution :
+3. Avant de lancer l'exécution :
   * Vérifiez la prise en compte des variables d'environnement :
 
     ```bash
@@ -52,12 +53,12 @@ Notes :
     make console CMD="debug:dotenv --env=prod API_ADRESSE_"
     ```
 
-* Lancez l'exécution avec :
+4. Lancez l'exécution avec :
 
   ```bash
   make console CMD="--env prod app:eudonet_paris:import"
   ```
 
-* Après l'exécution :
+5. Après l'exécution :
   * Vérifiez l'exécution en inspectant le fichier `import.prod-*.log` alimenté pendant l'import.
   * Commentez les variables dans `.env.prod.local` pour éviter de les réutiliser par mégarde jusqu'au prochain import.

--- a/tools/scalingodbtunnel
+++ b/tools/scalingodbtunnel
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+import argparse
+import subprocess
+from urllib.parse import urlparse, urlunparse
+
+
+def main(app, port):
+    # 1) Forward Scalingo -> host.
+
+    # https://doc.scalingo.com/platform/databases/access#encrypted-tunnel
+    db_tunnel_command = [
+        "scalingo",
+        "--app",
+        app,
+        "db-tunnel",
+        "-p",
+        str(port),
+        "DATABASE_URL",
+    ]
+
+    with subprocess.Popen(
+        db_tunnel_command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
+    ) as db_tunnel_proc:
+        db_tunnel_proc.poll()
+
+        # 2) Forward host -> Docker.
+        # This allows PHP/Doctrine container to access the Scalingo database.
+
+        username = (
+            subprocess.run(["whoami"], capture_output=True).stdout.decode().strip()
+        )
+
+        # https://stackoverflow.com/a/55224655
+        docker_bridge_ip_command = [
+            "docker",
+            "network",
+            "inspect",
+            "bridge",
+            "--format={{(index .IPAM.Config 0).Gateway}}",
+        ]
+        result = subprocess.run(docker_bridge_ip_command, capture_output=True)
+        docker_bridge_ip = result.stdout.decode().strip()
+        docker_tunnel_origin = f"{docker_bridge_ip}:{port}"
+
+        # https://stackoverflow.com/a/52120176
+        docker_tunnel_command = [
+            "ssh",
+            "-N",
+            "-L",
+            f"{docker_tunnel_origin}:127.0.0.1:{port}",
+            f"{username}@localhost",
+        ]
+
+        with subprocess.Popen(docker_tunnel_command) as docker_tunnel_proc:
+            # The tunnel database URL uses the same credentials, so we grab them
+            # from the configured DATABASE_URL.
+            database_url_command = ["scalingo", "--app", app, "env-get", "DATABASE_URL"]
+            result = subprocess.run(database_url_command, capture_output=True)
+            database_url = urlparse(result.stdout.strip().decode())
+
+            db_tunnel_database_url = database_url._replace(
+                netloc=f"{database_url.username}:{database_url.password}@{docker_tunnel_origin}"
+            )
+
+            print(f"DATABASE_URL={urlunparse(db_tunnel_database_url)}")
+
+            try:
+                db_tunnel_proc.wait()
+            except KeyboardInterrupt:
+                db_tunnel_proc.terminate()
+                docker_tunnel_proc.terminate()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("app", help="Name of the Scalingo application")
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=10000,
+        help="Port of the SSH tunnel (default: 10000)",
+    )
+    args = parser.parse_args()
+
+    main(args.app, args.port)

--- a/tools/scalingodbtunnel
+++ b/tools/scalingodbtunnel
@@ -1,10 +1,56 @@
 #!/usr/bin/env python3
 import argparse
+import shlex
 import subprocess
+import sys
+from contextlib import contextmanager
 from urllib.parse import urlparse, urlunparse
 
 
+def _get_output(command):
+    result = subprocess.run(command, capture_output=True)
+
+    if result.returncode:
+        raise RuntimeError(
+            f"command {shlex.join(command)!r} "
+            f"returned non-zero exit status {result.returncode}.\n"
+            f"stdout: {result.stdout.decode()}"
+            f"stderr: {result.stderr.decode()}"
+        )
+
+    out = result.stdout.decode().strip()
+
+    if not out:
+        raise RuntimeError(
+            f"command {shlex.join(command)!r} returned empty output.\n"
+            f"stderr: {result.stderr.decode()}"
+        )
+
+    return out
+
+
+@contextmanager
+def _popen_terminate_on_exit(*args, **kwargs):
+    with subprocess.Popen(*args, **kwargs) as proc:
+        try:
+            yield proc
+        finally:
+            proc.terminate()
+
+
 def main(app, port):
+    # Ensure Scalingo CLI is authenticated
+    result = subprocess.run(["scalingo", "whoami"], capture_output=True)
+    if result.returncode:
+        result = subprocess.run(["scalingo", "login", "--ssh"], capture_output=True)
+        if result.returncode:
+            print("ERROR: not authenticated and failed to run 'scalingo login --ssh'")
+            print(
+                "HINT: https://doc.scalingo.com/platform/getting-started/first-steps#ssh-key-setup"
+            )
+            return 1
+        print(result.stdout.decode())
+
     # 1) Forward Scalingo -> host.
 
     # https://doc.scalingo.com/platform/databases/access#encrypted-tunnel
@@ -18,28 +64,24 @@ def main(app, port):
         "DATABASE_URL",
     ]
 
-    with subprocess.Popen(
+    with _popen_terminate_on_exit(
         db_tunnel_command, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL
     ) as db_tunnel_proc:
-        db_tunnel_proc.poll()
-
         # 2) Forward host -> Docker.
         # This allows PHP/Doctrine container to access the Scalingo database.
 
-        username = (
-            subprocess.run(["whoami"], capture_output=True).stdout.decode().strip()
-        )
+        username = _get_output(["whoami"])
 
         # https://stackoverflow.com/a/55224655
-        docker_bridge_ip_command = [
-            "docker",
-            "network",
-            "inspect",
-            "bridge",
-            "--format={{(index .IPAM.Config 0).Gateway}}",
-        ]
-        result = subprocess.run(docker_bridge_ip_command, capture_output=True)
-        docker_bridge_ip = result.stdout.decode().strip()
+        docker_bridge_ip = _get_output(
+            [
+                "docker",
+                "network",
+                "inspect",
+                "bridge",
+                "--format={{(index .IPAM.Config 0).Gateway}}",
+            ]
+        )
         docker_tunnel_origin = f"{docker_bridge_ip}:{port}"
 
         # https://stackoverflow.com/a/52120176
@@ -51,12 +93,12 @@ def main(app, port):
             f"{username}@localhost",
         ]
 
-        with subprocess.Popen(docker_tunnel_command) as docker_tunnel_proc:
+        with _popen_terminate_on_exit(docker_tunnel_command):
             # The tunnel database URL uses the same credentials, so we grab them
             # from the configured DATABASE_URL.
-            database_url_command = ["scalingo", "--app", app, "env-get", "DATABASE_URL"]
-            result = subprocess.run(database_url_command, capture_output=True)
-            database_url = urlparse(result.stdout.strip().decode())
+            database_url = urlparse(
+                _get_output(["scalingo", "--app", app, "env-get", "DATABASE_URL"])
+            )
 
             db_tunnel_database_url = database_url._replace(
                 netloc=f"{database_url.username}:{database_url.password}@{docker_tunnel_origin}"
@@ -67,8 +109,9 @@ def main(app, port):
             try:
                 db_tunnel_proc.wait()
             except KeyboardInterrupt:
-                db_tunnel_proc.terminate()
-                docker_tunnel_proc.terminate()
+                pass
+
+    return 0
 
 
 if __name__ == "__main__":
@@ -82,4 +125,4 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    main(args.app, args.port)
+    sys.exit(main(args.app, args.port))


### PR DESCRIPTION
Dernière étape pour pouvoir effectivement importer les données Eudonet en prod, ref #343

Il faut que PHP/Doctrine ait effectivement accès à la DB de prod quand on lance l'import. Or la DB est chez Scalingo, qui ne l'expose pas à tout Internet par défaut (ce qui est très bien).

La doc Scalingo explique comment accéder à une DB via SSH ici : https://doc.scalingo.com/platform/databases/access

Mais il y a de multiples étapes de recopiage, sans compter l'accès du conteneur PHP au tunnel qui tourne sur la machine hôte.

Donc cette PR :

* Ajoute un utilitaire `tools/scalingodbtunnel` qui permet de forwarded la DB distante en SSH jusqu'au conteneur PHP
  * Il est écrit en Python sans dépendances, normalement n'importe quel Python 3.7+ devrait suffire (Ubuntu installe 3.8 par défaut je crois)
* Ajoute de la doc à ce sujet