### PR TITLE
Corrige l'affichage du bouton 'Définir des horaires'

### DIFF
--- a/assets/controllers/form_collection_controller.js
+++ b/assets/controllers/form_collection_controller.js
@@ -24,6 +24,14 @@ export default class extends Controller {
         this.collectionContainerTarget.appendChild(el.children[0]);
         this.nextIndexValue++;
         this._nextPosition++;
+
+        this.collectionContainerTarget.removeAttribute('data-empty');
+    }
+
+    collectionItemTargetDisconnected(_element) {
+        if (this.collectionItemTargets.length === 0) {
+            this.collectionContainerTarget.setAttribute('data-empty', 'data-empty');
+        }
     }
 
     syncPositions(_event) {

--- a/assets/styles/app.scss
+++ b/assets/styles/app.scss
@@ -515,6 +515,6 @@ ul.app-timeslot-list > li:not(:last-child) .app-timeslot-list-add {
     display: none;
 }
 
-ul.app-timeslot-list:not(:empty) + button.app-timeslot-define {
+ul.app-timeslot-list:not([data-empty]) + button.app-timeslot-define {
     display: none;
 }

--- a/templates/regulation/fragments/_location_form.html.twig
+++ b/templates/regulation/fragments/_location_form.html.twig
@@ -85,8 +85,9 @@
                 >
                     <ul
                         class="app-timeslot-list fr-raw-list fr-mb-2w"
-                        data-testid="timeSlot-list"
+                        data-testid="timeslot-list"
                         data-form-collection-target="collectionContainer"
+                        {% if form.timeSlots|length == 0 %}data-empty{% endif %}
                         aria-label="{{ form.timeSlots.vars.label|trans }}"
                     >
                         {%- for item in form.timeSlots -%}

--- a/tests/e2e/pages/regulation_order.page.js
+++ b/tests/e2e/pages/regulation_order.page.js
@@ -248,6 +248,34 @@ export class RegulationOrderPage {
 
     /**
      * @param {Locator} location
+     * @param {{ measureIndex: number }} options
+     */
+    async manipulateTimeSlots(location, { measureIndex }) {
+        await this._beginEditLocation(location);
+
+        const measure = location.getByTestId('measure-list').getByRole('listitem').nth(measureIndex);
+        await measure.getByRole('button', { name: 'Ajouter une plage' }).click();
+
+        const period = measure.getByTestId('period-list').getByRole('listitem').nth(0);
+        const timeSlots = period.getByTestId('timeslot-list').getByRole('listitem');
+        const addTimeSlotBtn = period.getByRole('button', { name: 'Définir des horaires' });
+
+        await expect(timeSlots).toHaveCount(0);
+        await expect(addTimeSlotBtn).toBeVisible();
+        
+        await addTimeSlotBtn.click();
+        await expect(timeSlots).toHaveCount(1);
+        await expect(addTimeSlotBtn).not.toBeVisible();
+
+        await timeSlots.nth(0).getByRole('button', {name: 'Supprimer'}).click();
+        await expect(timeSlots).toHaveCount(0);
+        await expect(addTimeSlotBtn).toBeVisible();
+
+        await this.cancelLocation(location);
+    }
+
+    /**
+     * @param {Locator} location
      */
     async _waitForReadMode(location) {
         await location.getByRole('button', { name: 'Modifier' }).waitFor();

--- a/tests/e2e/regulation_edit.spec.js
+++ b/tests/e2e/regulation_edit.spec.js
@@ -129,3 +129,13 @@ test('Delete a period from a measure', async ({ regulationOrderPage }) => {
     await page.removePeriodFromMeasure(location, { measureIndex: 0, periodIndex: 0 });
     await expect(location).toContainText('Circulation interdite tous les jours');
 });
+
+test('Manipulate time slots', async ({ regulationOrderPage }) => {
+    /** @type {RegulationOrderPage} */
+    let page = regulationOrderPage;
+
+    await page.goToRegulation('e413a47e-5928-4353-a8b2-8b7dda27f9a5');
+    const location = await page.addLocation({ address: 'Rue Monge, 21000 Dijon', restrictionType: 'Circulation interdite', expectedTitle: 'Rue Monge' });
+
+    await page.manipulateTimeSlots(location, { measureIndex: 0 });
+});


### PR DESCRIPTION
Closes #554 

Je passe par JS au lieu d'utiliser le pseudo-sélecteur `:empty`, parce que ce dernier ne sera pas vrai si l'élément contient... des espaces, ce qui est trop fragile

cf encadré ici https://developer.mozilla.org/fr/docs/Web/CSS/:empty

@Lealefoulon Tu dois avoir le contexte