### PR TITLE
Migre la dernière localisation avec géométrie mais sans roadName

### DIFF
--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20231227133838.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20231227133838.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20231227133838 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix road_name extraction';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql("UPDATE location SET road_name = substring(address from '^(.+),? \d{5}') WHERE road_name IS NULL AND geometry IS NOT NULL;");
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}


### PR DESCRIPTION
Corrige #583 

Dans les logs de la prod on avait des erreurs de ce type en accédant aux données DATEX:

```json
{"message":"Uncaught PHP Exception TypeError: \"App\\Application\\Regulation\\View\\DatexLocationView::__construct(): Argument #1 ($roadName) must be of type string, null given, called in /app/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php on line 74\" at /app/src/Application/Regulation/View/DatexLocationView.php line 14","context":{"exception":{"class":"TypeError","message":"App\\Application\\Regulation\\View\\DatexLocationView::__construct(): Argument #1 ($roadName) must be of type string, null given, called in /app/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php on line 74","code":0,"file":"/app/src/Application/Regulation/View/DatexLocationView.php:14"}},"level":500,"level_name":"CRITICAL","channel":"request","datetime":"2023-12-27T13:00:23.303192+00:00","extra":{}} 
```

En me connectant à la DB avec `./tools/scalingodbtunnel dialog`, et en exécutant cette requête:

```sql
SELECT uuid, address
FROM location
WHERE road_name IS NULL
AND geometry IS NOT NULL;
```

Je vois que le problème provient de la localisation "Voie Bh/16, 75016 Paris" provenant d'Eudonet Paris:

uuid | address | 
 018b6c8e-a08e-7fe6-bffd-2fec3e0e7e77 | Voie Bh/16, 75016 Paris
(1 row)


La regex `^([^\d,]+),? \d{5}` utilisée pour la migration de #572 n'a pas extrait "Voie Bh/16" en raison du "16" qui match le `\d` que la regex exclut.

On aurait dû utiliser `^(.+),? \d{5}`, c'est-à-dire "tout ce qu'il y a avant le code postal sauf la virgule".

Cette PR ajoute une migration qui vient compléter ce cas précis.

## Tests

J'ai récupéré un dump de la DB en local et l'exécution de l'UPDATE n'affecte qu'1 seule ligne (la localisation en question) et fait renvoyer l'ensemble vide à la requête ci-dessus.