### PR TITLE
Mise à jour intégration Eudonet

### DIFF
--- a/src/Application/EudonetParis/Command/ImportEudonetParisRegulationCommandHandler.php
+++ b/src/Application/EudonetParis/Command/ImportEudonetParisRegulationCommandHandler.php
@@ -6,6 +6,7 @@ namespace App\Application\EudonetParis\Command;
 
 use App\Application\CommandBusInterface;
 use App\Application\EudonetParis\Exception\ImportEudonetParisRegulationFailedException;
+use App\Application\Exception\GeocodingFailureException;
 use App\Application\Regulation\Command\PublishRegulationCommand;
 use App\Domain\Regulation\Exception\RegulationOrderRecordCannotBePublishedException;
 use App\Domain\Regulation\RegulationOrderRecord;
@@ -25,7 +26,11 @@ final class ImportEudonetParisRegulationCommandHandler
         foreach ($command->locationCommands as $locationCommand) {
             $locationCommand->regulationOrderRecord = $regulationOrderRecord;
 
-            $location = $this->commandBus->handle($locationCommand);
+            try {
+                $location = $this->commandBus->handle($locationCommand);
+            } catch (GeocodingFailureException $exc) {
+                throw new ImportEudonetParisRegulationFailedException($exc->getMessage());
+            }
 
             $regulationOrderRecord->getRegulationOrder()->addLocation($location);
         }

--- a/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
@@ -19,13 +19,15 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
 
     public function computeRoadLine(string $roadName, string $inseeCode): string
     {
+        $nomMinuscule = str_replace("'", "''", strtolower($roadName));
+
         $query = [
             'SERVICE' => 'WFS',
             'REQUEST' => 'GetFeature',
             'VERSION' => '2.0.0',
             'OUTPUTFORMAT' => 'application/json',
             'TYPENAME' => 'BDTOPO_V3:voie_nommee',
-            'cql_filter' => sprintf("nom_minuscule='%s' AND code_insee='%s'", strtolower($roadName), $inseeCode),
+            'cql_filter' => sprintf("nom_minuscule='%s' AND code_insee='%s'", $nomMinuscule, $inseeCode),
             'PropertyName' => 'geometrie',
         ];
 
@@ -59,7 +61,7 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
             return json_encode($geometry);
         }
 
-        $message = sprintf('could not retrieve geometry: %s', $body);
+        $message = sprintf('could not retrieve geometry for roadName="%s", inseeCode="%s", response was: %s', $roadName, $inseeCode, $body);
         throw new GeocodingFailureException($message);
     }
 }

--- a/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
@@ -19,7 +19,7 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
 
     public function computeRoadLine(string $roadName, string $inseeCode): string
     {
-        $nomMinuscule = str_replace("'", "''", strtolower($roadName));
+        $normalizedRoadName = str_replace("'", "''", strtolower($roadName));
 
         $query = [
             'SERVICE' => 'WFS',
@@ -27,7 +27,7 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
             'VERSION' => '2.0.0',
             'OUTPUTFORMAT' => 'application/json',
             'TYPENAME' => 'BDTOPO_V3:voie_nommee',
-            'cql_filter' => sprintf("strStripAccents(nom_minuscule)=strStripAccents('%s') AND code_insee='%s'", $nomMinuscule, $inseeCode),
+            'cql_filter' => sprintf("strStripAccents(nom_minuscule)=strStripAccents('%s') AND code_insee='%s'", $normalizedRoadName, $inseeCode),
             'PropertyName' => 'geometrie',
         ];
 

--- a/src/Infrastructure/EudonetParis/EudonetParisExtractor.php
+++ b/src/Infrastructure/EudonetParis/EudonetParisExtractor.php
@@ -27,6 +27,7 @@ final class EudonetParisExtractor
     public const LOCALISATION_TAB_ID = 2700;
     public const LOCALISATION_ID = 2701;
     public const LOCALISATION_PORTE_SUR = 2705;
+    public const LOCALISATION_ARRONDISSEMENT = 2708;
     public const LOCALISATION_LIBELLE_VOIE = 2710;
     public const LOCALISATION_LIBELLE_VOIE_DEBUT = 2730;
     public const LOCALISATION_LIBELLE_VOIE_FIN = 2740;
@@ -129,6 +130,7 @@ final class EudonetParisExtractor
                     listCols: [
                         $this::LOCALISATION_ID,
                         $this::LOCALISATION_PORTE_SUR,
+                        $this::LOCALISATION_ARRONDISSEMENT,
                         $this::LOCALISATION_LIBELLE_VOIE,
                         $this::LOCALISATION_LIBELLE_VOIE_DEBUT,
                         $this::LOCALISATION_LIBELLE_VOIE_FIN,

--- a/src/Infrastructure/EudonetParis/EudonetParisTransformer.php
+++ b/src/Infrastructure/EudonetParis/EudonetParisTransformer.php
@@ -86,7 +86,7 @@ final class EudonetParisTransformer
         return new EudonetParisTransformerResult($command, $errors);
     }
 
-    private function parseDate(string $value): \DateTimeInterface|null
+    private function parseDate(string $value): ?\DateTimeInterface
     {
         if ($date = \DateTimeImmutable::createFromFormat('Y/m/d H:i:s', $value, new \DateTimeZone('Europe/Paris'))) {
             return $date;

--- a/src/Infrastructure/EudonetParis/EudonetParisTransformer.php
+++ b/src/Infrastructure/EudonetParis/EudonetParisTransformer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\EudonetParis;
 
 use App\Application\EudonetParis\Command\ImportEudonetParisRegulationCommand;
+use App\Application\Exception\GeocodingFailureException;
 use App\Application\GeocoderInterface;
 use App\Application\Regulation\Command\SaveMeasureCommand;
 use App\Application\Regulation\Command\SaveRegulationGeneralInfoCommand;
@@ -17,7 +18,8 @@ use App\Domain\User\Organization;
 
 final class EudonetParisTransformer
 {
-    private const CITY_CODE = '75056';
+    private const ARRONDISSEMENT_REGEX = '/^(?<arrondissement>\d+)(er|e|ème|eme)\s+arrondissement$/i';
+    private const CITY_CODE_TEMPLATE = '751%s';
     private const CITY_LABEL = 'Paris';
 
     public function __construct(
@@ -30,16 +32,21 @@ final class EudonetParisTransformer
         $errors = [];
         $loc = ['regulation_identifier' => $row['fields'][EudonetParisExtractor::ARRETE_ID]];
 
-        $generalInfoCommand = $this->buildGeneralInfoCommand($row, $organization);
-
-        $locationCommands = [];
-        $errors = [];
-
         if (\count($row['measures']) === 0) {
             $errors[] = ['loc' => $loc, 'impact' => 'skip_regulation', 'reason' => 'no_measures_found'];
 
             return new EudonetParisTransformerResult(null, $errors);
         }
+
+        [$generalInfoCommand, $error] = $this->buildGeneralInfoCommand($row, $organization);
+
+        if ($error) {
+            $errors[] = ['loc' => [...$loc, ...$error['loc']], 'impact' => 'skip_regulation', ...$error];
+
+            return new EudonetParisTransformerResult(null, $errors);
+        }
+
+        $locationCommands = [];
 
         foreach ($row['measures'] as $measureRow) {
             [$measureCommand, $error] = $this->buildMeasureCommand($measureRow);
@@ -79,7 +86,20 @@ final class EudonetParisTransformer
         return new EudonetParisTransformerResult($command, $errors);
     }
 
-    private function buildGeneralInfoCommand(array $row, Organization $organization): SaveRegulationGeneralInfoCommand
+    private function parseDate(string $value): \DateTimeInterface|null
+    {
+        $possibleEudonetFormats = ['Y/m/d H:i:s', 'Y/m/d', 'd/m/Y'];
+
+        foreach ($possibleEudonetFormats as $format) {
+            if ($date = \DateTimeImmutable::createFromFormat($format, $value, new \DateTimeZone('Europe/Paris'))) {
+                return $date;
+            }
+        }
+
+        return null;
+    }
+
+    private function buildGeneralInfoCommand(array $row, Organization $organization): array
     {
         $command = new SaveRegulationGeneralInfoCommand();
         $command->identifier = $row['fields'][EudonetParisExtractor::ARRETE_ID];
@@ -94,19 +114,27 @@ final class EudonetParisTransformer
 
         $command->organization = $organization;
 
-        $command->startDate = \DateTimeImmutable::createFromFormat(
-            'Y/m/d H:i:s',
-            $row['fields'][EudonetParisExtractor::ARRETE_DATE_DEBUT],
-            new \DateTimeZone('Europe/Paris'),
-        );
+        $startDate = $this->parseDate($row['fields'][EudonetParisExtractor::ARRETE_DATE_DEBUT]);
 
-        $command->endDate = \DateTimeImmutable::createFromFormat(
-            'Y/m/d H:i:s',
-            $row['fields'][EudonetParisExtractor::ARRETE_DATE_FIN],
-            new \DateTimeZone('Europe/Paris'),
-        );
+        if (!$startDate) {
+            $error = ['loc' => ['fieldname' => 'ARRETE_DATE_DEBUT'], 'reason' => 'parsing_failed', 'value' => $row['fields'][EudonetParisExtractor::ARRETE_DATE_DEBUT]];
 
-        return $command;
+            return [null, $error];
+        }
+
+        $command->startDate = $startDate;
+
+        $endDate = $this->parseDate($row['fields'][EudonetParisExtractor::ARRETE_DATE_FIN]);
+
+        if (!$endDate) {
+            $error = ['loc' => ['fieldname' => 'ARRETE_DATE_FIN'], 'reason' => 'parsing_failed', 'value' => $row['fields'][EudonetParisExtractor::ARRETE_DATE_FIN]];
+
+            return [null, $error];
+        }
+
+        $command->endDate = $endDate;
+
+        return [$command, null];
     }
 
     private function buildMeasureCommand(array $row): array
@@ -130,6 +158,21 @@ final class EudonetParisTransformer
     private function buildLocationCommand(array $row, SaveMeasureCommand $measureCommand): array
     {
         $loc = ['location_id' => $row['fields'][EudonetParisExtractor::LOCALISATION_ID]];
+
+        $arrondissement = $row['fields'][EudonetParisExtractor::LOCALISATION_ARRONDISSEMENT];
+
+        if (!preg_match(self::ARRONDISSEMENT_REGEX, $arrondissement, $matches)) {
+            $error = [
+                'loc' => [...$loc, 'fieldname' => 'ARRONDISSEMENT'],
+                'reason' => 'value_does_not_match_pattern',
+                'value' => $arrondissement,
+                'pattern' => self::ARRONDISSEMENT_REGEX,
+            ];
+
+            return [null, $error];
+        }
+
+        $cityCode = sprintf(self::CITY_CODE_TEMPLATE, str_pad($matches['arrondissement'], 2, '0', STR_PAD_LEFT));
 
         $porteSur = $row['fields'][EudonetParisExtractor::LOCALISATION_PORTE_SUR];
         $libelleVoie = $row['fields'][EudonetParisExtractor::LOCALISATION_LIBELLE_VOIE];
@@ -165,12 +208,25 @@ final class EudonetParisTransformer
         }
 
         $locationCommand = new SaveRegulationLocationCommand();
-        $locationCommand->cityCode = self::CITY_CODE;
+        $locationCommand->cityCode = $cityCode;
         $locationCommand->cityLabel = self::CITY_LABEL;
         $locationCommand->roadName = $roadName;
         $locationCommand->fromHouseNumber = $fromHouseNumber;
         $locationCommand->toHouseNumber = $toHouseNumber;
-        $locationCommand->geometry = $this->makeLocationGeometry($locationCommand->roadName, $fromHouseNumber, $fromRoadName, $toHouseNumber, $toRoadName);
+
+        try {
+            $locationCommand->geometry = $this->makeLocationGeometry($locationCommand->roadName, $cityCode, $fromHouseNumber, $fromRoadName, $toHouseNumber, $toRoadName);
+        } catch (GeocodingFailureException $exc) {
+            $error = [
+                'loc' => $loc,
+                'reason' => 'geocoding_failure',
+                'message' => $exc->getMessage(),
+                'location_raw' => json_encode($row),
+            ];
+
+            return [null, $error];
+        }
+
         $locationCommand->measures[] = $measureCommand;
 
         return [$locationCommand, null];
@@ -178,6 +234,7 @@ final class EudonetParisTransformer
 
     private function makeLocationGeometry(
         string $roadName,
+        string $cityCode,
         ?string $fromHouseNumber,
         ?string $fromRoadName,
         ?string $toHouseNumber,
@@ -192,18 +249,22 @@ final class EudonetParisTransformer
             return null;
         }
 
-        if ($fromHouseNumber) {
-            $fromAddress = sprintf('%s %s', $fromHouseNumber, $roadName);
-            $fromPoint = $this->geocoder->computeCoordinates($fromAddress, self::CITY_CODE);
-        } else {
-            $fromPoint = $this->geocoder->computeJunctionCoordinates($roadName, $fromRoadName, self::CITY_CODE);
-        }
+        try {
+            if ($fromHouseNumber) {
+                $fromAddress = sprintf('%s %s', $fromHouseNumber, $roadName);
+                $fromPoint = $this->geocoder->computeCoordinates($fromAddress, $cityCode);
+            } else {
+                $fromPoint = $this->geocoder->computeJunctionCoordinates($roadName, $fromRoadName, $cityCode);
+            }
 
-        if ($toHouseNumber) {
-            $toAddress = sprintf('%s %s', $toHouseNumber, $roadName);
-            $toPoint = $this->geocoder->computeCoordinates($toAddress, self::CITY_CODE);
-        } else {
-            $toPoint = $this->geocoder->computeJunctionCoordinates($roadName, $toRoadName, self::CITY_CODE);
+            if ($toHouseNumber) {
+                $toAddress = sprintf('%s %s', $toHouseNumber, $roadName);
+                $toPoint = $this->geocoder->computeCoordinates($toAddress, $cityCode);
+            } else {
+                $toPoint = $this->geocoder->computeJunctionCoordinates($roadName, $toRoadName, $cityCode);
+            }
+        } catch (GeocodingFailureException $exc) {
+            throw $exc;
         }
 
         return GeoJSON::toLineString([$fromPoint, $toPoint]);

--- a/src/Infrastructure/EudonetParis/EudonetParisTransformer.php
+++ b/src/Infrastructure/EudonetParis/EudonetParisTransformer.php
@@ -88,12 +88,19 @@ final class EudonetParisTransformer
 
     private function parseDate(string $value): \DateTimeInterface|null
     {
-        $possibleEudonetFormats = ['Y/m/d H:i:s', 'Y/m/d', 'd/m/Y'];
+        if ($date = \DateTimeImmutable::createFromFormat('Y/m/d H:i:s', $value, new \DateTimeZone('Europe/Paris'))) {
+            return $date;
+        }
 
-        foreach ($possibleEudonetFormats as $format) {
-            if ($date = \DateTimeImmutable::createFromFormat($format, $value, new \DateTimeZone('Europe/Paris'))) {
-                return $date;
-            }
+        if (\DateTimeImmutable::createFromFormat('Y/m/d', $value, new \DateTimeZone('Europe/Paris'))) {
+            // Need to add a datetime otherwise PHP would use the current server time, not midnight.
+            return $this->parseDate($value . ' 00:00:00');
+        }
+
+        if (\DateTimeImmutable::createFromFormat('d/m/Y', $value, new \DateTimeZone('Europe/Paris'))) {
+            // This format is somtimes used by some Eudonet Paris data input users.
+            // Again, we need to ensure there is a datetime.
+            return \DateTimeImmutable::createFromFormat('d/m/Y H:i:s', $value . ' 00:00:00', new \DateTimeZone('Europe/Paris'));
         }
 
         return null;

--- a/tests/Unit/Application/EudonetParis/Command/ImportEudonetParisRegulationCommandHandlerTest.php
+++ b/tests/Unit/Application/EudonetParis/Command/ImportEudonetParisRegulationCommandHandlerTest.php
@@ -8,6 +8,7 @@ use App\Application\CommandBusInterface;
 use App\Application\EudonetParis\Command\ImportEudonetParisRegulationCommand;
 use App\Application\EudonetParis\Command\ImportEudonetParisRegulationCommandHandler;
 use App\Application\EudonetParis\Exception\ImportEudonetParisRegulationFailedException;
+use App\Application\Exception\GeocodingFailureException;
 use App\Application\Regulation\Command\PublishRegulationCommand;
 use App\Application\Regulation\Command\SaveRegulationGeneralInfoCommand;
 use App\Application\Regulation\Command\SaveRegulationLocationCommand;
@@ -86,6 +87,31 @@ final class ImportEudonetParisRegulationCommandHandlerTest extends TestCase
 
         $handler = new ImportEudonetParisRegulationCommandHandler($this->commandBus);
         $command = new ImportEudonetParisRegulationCommand($generalInfoCommand, []);
+
+        $handler($command);
+    }
+
+    public function testErrorGeocodingFailure(): void
+    {
+        $this->expectException(ImportEudonetParisRegulationFailedException::class);
+
+        $generalInfoCommand = $this->createMock(SaveRegulationGeneralInfoCommand::class);
+        $locationCommand = $this->createMock(SaveRegulationLocationCommand::class);
+        $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
+
+        $matcher = self::exactly(2);
+        $this->commandBus
+            ->expects($matcher)
+            ->method('handle')
+            ->willReturnCallback(
+                fn ($command) => match ($matcher->getInvocationCount()) {
+                    1 => $this->assertEquals($generalInfoCommand, $command) ?: $regulationOrderRecord,
+                    2 => $this->assertEquals($locationCommand, $command) ?: throw new GeocodingFailureException('Could not geocode'),
+                },
+            );
+
+        $handler = new ImportEudonetParisRegulationCommandHandler($this->commandBus);
+        $command = new ImportEudonetParisRegulationCommand($generalInfoCommand, [$locationCommand]);
 
         $handler($command);
     }

--- a/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
+++ b/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
@@ -64,9 +64,9 @@ final class IgnWfsRoadGeocoderTest extends TestCase
     {
         return [
             ['{"features": }', '/invalid json: Syntax error/'],
-            ['{}', '/could not retrieve geometry: /'],
-            ['{"features": []}', '/could not retrieve geometry: /'],
-            ['{"features": [{}]}', '/could not retrieve geometry: /'],
+            ['{}', '/could not retrieve geometry/'],
+            ['{"features": []}', '/could not retrieve geometry /'],
+            ['{"features": [{}]}', '/could not retrieve geometry/'],
         ];
     }
 

--- a/tests/Unit/Infrastructure/EudonetParis/EudonetParisExtractorTest.php
+++ b/tests/Unit/Infrastructure/EudonetParis/EudonetParisExtractorTest.php
@@ -90,7 +90,7 @@ final class EudonetParisExtractorTest extends TestCase
 
                 3 => $this->assertSame([
                     2700,
-                    [2701, 2705, 2710, 2730, 2740, 2720, 2737],
+                    [2701, 2705, 2708, 2710, 2730, 2740, 2720, 2737],
                     [
                         'Criteria' => [
                             'Field' => 1200,
@@ -126,7 +126,7 @@ final class EudonetParisExtractorTest extends TestCase
 
                 5 => $this->assertSame([
                     2700,
-                    [2701, 2705, 2710, 2730, 2740, 2720, 2737],
+                    [2701, 2705, 2708, 2710, 2730, 2740, 2720, 2737],
                     [
                         'Criteria' => [
                             'Field' => 1200,
@@ -138,7 +138,7 @@ final class EudonetParisExtractorTest extends TestCase
 
                 6 => $this->assertSame([
                     2700,
-                    [2701, 2705, 2710, 2730, 2740, 2720, 2737],
+                    [2701, 2705, 2708, 2710, 2730, 2740, 2720, 2737],
                     [
                         'Criteria' => [
                             'Field' => 1200,


### PR DESCRIPTION
* Refs #590 

Quelques changements à l'intégration Eudonet en raison d'erreurs lors de l'exécution en local

* Gestion des `GeocodingFailureException`
* Utilisation de l'arrondissement pour le `citycode`, car en général l'API WFS ne trouve rien avec `citycode=75056` (code Insee de la Ville de Paris)
* Parsing des dates corrigé : les données Eudonet ont maintenant plusieurs formats possibles... 