### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
         # Required for E2E testing
         run: |
           curl -sS https://get.symfony.com/cli/installer > installer.sh
+          # v5.8+ is buggy with Playwright
+          # See: https://github.com/MTES-MCT/dialog/pull/591
           sed -i 's/releases\/latest\/download/releases\/download\/v5.7.7/g' installer.sh
           sudo bash installer.sh
           sudo mv /root/.symfony5/bin/symfony /usr/local/bin/symfony

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,10 @@ jobs:
       - name: Install Symfony CLI
         # Required for E2E testing
         run: |
-          curl -1sLf 'https://dl.cloudsmith.io/public/symfony/stable/setup.deb.sh' | sudo -E bash
-          sudo apt install symfony-cli
+          curl -sS https://get.symfony.com/cli/installer > installer.sh
+          sed -i 's/releases\/latest\/download/releases\/download\/v5.7.7/g' installer.sh
+          sudo bash installer.sh
+          sudo mv /root/.symfony5/bin/symfony /usr/local/bin/symfony
 
       - name: CI
         run: make ci CI=1 BIN_PHP="php" BIN_CONSOLE="php bin/console" BIN_COMPOSER="composer" BIN_NPM="npm" BIN_NPX="npx" PLAYWRIGHT_ARGS="-x --forbid-only"

--- a/Makefile
+++ b/Makefile
@@ -219,9 +219,9 @@ test_integration: ## Run integration tests only
 
 test_e2e: ## Run end-to-end tests only
 	make dbfixtures
-	$(BIN_NPX) playwright test --project mobile-chromium ${ARGS}
+	$(BIN_NPX) playwright test --project desktop-firefox ${ARGS}
 	make dbfixtures
-	PW_REUSE_SERVER=1 $(BIN_NPX) playwright test --project desktop-firefox ${ARGS}
+	$(BIN_NPX) playwright test --project mobile-chromium ${ARGS}
 
 report_e2e: ## Open the Playwright HTML report
 	xdg-open playwright-report/index.html

--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,7 @@ format: php_lint ## Format code
 
 test: ## Run the test suite
 	${BIN_PHP} ${OPTIONS} ./bin/phpunit ${ARGS}
-	#make test_e2e ARGS="${PLAYWRIGHT_ARGS}"
+	make test_e2e ARGS="${PLAYWRIGHT_ARGS}"
 
 test_cov: ## Run the test suite (with code coverage)
 	make test OPTIONS="-d xdebug.mode=coverage" ARGS="--coverage-html coverage --coverage-clover coverage.xml"
@@ -219,9 +219,9 @@ test_integration: ## Run integration tests only
 
 test_e2e: ## Run end-to-end tests only
 	make dbfixtures
-	$(BIN_NPX) playwright test --project desktop-firefox ${ARGS}
-	make dbfixtures
 	$(BIN_NPX) playwright test --project mobile-chromium ${ARGS}
+	make dbfixtures
+	PW_REUSE_SERVER=1 $(BIN_NPX) playwright test --project desktop-firefox ${ARGS}
 
 report_e2e: ## Open the Playwright HTML report
 	xdg-open playwright-report/index.html


### PR DESCRIPTION
Les tests E2E mobile ne se lancent plus:

> npx playwright test --project mobile-chromium -x --forbid-only
> [WebServer]
> no child processes

Je n'ai pas trouvé l'origine du problème. La version Playwright n'a pas changée...

L'erreur apparaît dans la 2e exécution : j'ai essayé d'inverser tests mobiles et tests desktop, et c'est les tests desktop qui échouent...

Ce qui a changé c'est la version du runner GitHub Actions, qui est [20240107.1.0](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20240107.1), alors qu'elle valait auparavant [20231217.2](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20231217.2)

Peut-être le CLI Symfony ? https://github.com/symfony-cli/symfony-cli/releases