### PR TITLE
IGN WFS: Ignore accents in nom_minuscule

### DIFF
--- a/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
@@ -25,7 +25,7 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
             'VERSION' => '2.0.0',
             'OUTPUTFORMAT' => 'application/json',
             'TYPENAME' => 'BDTOPO_V3:voie_nommee',
-            'cql_filter' => sprintf("nom_minuscule='%s' AND code_insee='%s'", strtolower($roadName), $inseeCode),
+            'cql_filter' => sprintf("strStripAccents(nom_minuscule)=strStripAccents('%s') AND code_insee='%s'", strtolower($roadName), $inseeCode),
             'PropertyName' => 'geometrie',
         ];
 

--- a/tests/Mock/IgnWfsMockClient.php
+++ b/tests/Mock/IgnWfsMockClient.php
@@ -26,7 +26,7 @@ final class IgnWfsMockClient extends MockHttpClient
 
     private function getWfsMock($options): MockResponse
     {
-        if (str_contains($options['query']['cql_filter'], "nom_minuscule='rue saint-victor'")) {
+        if (str_contains($options['query']['cql_filter'], "strStripAccents(nom_minuscule)=strStripAccents('rue saint-victor')")) {
             $body = [
                 'features' => [
                     [
@@ -46,7 +46,7 @@ final class IgnWfsMockClient extends MockHttpClient
                     ],
                 ],
             ];
-        } elseif (str_contains($options['query']['cql_filter'], "nom_minuscule='rue monge'")) {
+        } elseif (str_contains($options['query']['cql_filter'], "strStripAccents(nom_minuscule)=strStripAccents('rue monge')")) {
             // E2E tests
             $body = [
                 'features' => [

--- a/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
+++ b/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
@@ -31,7 +31,7 @@ final class IgnWfsRoadGeocoderTest extends TestCase
 
         $this->assertSame('GET', $response->getRequestMethod());
         $this->assertSame(
-            'http://testserver/wfs/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=BDTOPO_V3:voie_nommee&cql_filter=nom_minuscule%3D%27rue%20saint-victor%2059110%20la%20madeleine%27%20AND%20code_insee%3D%2759368%27&PropertyName=geometrie',
+            'http://testserver/wfs/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=BDTOPO_V3:voie_nommee&cql_filter=strStripAccents(nom_minuscule)%3DstrStripAccents(%27rue%20saint-victor%2059110%20la%20madeleine%27)%20AND%20code_insee%3D%2759368%27&PropertyName=geometrie',
             $response->getRequestUrl(),
         );
     }


### PR DESCRIPTION
Corrige un bug suite à #536 découvert par @aureliebaton 

**Description du bug**

Actions:

* Se connecter sur https://dialog-staging-pr586.osc-fr1.scalingo.io
* Dans "Ville", chercher et choisir "Le Petit-Quevilly"
* Dans "Voie", chercher "Rue Ber", choisir "Rue Beranger" renvoyé par l'API Adresse
* Faire "Valider"
* Une erreur apparaît : adresse introuvable

Le problème est que l'API IGN reçoit cette requête :

https://data.geopf.fr/wfs/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=BDTOPO_V3:voie_nommee&cql_filter=nom_minuscule=%27rue%20beranger%27%20AND%20code_insee=76498&PropertyName=geometrie

Donc "rue beranger" (sans accent), ce qui ne renvoie aucun résultat

Mais la requête avec accent renvoie le résultat attendu :

https://data.geopf.fr/wfs/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=BDTOPO_V3:voie_nommee&cql_filter=nom_minuscule=%27rue%20béranger%27%20AND%20code_insee=76498&PropertyName=geometrie

**Solution de cette PR**

En cherchant, je suis tombé sur la doc Geoserver des "fonctions de filtres", qui contient notamment "strStripAccents" https://docs.geoserver.org/stable/en/user/filter/function_reference.html#string-functions

Par chance le paramètre `cql_filter` accepte bien cette fonction

Cette PR utilise donc ce filtre pour faire une recherche "accent-insensitive"