### PR TITLE
Refactor: move all locationNew logic

### DIFF
--- a/src/Application/Regulation/Command/Location/DeleteLocationNewCommand.php
+++ b/src/Application/Regulation/Command/Location/DeleteLocationNewCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\Command\Location;
+
+use App\Application\CommandInterface;
+use App\Domain\Regulation\LocationNew;
+
+final class DeleteLocationNewCommand implements CommandInterface
+{
+    public function __construct(
+        public readonly LocationNew $locationNew,
+    ) {
+    }
+}

--- a/src/Application/Regulation/Command/Location/DeleteLocationNewCommandHandler.php
+++ b/src/Application/Regulation/Command/Location/DeleteLocationNewCommandHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\Command\Location;
+
+use App\Domain\Regulation\Repository\LocationNewRepositoryInterface;
+
+final class DeleteLocationNewCommandHandler
+{
+    public function __construct(
+        private LocationNewRepositoryInterface $locationNewRepository,
+    ) {
+    }
+
+    public function __invoke(DeleteLocationNewCommand $command): void
+    {
+        $this->locationNewRepository->delete($command->locationNew);
+    }
+}

--- a/src/Application/Regulation/Command/Location/SaveLocationNewCommand.php
+++ b/src/Application/Regulation/Command/Location/SaveLocationNewCommand.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\Command\Location;
+
+use App\Application\CommandInterface;
+use App\Domain\Regulation\Location;
+use App\Domain\Regulation\LocationNew;
+use App\Domain\Regulation\Measure;
+
+final class SaveLocationNewCommand implements CommandInterface
+{
+    public ?string $cityCode;
+    public ?string $cityLabel;
+    public ?string $roadName;
+    public ?string $fromHouseNumber;
+    public ?string $toHouseNumber;
+    public ?string $geometry;
+    public ?Measure $measure;
+
+    public function __construct(
+        public readonly ?LocationNew $locationNew = null,
+    ) {
+        $this->cityCode = $locationNew?->getCityCode();
+        $this->cityLabel = $locationNew?->getCityLabel();
+        $this->roadName = $locationNew?->getRoadName();
+        $this->fromHouseNumber = $locationNew?->getFromHouseNumber();
+        $this->toHouseNumber = $locationNew?->getToHouseNumber();
+        $this->geometry = $locationNew?->getGeometry();
+    }
+
+    public static function fromLocation(Location $location, LocationNew $locationNew = null): self
+    {
+        $locationNew = new self($locationNew);
+        $locationNew->cityLabel = $location->getCityLabel();
+        $locationNew->cityCode = $location->getCityCode();
+        $locationNew->roadName = $location->getRoadName();
+        $locationNew->fromHouseNumber = $location->getFromHouseNumber();
+        $locationNew->toHouseNumber = $location->getToHouseNumber();
+        $locationNew->geometry = $location->getGeometry();
+
+        return $locationNew;
+    }
+}

--- a/src/Application/Regulation/Command/Location/SaveLocationNewCommandHandler.php
+++ b/src/Application/Regulation/Command/Location/SaveLocationNewCommandHandler.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\Command\Location;
+
+use App\Application\IdFactoryInterface;
+use App\Domain\Regulation\LocationNew;
+use App\Domain\Regulation\Repository\LocationNewRepositoryInterface;
+
+final class SaveLocationNewCommandHandler
+{
+    public function __construct(
+        private IdFactoryInterface $idFactory,
+        private LocationNewRepositoryInterface $locationNewRepository,
+    ) {
+    }
+
+    public function __invoke(SaveLocationNewCommand $command): LocationNew
+    {
+        // Create locationNew if needed
+        if (!$command->locationNew instanceof LocationNew) {
+            $locationNew = $this->locationNewRepository->add(
+                new LocationNew(
+                    uuid: $this->idFactory->make(),
+                    measure: $command->measure,
+                    cityLabel: $command->cityLabel,
+                    cityCode: $command->cityCode,
+                    roadName: $command->roadName,
+                    fromHouseNumber: $command->fromHouseNumber,
+                    toHouseNumber: $command->toHouseNumber,
+                    geometry: $command->geometry,
+                ),
+            );
+
+            $command->measure->addLocationNew($locationNew);
+
+            return $locationNew;
+        }
+
+        $command->locationNew->update(
+            cityCode: $command->cityCode,
+            cityLabel: $command->cityLabel,
+            roadName: $command->roadName,
+            fromHouseNumber: $command->fromHouseNumber,
+            toHouseNumber: $command->toHouseNumber,
+            geometry: $command->geometry,
+        );
+
+        return $command->locationNew;
+    }
+}

--- a/src/Application/Regulation/Command/SaveMeasureCommand.php
+++ b/src/Application/Regulation/Command/SaveMeasureCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Application\Regulation\Command;
 
 use App\Application\CommandInterface;
+use App\Application\Regulation\Command\Location\SaveLocationNewCommand;
 use App\Application\Regulation\Command\Period\SavePeriodCommand;
 use App\Application\Regulation\Command\VehicleSet\SaveVehicleSetCommand;
 use App\Domain\Regulation\Location;
@@ -15,6 +16,8 @@ final class SaveMeasureCommand implements CommandInterface
     public ?string $type;
     public ?int $maxSpeed = null;
     public ?Location $location;
+    /** @var SaveLocationNewCommand[] */
+    public array $locationsNew = [];
     public array $periods = [];
     public ?\DateTimeInterface $createdAt = null;
     public ?SaveVehicleSetCommand $vehicleSet = null;
@@ -32,6 +35,10 @@ final class SaveMeasureCommand implements CommandInterface
 
             if ($vehicleSet) {
                 $this->vehicleSet = new SaveVehicleSetCommand($vehicleSet);
+            }
+
+            foreach ($measure->getLocationsNew() as $locationNew) {
+                $this->locationsNew[] = new SaveLocationNewCommand($locationNew);
             }
 
             foreach ($measure->getPeriods() as $period) {

--- a/src/Application/Regulation/Command/SaveMeasureCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveMeasureCommandHandler.php
@@ -7,6 +7,7 @@ namespace App\Application\Regulation\Command;
 use App\Application\CommandBusInterface;
 use App\Application\DateUtilsInterface;
 use App\Application\IdFactoryInterface;
+use App\Application\Regulation\Command\Location\DeleteLocationNewCommand;
 use App\Application\Regulation\Command\Period\DeletePeriodCommand;
 use App\Domain\Regulation\Enum\MeasureTypeEnum;
 use App\Domain\Regulation\Measure;
@@ -58,6 +59,25 @@ final class SaveMeasureCommandHandler
                 }
             }
 
+            $locationsNewStillPresentUuids = [];
+
+            foreach ($command->locationsNew as $locationNewCommand) {
+                if ($locationNewCommand->locationNew) {
+                    $locationsNewStillPresentUuids[] = $locationNewCommand->locationNew->getUuid();
+                }
+
+                $locationNewCommand->measure = $command->measure;
+                $this->commandBus->handle($locationNewCommand);
+            }
+
+            // Locations that weren't present in the command get deleted.
+            foreach ($command->measure->getLocationsNew() as $locationNew) {
+                if (!\in_array($locationNew->getUuid(), $locationsNewStillPresentUuids)) {
+                    $this->commandBus->handle(new DeleteLocationNewCommand($locationNew));
+                    $command->measure->removeLocationNew($locationNew);
+                }
+            }
+
             return $command->measure;
         }
 
@@ -81,6 +101,12 @@ final class SaveMeasureCommandHandler
             $periodCommand->measure = $measure;
             $period = $this->commandBus->handle($periodCommand);
             $measure->addPeriod($period);
+        }
+
+        foreach ($command->locationsNew as $locationNewCommand) {
+            $locationNewCommand->measure = $measure;
+            $locationNew = $this->commandBus->handle($locationNewCommand);
+            $measure->addLocationNew($locationNew);
         }
 
         return $measure;

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
@@ -17,6 +17,7 @@ final class SaveRegulationLocationCommand implements CommandInterface
     public ?string $toHouseNumber;
     public ?string $geometry;
 
+    /** @var SaveMeasureCommand[] */
     public array $measures = [];
 
     public function __construct(

--- a/src/Domain/Regulation/Measure.php
+++ b/src/Domain/Regulation/Measure.php
@@ -11,7 +11,7 @@ use Doctrine\Common\Collections\Collection;
 
 class Measure
 {
-    private Collection $locations;
+    private Collection $locationsNew;
     private Collection $periods;
     private ?VehicleSet $vehicleSet = null;
 
@@ -23,7 +23,7 @@ class Measure
         private ?int $maxSpeed = null,
     ) {
         $this->periods = new ArrayCollection();
-        $this->locations = new ArrayCollection();
+        $this->locationsNew = new ArrayCollection();
     }
 
     public function getUuid(): string
@@ -51,14 +51,14 @@ class Measure
         return $this->periods;
     }
 
-    public function getLocations(): iterable
+    public function getLocationsNew(): iterable
     {
-        return $this->locations;
+        return $this->locationsNew;
     }
 
     public function getLocationNew(): ?LocationNew
     {
-        return !empty($this->locations) ? $this->locations[0] : null;
+        return !empty($this->locationsNew) ? $this->locationsNew[0] : null;
     }
 
     public function getCreatedAt(): \DateTimeInterface
@@ -94,22 +94,22 @@ class Measure
         $this->periods->removeElement($period);
     }
 
-    public function addLocation(LocationNew $location): void
+    public function addLocationNew(LocationNew $locationNew): void
     {
-        if ($this->locations->contains($location)) {
+        if ($this->locationsNew->contains($locationNew)) {
             return;
         }
 
-        $this->locations[] = $location;
+        $this->locationsNew[] = $locationNew;
     }
 
-    public function removeLocation(LocationNew $location): void
+    public function removeLocationNew(LocationNew $locationNew): void
     {
-        if (!$this->locations->contains($location)) {
+        if (!$this->locationsNew->contains($locationNew)) {
             return;
         }
 
-        $this->locations->removeElement($location);
+        $this->locationsNew->removeElement($locationNew);
     }
 
     public function update(string $type, ?int $maxSpeed): void

--- a/src/Domain/Regulation/Repository/LocationNewRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/LocationNewRepositoryInterface.php
@@ -8,5 +8,7 @@ use App\Domain\Regulation\LocationNew;
 
 interface LocationNewRepositoryInterface
 {
-    public function add(LocationNew $location): LocationNew;
+    public function add(LocationNew $locationNew): LocationNew;
+
+    public function delete(LocationNew $locationNew): void;
 }

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.LocationNew.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.LocationNew.orm.xml
@@ -15,7 +15,7 @@
         <option name="srid">2154</option>
       </options>
     </field>
-    <many-to-one field="measure" target-entity="App\Domain\Regulation\Measure" inversed-by="locations">
+    <many-to-one field="measure" target-entity="App\Domain\Regulation\Measure" inversed-by="locationsNew">
         <join-column name="measure_uuid" referenced-column-name="uuid" on-delete="CASCADE"/>
     </many-to-one>
   </entity>

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Measure.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Measure.orm.xml
@@ -14,6 +14,6 @@
     <field name="maxSpeed" type="integer" column="max_speed" nullable="true"/>
     <one-to-one field="vehicleSet" target-entity="App\Domain\Condition\VehicleSet" mapped-by="measure" fetch="EAGER"/>
     <one-to-many field="periods" target-entity="App\Domain\Condition\Period\Period" mapped-by="measure" fetch="EAGER"/>
-    <one-to-many field="locations" target-entity="App\Domain\Regulation\LocationNew" mapped-by="measure" fetch="EAGER"/>
+    <one-to-many field="locationsNew" target-entity="App\Domain\Regulation\LocationNew" mapped-by="measure" fetch="EAGER"/>
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationNewRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationNewRepository.php
@@ -16,10 +16,15 @@ final class LocationNewRepository extends ServiceEntityRepository implements Loc
         parent::__construct($registry, LocationNew::class);
     }
 
-    public function add(LocationNew $location): LocationNew
+    public function add(LocationNew $locationNew): LocationNew
     {
-        $this->getEntityManager()->persist($location);
+        $this->getEntityManager()->persist($locationNew);
 
-        return $location;
+        return $locationNew;
+    }
+
+    public function delete(LocationNew $locationNew): void
+    {
+        $this->getEntityManager()->remove($locationNew);
     }
 }

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationNewRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationNewRepository.php
@@ -25,6 +25,7 @@ final class LocationNewRepository extends ServiceEntityRepository implements Loc
 
     public function delete(LocationNew $locationNew): void
     {
+        // Cannot be covered by integration tests yet
         $this->getEntityManager()->remove($locationNew);
     }
 }

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -160,7 +160,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->innerJoin('roc.organization', 'o')
             ->innerJoin('ro.locations', 'loc')
             ->innerJoin('loc.measures', 'm')
-            ->innerJoin('m.locations', 'locNew')
+            ->innerJoin('m.locationsNew', 'locNew')
             ->leftJoin('m.vehicleSet', 'v')
             ->where('roc.status = :status')
             ->setParameter('status', RegulationOrderRecordStatusEnum::PUBLISHED)

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -55,6 +55,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->innerJoin('roc.organization', 'o')
             ->innerJoin('roc.regulationOrder', 'ro', 'WITH', $isPermanent ? 'ro.endDate IS NULL' : 'ro.endDate IS NOT NULL')
             ->orderBy('ro.startDate', 'DESC')
+            ->addOrderBy('ro.identifier', 'ASC')
             ->addGroupBy('ro, roc, o')
             ->setFirstResult($maxItemsPerPage * ($page - 1))
             ->setMaxResults($maxItemsPerPage)

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -575,12 +575,12 @@
                         <locationByOrder xsi:type="loc:LinearLocation">
                             <loc:supplementaryPositionalDescription>
                                 <loc:roadInformation>
-                                    <loc:roadName>Rue de l'Hôtel de Ville</loc:roadName>
+                                <loc:roadName>Rue Gamot</loc:roadName>
                                 </loc:roadInformation>
                             </loc:supplementaryPositionalDescription>
                             <loc:_linearLocationExtension>
                                 <loc:linearLocationExtended>
-                                    <locdx:geoJsonGeometry>{"type":"LineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[1.352126,44.016833],[1.353016,44.016402]]}</locdx:geoJsonGeometry>
+                                    <locdx:geoJsonGeometry>{"type":"MultiLineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[[1.34352783,44.01741201],[1.34351021,44.01728842],[1.34344305,44.01672388]],[[1.34361127,44.01827476],[1.34363309,44.01855416],[1.34367982,44.01909228],[1.34373623,44.01964046],[1.34376444,44.02004327]],[[1.34355908,44.01762403],[1.34352783,44.01741201]],[[1.34361127,44.01827476],[1.34359579,44.01799187],[1.34355908,44.01762403]]]}</locdx:geoJsonGeometry>
                                 </loc:linearLocationExtended>
                             </loc:_linearLocationExtension>
                         </locationByOrder>
@@ -590,11 +590,8 @@
 
             <trafficRegulation>
                 <status>active</status>
-                <typeOfRegulation xsi:type="SpeedLimit">
-                    <maxValue>
-                        <numericValue>50</numericValue>
-                        <unitOfMeasure>kilometresPerHour</unitOfMeasure>
-                    </maxValue>
+                <typeOfRegulation xsi:type="AccessRestriction">
+                    <accessRestrictionType>noEntry</accessRestrictionType>
                 </typeOfRegulation>
 
                 <condition xsi:type="ConditionSet">
@@ -627,8 +624,11 @@
             </trafficRegulation>
             <trafficRegulation>
                 <status>active</status>
-                <typeOfRegulation xsi:type="AccessRestriction">
-                    <accessRestrictionType>noEntry</accessRestrictionType>
+                <typeOfRegulation xsi:type="SpeedLimit">
+                    <maxValue>
+                        <numericValue>50</numericValue>
+                        <unitOfMeasure>kilometresPerHour</unitOfMeasure>
+                    </maxValue>
                 </typeOfRegulation>
                 <condition xsi:type="ConditionSet">
                     <operator>and</operator>
@@ -646,12 +646,12 @@
                         <locationByOrder xsi:type="loc:LinearLocation">
                             <loc:supplementaryPositionalDescription>
                                 <loc:roadInformation>
-                                <loc:roadName>Rue Gamot</loc:roadName>
+                                    <loc:roadName>Rue de l'Hôtel de Ville</loc:roadName>
                                 </loc:roadInformation>
                             </loc:supplementaryPositionalDescription>
                             <loc:_linearLocationExtension>
                                 <loc:linearLocationExtended>
-                                    <locdx:geoJsonGeometry>{"type":"MultiLineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[[1.34352783,44.01741201],[1.34351021,44.01728842],[1.34344305,44.01672388]],[[1.34361127,44.01827476],[1.34363309,44.01855416],[1.34367982,44.01909228],[1.34373623,44.01964046],[1.34376444,44.02004327]],[[1.34355908,44.01762403],[1.34352783,44.01741201]],[[1.34361127,44.01827476],[1.34359579,44.01799187],[1.34355908,44.01762403]]]}</locdx:geoJsonGeometry>
+                                    <locdx:geoJsonGeometry>{"type":"LineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[1.352126,44.016833],[1.353016,44.016402]]}</locdx:geoJsonGeometry>
                                 </loc:linearLocationExtended>
                             </loc:_linearLocationExtension>
                         </locationByOrder>

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -575,12 +575,12 @@
                         <locationByOrder xsi:type="loc:LinearLocation">
                             <loc:supplementaryPositionalDescription>
                                 <loc:roadInformation>
-                                <loc:roadName>Rue Gamot</loc:roadName>
+                                    <loc:roadName>Rue de l'Hôtel de Ville</loc:roadName>
                                 </loc:roadInformation>
                             </loc:supplementaryPositionalDescription>
                             <loc:_linearLocationExtension>
                                 <loc:linearLocationExtended>
-                                    <locdx:geoJsonGeometry>{"type":"MultiLineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[[1.34352783,44.01741201],[1.34351021,44.01728842],[1.34344305,44.01672388]],[[1.34361127,44.01827476],[1.34363309,44.01855416],[1.34367982,44.01909228],[1.34373623,44.01964046],[1.34376444,44.02004327]],[[1.34355908,44.01762403],[1.34352783,44.01741201]],[[1.34361127,44.01827476],[1.34359579,44.01799187],[1.34355908,44.01762403]]]}</locdx:geoJsonGeometry>
+                                    <locdx:geoJsonGeometry>{"type":"LineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[1.352126,44.016833],[1.353016,44.016402]]}</locdx:geoJsonGeometry>
                                 </loc:linearLocationExtended>
                             </loc:_linearLocationExtension>
                         </locationByOrder>
@@ -590,8 +590,11 @@
 
             <trafficRegulation>
                 <status>active</status>
-                <typeOfRegulation xsi:type="AccessRestriction">
-                    <accessRestrictionType>noEntry</accessRestrictionType>
+                <typeOfRegulation xsi:type="SpeedLimit">
+                    <maxValue>
+                        <numericValue>50</numericValue>
+                        <unitOfMeasure>kilometresPerHour</unitOfMeasure>
+                    </maxValue>
                 </typeOfRegulation>
 
                 <condition xsi:type="ConditionSet">
@@ -624,11 +627,8 @@
             </trafficRegulation>
             <trafficRegulation>
                 <status>active</status>
-                <typeOfRegulation xsi:type="SpeedLimit">
-                    <maxValue>
-                        <numericValue>50</numericValue>
-                        <unitOfMeasure>kilometresPerHour</unitOfMeasure>
-                    </maxValue>
+                <typeOfRegulation xsi:type="AccessRestriction">
+                    <accessRestrictionType>noEntry</accessRestrictionType>
                 </typeOfRegulation>
                 <condition xsi:type="ConditionSet">
                     <operator>and</operator>
@@ -646,12 +646,12 @@
                         <locationByOrder xsi:type="loc:LinearLocation">
                             <loc:supplementaryPositionalDescription>
                                 <loc:roadInformation>
-                                    <loc:roadName>Rue de l'Hôtel de Ville</loc:roadName>
+                                <loc:roadName>Rue Gamot</loc:roadName>
                                 </loc:roadInformation>
                             </loc:supplementaryPositionalDescription>
                             <loc:_linearLocationExtension>
                                 <loc:linearLocationExtended>
-                                    <locdx:geoJsonGeometry>{"type":"LineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[1.352126,44.016833],[1.353016,44.016402]]}</locdx:geoJsonGeometry>
+                                    <locdx:geoJsonGeometry>{"type":"MultiLineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[[1.34352783,44.01741201],[1.34351021,44.01728842],[1.34344305,44.01672388]],[[1.34361127,44.01827476],[1.34363309,44.01855416],[1.34367982,44.01909228],[1.34373623,44.01964046],[1.34376444,44.02004327]],[[1.34355908,44.01762403],[1.34352783,44.01741201]],[[1.34361127,44.01827476],[1.34359579,44.01799187],[1.34355908,44.01762403]]]}</locdx:geoJsonGeometry>
                                 </loc:linearLocationExtended>
                             </loc:_linearLocationExtension>
                         </locationByOrder>

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
@@ -75,7 +75,6 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
         $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#location_form_measures_0_maxSpeed_error')->text());
     }
 
-    /** @group only */
     public function testEditAndAddMeasure(): void
     {
         $client = $this->login();

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
@@ -75,6 +75,7 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
         $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#location_form_measures_0_maxSpeed_error')->text());
     }
 
+    /** @group only */
     public function testEditAndAddMeasure(): void
     {
         $client = $this->login();
@@ -88,9 +89,9 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
         // Get the raw values.
         $values = $form->getPhpValues();
         // Edit
-        $values['location_form']['measures'][0]['type'] = 'speedLimitation';
-        $values['location_form']['measures'][0]['maxSpeed'] = 60;
-        $values['location_form']['measures'][0]['periods'] = []; // Remove period
+        $values['location_form']['measures'][1]['type'] = 'speedLimitation';
+        $values['location_form']['measures'][1]['maxSpeed'] = 60;
+        $values['location_form']['measures'][1]['periods'] = []; // Remove period
 
         // Add
         $values['location_form']['measures'][2]['type'] = 'alternateRoad';
@@ -112,7 +113,7 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
 
         $this->assertResponseStatusCodeSame(200);
         $this->assertRouteSame('fragment_regulations_location', ['uuid' => LocationFixture::UUID_TYPICAL]);
-        $this->assertSame('Vitesse limitée à 60 km/h tous les jours pour tous les véhicules', $detailItems->eq(2)->text());
+        $this->assertSame('Vitesse limitée à 60 km/h tous les jours pour tous les véhicules', $detailItems->eq(3)->text());
         $this->assertSame('Circulation alternée du 09/06/2023 - 09h00 au 09/06/2023 - 09h00, le lundi pour tous les véhicules', $detailItems->eq(4)->text());
     }
 

--- a/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
@@ -35,40 +35,40 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
 
         // First item
         $pageOne = $client->request('GET', '/regulations?pageSize=1&tab=temporary&page=1');
+
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
         $pageOneTemporaryRows = $pageOne->filter('#temporary-panel tbody > tr');
-        $this->assertSame(1, $pageOneTemporaryRows->count()); // One item per page
+        $this->assertSame(1, $pageOneTemporaryRows->count());
 
         $pageOneTemporaryRow0 = $pageOneTemporaryRows->eq(0)->filter('td');
-        $this->assertSame('FO1/2023', $pageOneTemporaryRow0->eq(0)->text());
-        // This test cannot work because there is no measure associated with this regulationOrder
-        // $this->assertSame('Savenay (44260) Route du Grand Brossais + 2 localisations', $pageOneTemporaryRow0->eq(1)->text());
-        $this->assertSame('Savenay (44260) Route du Grand Brossais', $pageOneTemporaryRow0->eq(1)->text());
+        $this->assertSame('F2023/no-locations', $pageOneTemporaryRow0->eq(0)->text());
+        $this->assertEmpty($pageOneTemporaryRow0->eq(1)->text()); // No location set
         $this->assertSame('du 13/03/2023 au 15/03/2023 passé', $pageOneTemporaryRow0->eq(2)->text());
         $this->assertSame('Brouillon', $pageOneTemporaryRow0->eq(3)->text());
 
         $links = $pageOneTemporaryRow0->eq(4)->filter('a');
         $this->assertSame('Modifier', $links->eq(0)->text());
-        $this->assertSame('http://localhost/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL, $links->eq(0)->link()->getUri());
+        $this->assertSame('http://localhost/regulations/' . RegulationOrderRecordFixture::UUID_NO_LOCATIONS, $links->eq(0)->link()->getUri());
 
         // Second item
         $pageTwo = $client->request('GET', '/regulations?pageSize=1&tab=temporary&page=2');
-
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
         $pageTwoTemporaryRows = $pageTwo->filter('#temporary-panel tbody > tr');
-        $this->assertSame(1, $pageTwoTemporaryRows->count());
+        $this->assertSame(1, $pageTwoTemporaryRows->count()); // One item per page
 
         $pageTwoTemporaryRow0 = $pageTwoTemporaryRows->eq(0)->filter('td');
-        $this->assertSame('F2023/no-locations', $pageTwoTemporaryRow0->eq(0)->text());
-        $this->assertEmpty($pageTwoTemporaryRow0->eq(1)->text()); // No location set
+        $this->assertSame('FO1/2023', $pageTwoTemporaryRow0->eq(0)->text());
+        // This test cannot work because there is no measure associated with this regulationOrder
+        // $this->assertSame('Savenay (44260) Route du Grand Brossais + 2 localisations', $pageOneTemporaryRow0->eq(1)->text());
+        $this->assertSame('Savenay (44260) Route du Grand Brossais', $pageTwoTemporaryRow0->eq(1)->text());
         $this->assertSame('du 13/03/2023 au 15/03/2023 passé', $pageTwoTemporaryRow0->eq(2)->text());
         $this->assertSame('Brouillon', $pageTwoTemporaryRow0->eq(3)->text());
 
-        $links = $pageOneTemporaryRow0->eq(4)->filter('a');
+        $links = $pageTwoTemporaryRow0->eq(4)->filter('a');
         $this->assertSame('Modifier', $links->eq(0)->text());
         $this->assertSame('http://localhost/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL, $links->eq(0)->link()->getUri());
     }

--- a/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
@@ -76,11 +76,11 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
     public function testPublishedRegulationRendering(): void
     {
         $client = $this->login();
-        $cralwer = $client->request('GET', '/regulations?pageSize=1&tab=temporary&page=5');
+        $crawler = $client->request('GET', '/regulations?pageSize=1&tab=temporary&page=4');
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $rows = $cralwer->filter('#temporary-panel tbody > tr');
+        $rows = $crawler->filter('#temporary-panel tbody > tr');
         $this->assertSame(1, $rows->count());
 
         $row0 = $rows->eq(0)->filter('td');

--- a/tests/Unit/Application/Regulation/Command/Location/DeleteLocationNewCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Location/DeleteLocationNewCommandHandlerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Application\Regulation\Command\Location;
+
+use App\Application\Regulation\Command\Location\DeleteLocationNewCommand;
+use App\Application\Regulation\Command\Location\DeleteLocationNewCommandHandler;
+use App\Domain\Regulation\LocationNew;
+use App\Domain\Regulation\Repository\LocationNewRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+final class DeleteLocationNewCommandHandlerTest extends TestCase
+{
+    private $locationNew;
+    private $locationNewRepository;
+
+    protected function setUp(): void
+    {
+        $this->locationNew = $this->createMock(LocationNew::class);
+        $this->locationNewRepository = $this->createMock(LocationNewRepositoryInterface::class);
+    }
+
+    public function testDelete(): void
+    {
+        $this->locationNewRepository
+            ->expects(self::once())
+            ->method('delete')
+            ->with($this->equalTo($this->locationNew));
+
+        $handler = new DeleteLocationNewCommandHandler($this->locationNewRepository);
+
+        $command = new DeleteLocationNewCommand($this->locationNew);
+        $this->assertEmpty($handler($command));
+    }
+}

--- a/tests/Unit/Application/Regulation/Command/Location/SaveLocationNewCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Location/SaveLocationNewCommandHandlerTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Application\Command\Location;
+
+use App\Application\IdFactoryInterface;
+use App\Application\Regulation\Command\Location\SaveLocationNewCommand;
+use App\Application\Regulation\Command\Location\SaveLocationNewCommandHandler;
+use App\Domain\Geography\Coordinates;
+use App\Domain\Geography\GeoJSON;
+use App\Domain\Regulation\LocationNew;
+use App\Domain\Regulation\Measure;
+use App\Domain\Regulation\Repository\LocationNewRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+final class SaveLocationNewCommandHandlerTest extends TestCase
+{
+    private string $cityCode;
+    private string $cityLabel;
+    private string $roadName;
+    private string $fromHouseNumber;
+    private string $toHouseNumber;
+    private string $geometry;
+    private MockObject $idFactory;
+    private MockObject $locationNewRepository;
+
+    public function setUp(): void
+    {
+        $this->idFactory = $this->createMock(IdFactoryInterface::class);
+        $this->locationNewRepository = $this->createMock(LocationNewRepositoryInterface::class);
+
+        $this->cityCode = '44195';
+        $this->cityLabel = 'Savenay';
+        $this->roadName = 'Route du Grand Brossais';
+        $this->fromHouseNumber = '15';
+        $this->toHouseNumber = '37bis';
+        $this->geometry = GeoJSON::toLineString([
+            Coordinates::fromLonLat(-1.935836, 47.347024),
+            Coordinates::fromLonLat(-1.930973, 47.347917),
+        ]);
+    }
+
+    public function testCreate(): void
+    {
+        $this->idFactory
+            ->expects(self::once())
+            ->method('make')
+            ->willReturn('7fb74c5d-069b-4027-b994-7545bb0942d0');
+
+        $createdLocationNew = $this->createMock(LocationNew::class);
+        $measure = $this->createMock(Measure::class);
+
+        $this->locationNewRepository
+            ->expects(self::once())
+            ->method('add')
+            ->with(
+                $this->equalTo(
+                    new LocationNew(
+                        uuid: '7fb74c5d-069b-4027-b994-7545bb0942d0',
+                        measure: $measure,
+                        cityCode: $this->cityCode,
+                        cityLabel: $this->cityLabel,
+                        roadName: $this->roadName,
+                        fromHouseNumber: $this->fromHouseNumber,
+                        toHouseNumber: $this->toHouseNumber,
+                        geometry: $this->geometry,
+                    ),
+                ),
+            )
+            ->willReturn($createdLocationNew);
+
+        $handler = new SaveLocationNewCommandHandler(
+            $this->idFactory,
+            $this->locationNewRepository,
+        );
+
+        $command = new SaveLocationNewCommand();
+        $command->measure = $measure;
+        $command->cityCode = $this->cityCode;
+        $command->cityLabel = $this->cityLabel;
+        $command->roadName = $this->roadName;
+        $command->fromHouseNumber = $this->fromHouseNumber;
+        $command->toHouseNumber = $this->toHouseNumber;
+        $command->geometry = $this->geometry;
+
+        $result = $handler($command);
+
+        $this->assertSame($createdLocationNew, $result);
+    }
+
+    public function testUpdate(): void
+    {
+        $this->idFactory
+            ->expects(self::never())
+            ->method('make');
+
+        $measure = $this->createMock(Measure::class);
+        $locationNew = $this->createMock(LocationNew::class);
+        $locationNew
+            ->expects(self::once())
+            ->method('update')
+            ->with(
+                $this->cityCode,
+                $this->cityLabel,
+                $this->roadName,
+                $this->fromHouseNumber,
+                $this->toHouseNumber,
+                $this->geometry,
+            );
+
+        $handler = new SaveLocationNewCommandHandler(
+            $this->idFactory,
+            $this->locationNewRepository,
+        );
+
+        $command = new SaveLocationNewCommand($locationNew);
+        $command->measure = $measure;
+        $command->cityCode = $this->cityCode;
+        $command->cityLabel = $this->cityLabel;
+        $command->roadName = $this->roadName;
+        $command->fromHouseNumber = $this->fromHouseNumber;
+        $command->toHouseNumber = $this->toHouseNumber;
+        $command->geometry = $this->geometry;
+
+        $result = $handler($command);
+
+        $this->assertSame($locationNew, $result);
+    }
+}

--- a/tests/Unit/Application/Regulation/Command/Location/SaveLocationNewCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Location/SaveLocationNewCommandHandlerTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Tests\Unit\Application\Command\Location;
+namespace App\Tests\Unit\Application\Regulation\Command\Location;
 
 use App\Application\IdFactoryInterface;
 use App\Application\Regulation\Command\Location\SaveLocationNewCommand;

--- a/tests/Unit/Application/Regulation/Command/SaveMeasureCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/SaveMeasureCommandHandlerTest.php
@@ -7,6 +7,8 @@ namespace App\Tests\Unit\Application\Regulation\Command;
 use App\Application\CommandBusInterface;
 use App\Application\DateUtilsInterface;
 use App\Application\IdFactoryInterface;
+use App\Application\Regulation\Command\Location\DeleteLocationNewCommand;
+use App\Application\Regulation\Command\Location\SaveLocationNewCommand;
 use App\Application\Regulation\Command\Period\DeletePeriodCommand;
 use App\Application\Regulation\Command\Period\SavePeriodCommand;
 use App\Application\Regulation\Command\SaveMeasureCommand;
@@ -16,6 +18,7 @@ use App\Domain\Condition\Period\Period;
 use App\Domain\Condition\VehicleSet;
 use App\Domain\Regulation\Enum\MeasureTypeEnum;
 use App\Domain\Regulation\Location;
+use App\Domain\Regulation\LocationNew;
 use App\Domain\Regulation\Measure;
 use App\Domain\Regulation\Repository\MeasureRepositoryInterface;
 use PHPUnit\Framework\TestCase;
@@ -49,6 +52,7 @@ final class SaveMeasureCommandHandlerTest extends TestCase
             ->willReturn($now);
 
         $createdPeriod = $this->createMock(Period::class);
+        $createdLocationNew = $this->createMock(LocationNew::class);
         $createdMeasure = $this->createMock(Measure::class);
         $location = $this->createMock(Location::class);
 
@@ -56,6 +60,11 @@ final class SaveMeasureCommandHandlerTest extends TestCase
             ->expects(self::once())
             ->method('addPeriod')
             ->with($createdPeriod);
+
+        $createdMeasure
+            ->expects(self::once())
+            ->method('addLocationNew')
+            ->with($createdLocationNew);
 
         $this->measureRepository
             ->expects(self::once())
@@ -73,13 +82,18 @@ final class SaveMeasureCommandHandlerTest extends TestCase
             ->willReturn($createdMeasure);
 
         $periodCommand = new SavePeriodCommand();
-        $periodCommand->measure = $createdMeasure;
+        $locationNewCommand = new SaveLocationNewCommand();
 
+        $handleMatcher = self::exactly(2);
         $this->commandBus
-            ->expects(self::once())
+            ->expects($handleMatcher)
             ->method('handle')
-            ->with($this->equalTo($periodCommand))
-            ->willReturn($createdPeriod);
+            ->willReturnCallback(
+                fn ($command) => match ($handleMatcher->getInvocationCount()) {
+                    1 => $this->assertEquals($periodCommand, $command) ?: $createdPeriod,
+                    2 => $this->assertEquals($locationNewCommand, $command) ?: $createdLocationNew,
+                },
+            );
 
         $handler = new SaveMeasureCommandHandler(
             $this->idFactory,
@@ -92,6 +106,7 @@ final class SaveMeasureCommandHandlerTest extends TestCase
         $command->location = $location;
         $command->type = MeasureTypeEnum::ALTERNATE_ROAD->value;
         $command->periods = [$periodCommand];
+        $command->locationsNew = [$locationNewCommand];
 
         $result = $handler($command);
 
@@ -246,6 +261,18 @@ final class SaveMeasureCommandHandlerTest extends TestCase
             ->method('getUuid')
             ->willReturn('28accfd6-d896-4ed9-96a3-1754f288f511');
 
+        $locationNew1 = $this->createMock(LocationNew::class);
+        $locationNew1
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('065af978-a0f0-7cf8-8000-ce7f83c57ca3');
+
+        $locationNew2 = $this->createMock(LocationNew::class);
+        $locationNew2
+            ->expects(self::exactly(2))
+            ->method('getUuid')
+            ->willReturn('065af992-ecb9-7afd-8000-a1ac6e020f2f');
+
         $measure = $this->createMock(Measure::class);
 
         $measure
@@ -264,6 +291,11 @@ final class SaveMeasureCommandHandlerTest extends TestCase
             ->willReturn([$period1, $period2]);
 
         $measure
+            ->expects(self::exactly(2))
+            ->method('getLocationsNew')
+            ->willReturn([$locationNew1, $locationNew2]);
+
+        $measure
             ->expects(self::once())
             ->method('setVehicleSet')
             ->with(null);
@@ -273,20 +305,27 @@ final class SaveMeasureCommandHandlerTest extends TestCase
             ->method('removePeriod')
             ->with($period2);
 
+        $measure
+            ->expects(self::once())
+            ->method('removeLocationNew')
+            ->with($locationNew1);
+
         $this->measureRepository
             ->expects(self::never())
             ->method('add');
 
         $periodCommand1 = new SavePeriodCommand($period1);
-        $periodCommand1->measure = $measure;
-
-        $periodCommand2 = new SavePeriodCommand($period2);
-        $periodCommand2->measure = $measure;
+        $locationNewCommand2 = new SaveLocationNewCommand($locationNew2);
 
         $this->commandBus
-            ->expects(self::exactly(2))
+            ->expects(self::exactly(4))
             ->method('handle')
-            ->withConsecutive([$this->equalTo($periodCommand1)], [$this->equalTo(new DeletePeriodCommand($period2))]);
+            ->withConsecutive(
+                [$this->equalTo($periodCommand1)],
+                [$this->equalTo(new DeletePeriodCommand($period2))],
+                [$this->equalTo($locationNewCommand2)],
+                [$this->equalTo(new DeleteLocationNewCommand($locationNew1))],
+            );
 
         $handler = new SaveMeasureCommandHandler(
             $this->idFactory,
@@ -299,6 +338,7 @@ final class SaveMeasureCommandHandlerTest extends TestCase
         $command->type = MeasureTypeEnum::ALTERNATE_ROAD->value;
         $command->vehicleSet = null; // Removes vehicle set
         $command->periods = [$periodCommand1]; // Removes period2.
+        $command->locationsNew = [$locationNewCommand2]; // Removes locationNew1.
 
         $result = $handler($command);
 

--- a/tests/Unit/Application/Regulation/Command/SaveRegulationLocationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/SaveRegulationLocationCommandHandlerTest.php
@@ -8,6 +8,7 @@ use App\Application\CommandBusInterface;
 use App\Application\GeocoderInterface;
 use App\Application\IdFactoryInterface;
 use App\Application\Regulation\Command\DeleteMeasureCommand;
+use App\Application\Regulation\Command\Location\SaveLocationNewCommand;
 use App\Application\Regulation\Command\SaveMeasureCommand;
 use App\Application\Regulation\Command\SaveRegulationLocationCommand;
 use App\Application\Regulation\Command\SaveRegulationLocationCommandHandler;
@@ -16,11 +17,9 @@ use App\Domain\Geography\Coordinates;
 use App\Domain\Geography\GeoJSON;
 use App\Domain\Regulation\Enum\MeasureTypeEnum;
 use App\Domain\Regulation\Location;
-use App\Domain\Regulation\LocationNew;
 use App\Domain\Regulation\Measure;
 use App\Domain\Regulation\RegulationOrder;
 use App\Domain\Regulation\RegulationOrderRecord;
-use App\Domain\Regulation\Repository\LocationNewRepositoryInterface;
 use App\Domain\Regulation\Repository\LocationRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -36,7 +35,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
     private $commandBus;
     private $idFactory;
     private $locationRepository;
-    private $locationNewRepository;
     private $geocoder;
     private $roadGeocoder;
     private $geometry;
@@ -53,7 +51,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
             Coordinates::fromLonLat(-1.930973, 47.347917),
         ]);
         $this->locationRepository = $this->createMock(LocationRepositoryInterface::class);
-        $this->locationNewRepository = $this->createMock(LocationNewRepositoryInterface::class);
         $this->idFactory = $this->createMock(IdFactoryInterface::class);
         $this->commandBus = $this->createMock(CommandBusInterface::class);
         $this->regulationOrder = $this->createMock(RegulationOrder::class);
@@ -69,12 +66,9 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
     public function testCreate(): void
     {
         $this->idFactory
-            ->expects(self::exactly(2))
+            ->expects(self::once())
             ->method('make')
-            ->willReturn(
-                '4430a28a-f9ad-4c4b-ba66-ce9cc9adb7d8',
-                '9dbbe0ce-2672-4f18-80b9-06d0102cb855',
-            );
+            ->willReturn('4430a28a-f9ad-4c4b-ba66-ce9cc9adb7d8');
 
         $this->geocoder
             ->expects(self::exactly(2))
@@ -86,7 +80,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
 
         $createdMeasure = $this->createMock(Measure::class);
         $createdLocation = $this->createMock(Location::class);
-        $createdLocationNew = $this->createMock(LocationNew::class);
 
         $location = new Location(
             uuid: '4430a28a-f9ad-4c4b-ba66-ce9cc9adb7d8',
@@ -99,63 +92,24 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
             geometry: $this->geometry,
         );
 
-        $locationNew = new LocationNew(
-            uuid: '9dbbe0ce-2672-4f18-80b9-06d0102cb855',
-            measure: $createdMeasure,
-            cityCode: $this->cityCode,
-            cityLabel: $this->cityLabel,
-            roadName: $this->roadName,
-            fromHouseNumber: $this->fromHouseNumber,
-            geometry: $this->geometry,
-            toHouseNumber: $this->toHouseNumber,
-        );
-
         $measureCommand = new SaveMeasureCommand();
         $measureCommand->location = $createdLocation;
         $measureCommand->type = MeasureTypeEnum::ALTERNATE_ROAD->value;
+        $measureCommand->locationsNew = [
+            SaveLocationNewCommand::fromLocation($location),
+        ];
 
         $createdLocation
             ->expects(self::once())
             ->method('addMeasure')
             ->with($createdMeasure);
-        $createdLocation
-            ->expects(self::once())
-            ->method('getCityCode')
-            ->willReturn($this->cityCode);
-        $createdLocation
-            ->expects(self::once())
-            ->method('getCityLabel')
-            ->willReturn($this->cityLabel);
-        $createdLocation
-            ->expects(self::once())
-            ->method('getRoadName')
-            ->willReturn($this->roadName);
-        $createdLocation
-            ->expects(self::once())
-            ->method('getGeometry')
-            ->willReturn($this->geometry);
-        $createdLocation
-            ->expects(self::once())
-            ->method('getFromHouseNumber')
-            ->willReturn($this->fromHouseNumber);
-        $createdLocation
-            ->expects(self::once())
-            ->method('getToHouseNumber')
-            ->willReturn($this->toHouseNumber);
-        $createdMeasure
-            ->expects(self::once())
-            ->method('addLocation')
-            ->with($locationNew);
+
         $this->locationRepository
             ->expects(self::once())
             ->method('add')
             ->with($this->equalTo($location))
             ->willReturn($createdLocation);
-        $this->locationNewRepository
-            ->expects(self::once())
-            ->method('add')
-            ->with($this->equalTo($locationNew))
-            ->willReturn($createdLocationNew);
+
         $this->commandBus
             ->expects(self::once())
             ->method('handle')
@@ -166,7 +120,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
             $this->idFactory,
             $this->commandBus,
             $this->locationRepository,
-            $this->locationNewRepository,
             $this->geocoder,
             $this->roadGeocoder,
         );
@@ -187,12 +140,9 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
     public function testCreateFullRoad(): void
     {
         $this->idFactory
-            ->expects(self::exactly(2))
+            ->expects(self::once())
             ->method('make')
-            ->willReturn(
-                '4430a28a-f9ad-4c4b-ba66-ce9cc9adb7d8',
-                '9dbbe0ce-2672-4f18-80b9-06d0102cb855',
-            );
+            ->willReturn('4430a28a-f9ad-4c4b-ba66-ce9cc9adb7d8');
 
         $this->geocoder
             ->expects(self::never())
@@ -222,6 +172,9 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
 
         $measureCommand = new SaveMeasureCommand();
         $measureCommand->location = $createdLocation;
+        $measureCommand->locationsNew = [
+            SaveLocationNewCommand::fromLocation($location),
+        ];
         $measureCommand->type = MeasureTypeEnum::ALTERNATE_ROAD->value;
 
         $createdLocation
@@ -243,7 +196,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
             $this->idFactory,
             $this->commandBus,
             $this->locationRepository,
-            $this->locationNewRepository,
             $this->geocoder,
             $this->roadGeocoder,
         );
@@ -263,28 +215,11 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
 
     public function testUpdate(): void
     {
-        $locationNew = $this->createMock(LocationNew::class);
-        $locationNew
-            ->expects(self::once())
-            ->method('update')
-            ->with(
-                $this->cityCode,
-                $this->cityLabel,
-                $this->roadName,
-                $this->fromHouseNumber,
-                $this->toHouseNumber,
-                $this->geometry,
-            );
-
         $measureToUpdate = $this->createMock(Measure::class);
         $measureToUpdate
             ->expects(self::once())
             ->method('getCreatedAt')
             ->willReturn(new \DateTimeImmutable('2023-06-01'));
-        $measureToUpdate
-            ->expects(self::once())
-            ->method('getLocationNew')
-            ->willReturn($locationNew);
 
         $measureToRemove = $this->createMock(Measure::class);
         $measureToRemove
@@ -329,6 +264,7 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $measureToUpdateCommand = new SaveMeasureCommand($measureToUpdate);
         $measureToUpdateCommand->location = $location;
         $measureToUpdateCommand->type = MeasureTypeEnum::ALTERNATE_ROAD->value;
+        $measureToUpdateCommand->locationsNew = [SaveLocationNewCommand::fromLocation($location)];
 
         $matcher = self::exactly(2);
         $this->commandBus
@@ -354,7 +290,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
             $this->idFactory,
             $this->commandBus,
             $this->locationRepository,
-            $this->locationNewRepository,
             $this->geocoder,
             $this->roadGeocoder,
         );
@@ -400,7 +335,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
             $this->idFactory,
             $this->commandBus,
             $this->locationRepository,
-            $this->locationNewRepository,
             $this->geocoder,
             $this->roadGeocoder,
         );
@@ -444,7 +378,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
             $this->idFactory,
             $this->commandBus,
             $this->locationRepository,
-            $this->locationNewRepository,
             $this->geocoder,
             $this->roadGeocoder,
         );
@@ -514,7 +447,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
             $this->idFactory,
             $this->commandBus,
             $this->locationRepository,
-            $this->locationNewRepository,
             $this->geocoder,
             $this->roadGeocoder,
         );

--- a/tests/Unit/Domain/Regulation/LocationNewTest.php
+++ b/tests/Unit/Domain/Regulation/LocationNewTest.php
@@ -89,7 +89,7 @@ final class LocationNewTest extends TestCase
         $this->assertSame($newGeometry, $location->getGeometry());
     }
 
-    public function testCreate(): void
+    public function testFromLocation(): void
     {
         $measure = $this->createMock(Measure::class);
         $regulationOrder = $this->createMock(RegulationOrder::class);

--- a/tests/Unit/Domain/Regulation/LocationNewTest.php
+++ b/tests/Unit/Domain/Regulation/LocationNewTest.php
@@ -6,8 +6,10 @@ namespace App\Tests\Unit\Domain\Regulation;
 
 use App\Domain\Geography\Coordinates;
 use App\Domain\Geography\GeoJSON;
+use App\Domain\Regulation\Location;
 use App\Domain\Regulation\LocationNew;
 use App\Domain\Regulation\Measure;
+use App\Domain\Regulation\RegulationOrder;
 use PHPUnit\Framework\TestCase;
 
 final class LocationNewTest extends TestCase
@@ -85,5 +87,41 @@ final class LocationNewTest extends TestCase
         $this->assertSame($newFromHouseNumber, $location->getFromHouseNumber());
         $this->assertSame($newToHouseNumber, $location->getToHouseNumber());
         $this->assertSame($newGeometry, $location->getGeometry());
+    }
+
+    public function testCreate(): void
+    {
+        $measure = $this->createMock(Measure::class);
+        $regulationOrder = $this->createMock(RegulationOrder::class);
+
+        $location = new Location(
+            uuid: '504a1515-af1a-432c-bcc3-7938eca2b33f',
+            regulationOrder: $regulationOrder,
+            cityCode: '44195',
+            cityLabel: 'Savenay',
+            roadName: 'Route du Grand Brossais',
+            fromHouseNumber: '15',
+            toHouseNumber: '37bis',
+            geometry: GeoJSON::toLineString([
+                Coordinates::fromLonLat(-1.935836, 47.347024),
+                Coordinates::fromLonLat(-1.930973, 47.347917),
+            ]),
+        );
+
+        $locationNew = new LocationNew(
+            uuid: '9f3cbc01-8dbe-4306-9912-91c8d88e194f',
+            measure: $measure,
+            cityCode: '44195',
+            cityLabel: 'Savenay',
+            roadName: 'Route du Grand Brossais',
+            fromHouseNumber: '15',
+            toHouseNumber: '37bis',
+            geometry: GeoJSON::toLineString([
+                Coordinates::fromLonLat(-1.935836, 47.347024),
+                Coordinates::fromLonLat(-1.930973, 47.347917),
+            ]),
+        );
+
+        $this->assertEquals($locationNew, LocationNew::fromLocation('9f3cbc01-8dbe-4306-9912-91c8d88e194f', $measure, $location));
     }
 }

--- a/tests/Unit/Domain/Regulation/MeasureTest.php
+++ b/tests/Unit/Domain/Regulation/MeasureTest.php
@@ -57,13 +57,13 @@ final class MeasureTest extends TestCase
         $location2 = $this->createMock(LocationNew::class);
         $location3 = $this->createMock(LocationNew::class);
 
-        $measure->addLocation($location1);
-        $measure->addLocation($location1); // Test duplicate
-        $measure->addLocation($location2);
-        $this->assertEquals(new ArrayCollection([$location1, $location2]), $measure->getLocations());
+        $measure->addLocationNew($location1);
+        $measure->addLocationNew($location1); // Test duplicate
+        $measure->addLocationNew($location2);
+        $this->assertEquals(new ArrayCollection([$location1, $location2]), $measure->getLocationsNew());
 
-        $measure->removeLocation($location3); // Location that does not belong to the measure
-        $measure->removeLocation($location2);
-        $this->assertEquals(new ArrayCollection([$location1]), $measure->getLocations());
+        $measure->removeLocationNew($location3); // Location that does not belong to the measure
+        $measure->removeLocationNew($location2);
+        $this->assertEquals(new ArrayCollection([$location1]), $measure->getLocationsNew());
     }
 }

--- a/tests/Unit/Domain/Regulation/MeasureTest.php
+++ b/tests/Unit/Domain/Regulation/MeasureTest.php
@@ -61,6 +61,7 @@ final class MeasureTest extends TestCase
         $measure->addLocationNew($location1); // Test duplicate
         $measure->addLocationNew($location2);
         $this->assertEquals(new ArrayCollection([$location1, $location2]), $measure->getLocationsNew());
+        $this->assertEquals($location1, $measure->getLocationNew());
 
         $measure->removeLocationNew($location3); // Location that does not belong to the measure
         $measure->removeLocationNew($location2);

--- a/tests/Unit/Infrastructure/Repository/LocationNewRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Repository/LocationNewRepositoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure\Repository;
+
+use App\Domain\Regulation\LocationNew;
+use App\Infrastructure\Persistence\Doctrine\Repository\Regulation\LocationNewRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+
+final class LocationNewRepositoryTest extends TestCase
+{
+    // Coverage only
+    public function testDelete(): void
+    {
+        $locationNew = $this->createMock(LocationNew::class);
+
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em
+            ->expects(self::once())
+            ->method('remove')
+            ->with($locationNew);
+        $em
+            ->expects(self::once())
+            ->method('getClassMetadata')
+            ->willReturn(new ClassMetadata(LocationNew::class));
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry
+            ->expects(self::once())
+            ->method('getManagerForClass')
+            ->with(LocationNew::class)
+            ->willReturn($em);
+
+        $repository = new LocationNewRepository($registry);
+
+        $repository->delete($locationNew);
+    }
+}


### PR DESCRIPTION
* Refs #577 

En prérequis je pense qu'il faut que le code des Locations ne fassent plus aucune référence à LocationNew. Cette logique doit selon moi être déplacée dans le code des Measures car c'est là qu'au final on gèrera les localisations (à l'intérieur des mesures)

Cette PR est un brouillon de refactoring (il ne manque plus qu'à màj les tests) pour gérer la création/mise à jour de locationNew depuis SaveMeasureCommandHandler, et non depuis SaveLocationCommandHandler

Elle renomme aussi les attributs / méthodes de Measure pour faire référence à `locationNew` et pas `location`, comme on en a déjà discuté à l'oral @mmarchois. Je crois que dans ce cas ce n'est pas superflu, la rigueur se combine à la clarté et au fait qu'on puisse "s'y retrouver", ce qui semble imporant pour ne pas s'emmêler les pinceaux. On pourra tout renommer à la fin sans rien oublier