### PR TITLE
Improve tests performance

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -20,7 +20,7 @@ when@test:
         dbal:
             # "TEST_TOKEN" is typically set by ParaTest
             dbname_suffix: '_test%env(default::TEST_TOKEN)%'
-
+            logging: false
 when@prod:
     doctrine:
         orm:

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
          convertDeprecationsToExceptions="false"
 >
     <php>
+        <server name="APP_DEBUG" value="false" />
         <ini name="display_errors" value="1" />
         <ini name="error_reporting" value="-1" />
         <server name="APP_ENV" value="test" force="true" />
@@ -17,7 +18,7 @@
         <server name="SYMFONY_PHPUNIT_VERSION" value="9.5" />
     </php>
 
-    <coverage>
+    <coverage cacheDirectory=".coverage-cache">
         <include>
             <directory>src</directory>
         </include>


### PR DESCRIPTION
Avant : 

Tests unitaires : `Time: 00:05.923, Memory: 44.00 MB`
Tests intégration : 

Après : 
Tests unitaires :  `Time: 00:00.648, Memory: 18.00 MB`
Tests intégration : 
