### PR TITLE
Add FeatureFlagService

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -7,6 +7,7 @@ parameters:
     server_timezone: '%env(APP_SERVER_TIMEZONE)%'
     client_timezone: '%env(APP_CLIENT_TIMEZONE)%'
     admin_email: '%env(ADMIN_EMAIL)%'
+    features: {}
 
 services:
     # default configuration for services in *this* file
@@ -20,6 +21,7 @@ services:
             $eudonetParisOrgId: '%env(APP_EUDONET_PARIS_ORG_ID)%'
             $dialogOrgId: '%env(DIALOG_ORG_ID)%'
             $ignWfsUrl: '%env(APP_IGN_WFS_URL)%'
+            $featureMap: '%features%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/src/Infrastructure/FeatureFlagService.php
+++ b/src/Infrastructure/FeatureFlagService.php
@@ -8,11 +8,8 @@ use Symfony\Component\HttpFoundation\Request;
 
 class FeatureFlagService
 {
-    private array $env;
-
-    public function __construct(array $env = null)
+    public function __construct(private array $featureMap)
     {
-        $this->env = $env ?? $_ENV;
     }
 
     private function isTruthy(?string $value): bool
@@ -22,12 +19,12 @@ class FeatureFlagService
 
     public function isFeatureEnabled(string $featureName, Request $request = null): bool
     {
-        $key = 'APP_FEATURE_' . $featureName . '_ENABLED';
+        $queryParam = 'feature_' . $featureName;
 
-        if ($request && $request->query->has($key)) {
-            return $this->isTruthy($request->query->get($key));
+        if ($request && $request->query->has($queryParam)) {
+            return $this->isTruthy($request->query->get($queryParam));
         }
 
-        return \array_key_exists($key, $this->env) && $this->isTruthy($this->env[$key]);
+        return \array_key_exists($featureName, $this->featureMap) && $this->isTruthy($this->featureMap[$featureName]);
     }
 }

--- a/src/Infrastructure/FeatureFlagService.php
+++ b/src/Infrastructure/FeatureFlagService.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure;
+
+use Symfony\Component\HttpFoundation\Request;
+
+class FeatureFlagService
+{
+    private array $env;
+
+    public function __construct(array $env = null)
+    {
+        $this->env = $env ?? $_ENV;
+    }
+
+    private function isTruthy(?string $value): bool
+    {
+        return $value && strtolower($value) !== 'false';
+    }
+
+    public function isFeatureEnabled(string $featureName, Request $request = null): bool
+    {
+        $key = 'APP_FEATURE_' . $featureName . '_ENABLED';
+
+        if ($request && $request->query->has($key)) {
+            return $this->isTruthy($request->query->get($key));
+        }
+
+        return \array_key_exists($key, $this->env) && $this->isTruthy($this->env[$key]);
+    }
+}

--- a/src/Infrastructure/Twig/AppExtension.php
+++ b/src/Infrastructure/Twig/AppExtension.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Infrastructure\Twig;
 
 use App\Application\StringUtilsInterface;
+use App\Infrastructure\FeatureFlagService;
 use Symfony\Component\Form\FormError;
+use Symfony\Component\HttpFoundation\Request;
 
 class AppExtension extends \Twig\Extension\AbstractExtension
 {
@@ -14,6 +16,7 @@ class AppExtension extends \Twig\Extension\AbstractExtension
     public function __construct(
         string $clientTimezone,
         private StringUtilsInterface $stringUtils,
+        private FeatureFlagService $featureFlagService,
     ) {
         $this->clientTimezone = new \DateTimeZone($clientTimezone);
     }
@@ -26,6 +29,7 @@ class AppExtension extends \Twig\Extension\AbstractExtension
             new \Twig\TwigFunction('app_is_client_future_day', [$this, 'isClientFutureDay']),
             new \Twig\TwigFunction('app_vehicle_type_icon_name', [$this, 'getVehicleTypeIconName']),
             new \Twig\TwigFunction('app_is_fieldset_error', [$this, 'isFieldsetError']),
+            new \Twig\TwigFunction('app_is_feature_enabled', [$this, 'isFeatureEnabled']),
         ];
     }
 
@@ -84,5 +88,10 @@ class AppExtension extends \Twig\Extension\AbstractExtension
         $payload = $error->getCause()->getConstraint()->payload;
 
         return $payload && \array_key_exists('fieldset', $payload) && $payload['fieldset'] === $fieldset;
+    }
+
+    public function isFeatureEnabled(string $featureName, Request $request = null): bool
+    {
+        return $this->featureFlagService->isFeatureEnabled($featureName, $request);
     }
 }

--- a/tests/Unit/Infrastructure/FeatureFlagServiceTest.php
+++ b/tests/Unit/Infrastructure/FeatureFlagServiceTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure;
+
+use App\Infrastructure\FeatureFlagService;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+
+final class FeatureFlagServiceTest extends TestCase
+{
+    private function provideIsFeatureEnabled(): array
+    {
+        return [
+            'disabled-env-not-present' => [
+                'env' => [],
+                'featureName' => 'EXAMPLE',
+                'request' => null,
+                'expected' => false,
+            ],
+            'disabled-env-empty' => [
+                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => ''],
+                'featureName' => 'EXAMPLE',
+                'request' => null,
+                'expected' => false,
+            ],
+            'disabled-env-other-featyre' => [
+                'env' => ['APP_FEATURE_OTHER_ENABLED' => 'true'],
+                'featureName' => 'EXAMPLE',
+                'request' => null,
+                'expected' => false,
+            ],
+            'disabled-env-false' => [
+                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => 'false'],
+                'featureName' => 'EXAMPLE',
+                'request' => null,
+                'expected' => false,
+            ],
+            'disabled-env-false-case-insensitive' => [
+                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => 'FaLse'],
+                'featureName' => 'EXAMPLE',
+                'request' => null,
+                'expected' => false,
+            ],
+            'enabled-by-env' => [
+                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => 'true'],
+                'featureName' => 'EXAMPLE',
+                'request' => null,
+                'expected' => true,
+            ],
+            'enabled-by-env-truthy' => [
+                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => 'something'],
+                'featureName' => 'EXAMPLE',
+                'request' => null,
+                'expected' => true,
+            ],
+            'enabled-by-request' => [
+                'env' => [],
+                'featureName' => 'EXAMPLE',
+                'request' => new Request(query: ['APP_FEATURE_EXAMPLE_ENABLED' => 'true']),
+                'expected' => true,
+            ],
+            'disabled-by-request' => [
+                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => 'true'],
+                'featureName' => 'EXAMPLE',
+                'request' => new Request(query: ['APP_FEATURE_EXAMPLE_ENABLED' => 'false']),
+                'expected' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideIsFeatureEnabled
+     */
+    public function testIsFeatureEnabled(array $env, string $featureName, ?Request $request, bool $expected): void
+    {
+        $featureFlagService = new FeatureFlagService($env);
+
+        $this->assertSame($expected, $featureFlagService->isFeatureEnabled($featureName, $request));
+    }
+}

--- a/tests/Unit/Infrastructure/FeatureFlagServiceTest.php
+++ b/tests/Unit/Infrastructure/FeatureFlagServiceTest.php
@@ -13,58 +13,58 @@ final class FeatureFlagServiceTest extends TestCase
     private function provideIsFeatureEnabled(): array
     {
         return [
-            'disabled-env-not-present' => [
-                'env' => [],
+            'disabled-not-present' => [
+                'featureMap' => [],
                 'featureName' => 'EXAMPLE',
                 'request' => null,
                 'expected' => false,
             ],
-            'disabled-env-empty' => [
-                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => ''],
-                'featureName' => 'EXAMPLE',
+            'disabled-empty' => [
+                'featureMap' => ['example' => ''],
+                'featureName' => 'example',
                 'request' => null,
                 'expected' => false,
             ],
-            'disabled-env-other-featyre' => [
-                'env' => ['APP_FEATURE_OTHER_ENABLED' => 'true'],
-                'featureName' => 'EXAMPLE',
+            'disabled-other-featyre' => [
+                'env' => ['other' => 'true'],
+                'featureName' => 'example',
                 'request' => null,
                 'expected' => false,
             ],
-            'disabled-env-false' => [
-                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => 'false'],
-                'featureName' => 'EXAMPLE',
+            'disabled-false' => [
+                'env' => ['example' => 'false'],
+                'featureName' => 'example',
                 'request' => null,
                 'expected' => false,
             ],
-            'disabled-env-false-case-insensitive' => [
-                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => 'FaLse'],
-                'featureName' => 'EXAMPLE',
+            'disabled-false-case-insensitive' => [
+                'env' => ['example' => 'FaLse'],
+                'featureName' => 'example',
                 'request' => null,
                 'expected' => false,
             ],
-            'enabled-by-env' => [
-                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => 'true'],
-                'featureName' => 'EXAMPLE',
+            'enabled' => [
+                'env' => ['example' => 'true'],
+                'featureName' => 'example',
                 'request' => null,
                 'expected' => true,
             ],
-            'enabled-by-env-truthy' => [
-                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => 'something'],
-                'featureName' => 'EXAMPLE',
+            'enabled-truthy' => [
+                'env' => ['example' => 'something'],
+                'featureName' => 'example',
                 'request' => null,
                 'expected' => true,
             ],
             'enabled-by-request' => [
                 'env' => [],
-                'featureName' => 'EXAMPLE',
-                'request' => new Request(query: ['APP_FEATURE_EXAMPLE_ENABLED' => 'true']),
+                'featureName' => 'example',
+                'request' => new Request(query: ['feature_example' => 'true']),
                 'expected' => true,
             ],
             'disabled-by-request' => [
-                'env' => ['APP_FEATURE_EXAMPLE_ENABLED' => 'true'],
-                'featureName' => 'EXAMPLE',
-                'request' => new Request(query: ['APP_FEATURE_EXAMPLE_ENABLED' => 'false']),
+                'env' => ['example' => 'true'],
+                'featureName' => 'example',
+                'request' => new Request(query: ['feature_example' => 'false']),
                 'expected' => false,
             ],
         ];
@@ -73,9 +73,9 @@ final class FeatureFlagServiceTest extends TestCase
     /**
      * @dataProvider provideIsFeatureEnabled
      */
-    public function testIsFeatureEnabled(array $env, string $featureName, ?Request $request, bool $expected): void
+    public function testIsFeatureEnabled(array $featureMap, string $featureName, ?Request $request, bool $expected): void
     {
-        $featureFlagService = new FeatureFlagService($env);
+        $featureFlagService = new FeatureFlagService($featureMap);
 
         $this->assertSame($expected, $featureFlagService->isFeatureEnabled($featureName, $request));
     }

--- a/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
+++ b/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
@@ -7,6 +7,7 @@ namespace App\Test\Unit\Infrastructure\Twig;
 use App\Domain\Regulation\Enum\CritairEnum;
 use App\Domain\Regulation\Enum\VehicleTypeEnum;
 use App\Infrastructure\Adapter\StringUtils;
+use App\Infrastructure\FeatureFlagService;
 use App\Infrastructure\Twig\AppExtension;
 use App\Tests\TimezoneHelper;
 use PHPUnit\Framework\TestCase;
@@ -19,16 +20,22 @@ class AppExtensionTest extends TestCase
     use TimezoneHelper;
 
     private AppExtension $extension;
+    private $featureFlagService;
 
     protected function setUp(): void
     {
         $this->setDefaultTimezone('UTC');
-        $this->extension = new AppExtension('Etc/GMT-1', new StringUtils()); // Independent of Daylight Saving Time (DST).
+        $this->featureFlagService = $this->createMock(FeatureFlagService::class);
+        $this->extension = new AppExtension(
+            'Etc/GMT-1', // Independent of Daylight Saving Time (DST).
+            new StringUtils(),
+            $this->featureFlagService,
+        );
     }
 
     public function testGetFunctions(): void
     {
-        $this->assertCount(5, $this->extension->getFunctions());
+        $this->assertCount(6, $this->extension->getFunctions());
     }
 
     public function testFormatDateTimeDateOnly(): void
@@ -165,5 +172,24 @@ class AppExtensionTest extends TestCase
         $constraint->payload = $payload;
 
         $this->assertSame($expected, $this->extension->isFieldsetError($error, 'example'));
+    }
+
+    private function provideIsFeatureEnabled(): array
+    {
+        return [['enabled' => true], ['enabled' => false]];
+    }
+
+    /**
+     * @dataProvider provideIsFeatureEnabled
+     */
+    public function testIsFeatureEnabled(bool $enabled): void
+    {
+        $this->featureFlagService
+            ->expects(self::once())
+            ->method('isFeatureEnabled')
+            ->with('MY_FEATURE')
+            ->willReturn($enabled);
+
+        $this->assertSame($enabled, $this->extension->isFeatureEnabled('MY_FEATURE'));
     }
 }


### PR DESCRIPTION
Extrait de #593 

Cette PR ajoute un `FeatureFlagService` qui permet de déterminer si une feature est activée, à partir d'une variable d'environnement ou (priorité plus grande) d'un query param dans la requête HTTP