### PR TITLE
Fix period timezone handling

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,7 @@
 # define your env variables for the test env here
 KERNEL_CLASS='App\Kernel'
 APP_SERVER_TIMEZONE=UTC
-APP_CLIENT_TIMEZONE=Europe/Paris
+APP_CLIENT_TIMEZONE=Etc/GMT-1 # Independant of Daylight Saving Time (DST)
 APP_SECRET='$ecretf0rt3st'
 APP_EUDONET_PARIS_CREDENTIALS='{"SubscriberLogin": "testSubcriberLogin", "SubscriberPassword": "testSubcriberPassword", "BaseName": "TEST_BASE_NAME", "UserLogin": "testUserLogin", "UserPassword": "testPassword", "UserLang": "lang_00", "ProductName": "api"}'
 APP_EUDONET_PARIS_ORG_ID=e0d93630-acf7-4722-81e8-ff7d5fa64b66 # DiaLog org

--- a/src/Infrastructure/Adapter/DateUtils.php
+++ b/src/Infrastructure/Adapter/DateUtils.php
@@ -41,7 +41,6 @@ final class DateUtils implements DateUtilsInterface
         $min = (int) $date2->format('i');
 
         return \DateTime::createFromInterface($date1)
-            ->setTime($hour, $min)
-            ->setTimeZone($this->clientTimezone);
+            ->setTime($hour, $min);
     }
 }

--- a/src/Infrastructure/Form/Regulation/PeriodFormType.php
+++ b/src/Infrastructure/Form/Regulation/PeriodFormType.php
@@ -16,24 +16,33 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class PeriodFormType extends AbstractType
 {
+    public function __construct(
+        private string $clientTimezone,
+    ) {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('startDate', DateType::class, [
                 'label' => 'regulation.period.startDate',
                 'widget' => 'single_text',
+                'view_timezone' => $this->clientTimezone,
             ])
             ->add('startTime', TimeType::class, [
                 'label' => 'regulation.period.startTime',
                 'widget' => 'choice',
+                'view_timezone' => $this->clientTimezone,
             ])
             ->add('endDate', DateType::class, [
                 'label' => 'regulation.period.endDate',
                 'widget' => 'single_text',
+                'view_timezone' => $this->clientTimezone,
             ])
             ->add('endTime', TimeType::class, [
                 'label' => 'regulation.period.endTime',
                 'widget' => 'choice',
+                'view_timezone' => $this->clientTimezone,
             ])
             ->add('recurrenceType', ChoiceType::class,
                 options: $this->getRecurrenceTypeOptions(),

--- a/src/Infrastructure/Form/Regulation/TimeSlotFormType.php
+++ b/src/Infrastructure/Form/Regulation/TimeSlotFormType.php
@@ -12,16 +12,23 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 final class TimeSlotFormType extends AbstractType
 {
+    public function __construct(
+        private string $clientTimezone,
+    ) {
+    }
+
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
             ->add('startTime', TimeType::class, [
                 'label' => 'regulation.timeSlot.startTime',
                 'widget' => 'choice',
+                'view_timezone' => $this->clientTimezone,
             ])
             ->add('endTime', TimeType::class, [
                 'label' => 'regulation.timeSlot.endTime',
                 'widget' => 'choice',
+                'view_timezone' => $this->clientTimezone,
             ])
         ;
     }

--- a/src/Infrastructure/Twig/AppExtension.php
+++ b/src/Infrastructure/Twig/AppExtension.php
@@ -25,6 +25,7 @@ class AppExtension extends \Twig\Extension\AbstractExtension
     {
         return [
             new \Twig\TwigFunction('app_datetime', [$this, 'formatDateTime']),
+            new \Twig\TwigFunction('app_time', [$this, 'formatTime']),
             new \Twig\TwigFunction('app_is_client_past_day', [$this, 'isClientPastDay']),
             new \Twig\TwigFunction('app_is_client_future_day', [$this, 'isClientFutureDay']),
             new \Twig\TwigFunction('app_vehicle_type_icon_name', [$this, 'getVehicleTypeIconName']),
@@ -36,18 +37,23 @@ class AppExtension extends \Twig\Extension\AbstractExtension
     /**
      * Format a $date with an optional $time
      */
-    public function formatDateTime(\DateTimeInterface $date, \DateTimeInterface $time = null): string
+    public function formatDateTime(\DateTimeInterface $date, \DateTimeInterface|bool $time = null): string
     {
         $dateTime = \DateTimeImmutable::createFromInterface($date)->setTimeZone($this->clientTimezone);
         $format = 'd/m/Y';
 
         if ($time) {
-            $time = \DateTimeImmutable::createFromInterface($time)->setTimezone($this->clientTimezone);
+            $time = \DateTimeImmutable::createFromInterface($time === true ? $date : $time)->setTimezone($this->clientTimezone);
             $dateTime = $dateTime->setTime((int) $time->format('H'), (int) $time->format('i'), (int) $time->format('s'));
             $format = 'd/m/Y à H\hi';
         }
 
         return $dateTime->format($format);
+    }
+
+    public function formatTime(\DateTimeInterface $time): string
+    {
+        return \DateTimeImmutable::createFromInterface($time)->setTimeZone($this->clientTimezone)->format('H\hi');
     }
 
     public function isClientPastDay(\DateTimeInterface $date, \DateTimeInterface $today = null): bool

--- a/templates/regulation/_period.html.twig
+++ b/templates/regulation/_period.html.twig
@@ -1,9 +1,9 @@
 {%- for period in periods -%}
     <br/>
     {%- if period.endDateTime -%}
-        du {{ period.startDateTime|date('d/m/Y - H\\hi' ) }} au {{ period.endDateTime|date('d/m/Y - H\\hi' ) }}
+        du {{ app_datetime(period.startDateTime, true) }} au {{ app_datetime(period.endDateTime, true) }}
     {%- else -%}
-        {{ period.startDateTime|date('d/m/Y - H\\hi' ) }}
+        {{ app_datetime(period.startDateTime, true) }}
     {%- endif -%}
     {%- if period.dailyRange -%}
         ,&nbsp;
@@ -24,7 +24,7 @@
     {% if period.timeSlots|length %}
         (
         {%- for timeSlot in period.timeSlots -%}
-            {{ timeSlot.startTime|date('H\\hi' ) }}-{{ timeSlot.endTime|date('H\\hi' ) }}
+            {{ app_time(timeSlot.startTime) }}-{{ app_time(timeSlot.endTime) }}
             {%- if not loop.last -%}&nbsp;et&nbsp;{% endif %}
         {%- endfor -%}
         )

--- a/tests/Integration/Infrastructure/Controller/Regulation/DuplicateRegulationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/DuplicateRegulationControllerTest.php
@@ -32,7 +32,7 @@ final class DuplicateRegulationControllerTest extends AbstractWebTestCase
         $this->assertSame('Paris 18e Arrondissement (75018)', $location->filter('li')->eq(0)->text());
         $this->assertSame('Rue du Simplon', $location->filter('li')->eq(1)->text());
         $this->assertSame('Circulation alternée tous les jours pour tous les véhicules', $location->filter('li')->eq(2)->text());
-        $this->assertSame('Circulation interdite du 09/06/2023 - 09h00 au 09/06/2023 - 09h00, le lundi pour les véhicules de plus de 3.5 tonnes', $location->filter('li')->eq(3)->text());
+        $this->assertSame('Circulation interdite du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le lundi pour les véhicules de plus de 3.5 tonnes', $location->filter('li')->eq(3)->text());
     }
 
     public function testWithoutLocations(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetLocationControllerTest.php
@@ -22,7 +22,7 @@ final class GetLocationControllerTest extends AbstractWebTestCase
         $this->assertSame('Route du Grand Brossais', $crawler->filter('h3')->text());
         $this->assertSame('Savenay (44260)', $crawler->filter('li')->eq(0)->text());
         $this->assertSame('Route du Grand Brossais du n° 15 au n° 37bis', $crawler->filter('li')->eq(1)->text());
-        $this->assertSame('Circulation interdite du 31/10/2023 - 08h00 au 31/10/2023 - 22h00 pour tous les véhicules', $crawler->filter('li')->eq(2)->text());
+        $this->assertSame('Circulation interdite du 31/10/2023 à 09h00 au 31/10/2023 à 23h00 pour tous les véhicules', $crawler->filter('li')->eq(2)->text());
         $editForm = $crawler->selectButton('Modifier')->form();
         $this->assertSame('http://localhost/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/location/' . LocationFixture::UUID_TYPICAL . '/form', $editForm->getUri());
         $this->assertSame('GET', $editForm->getMethod());
@@ -37,7 +37,7 @@ final class GetLocationControllerTest extends AbstractWebTestCase
         $this->assertSecurityHeaders();
 
         $this->assertSame(
-            'Circulation interdite du 31/10/2023 - 08h00 au 31/10/2023 - 22h00, le lundi et le jeudi pour les véhicules de plus de 3.5 tonnes, 12 mètres de long ou 2.4 mètres de haut, crit\'air 4 et crit\'air 5, sauf piétons, véhicules d\'urgence et convois exceptionnels',
+            'Circulation interdite du 31/10/2023 à 09h00 au 31/10/2023 à 23h00, le lundi et le jeudi pour les véhicules de plus de 3.5 tonnes, 12 mètres de long ou 2.4 mètres de haut, crit\'air 4 et crit\'air 5, sauf piétons, véhicules d\'urgence et convois exceptionnels',
             $crawler->filter('li')->eq(2)->text(),
         );
     }

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateLocationControllerTest.php
@@ -113,7 +113,7 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(200);
         $this->assertRouteSame('fragment_regulations_location', ['uuid' => LocationFixture::UUID_TYPICAL]);
         $this->assertSame('Vitesse limitée à 60 km/h tous les jours pour tous les véhicules', $detailItems->eq(3)->text());
-        $this->assertSame('Circulation alternée du 09/06/2023 - 09h00 au 09/06/2023 - 09h00, le lundi pour tous les véhicules', $detailItems->eq(4)->text());
+        $this->assertSame('Circulation alternée du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le lundi pour tous les véhicules', $detailItems->eq(4)->text());
     }
 
     public function testDeletePeriod(): void
@@ -164,7 +164,7 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
         $values['location_form']['measures'][1]['periods'][0]['timeSlots'][0]['endTime']['minute'] = '0';
         $client->request($form->getMethod(), $form->getUri(), $values);
         $crawler = $client->followRedirect();
-        $this->assertSame('Circulation alternée du 09/06/2023 - 09h00 au 09/06/2023 - 09h00, le lundi (08h00-18h00) pour tous les véhicules', $crawler->filter('li')->eq(3)->text());
+        $this->assertSame('Circulation alternée du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le lundi (08h00-18h00) pour tous les véhicules', $crawler->filter('li')->eq(3)->text());
 
         // Remove added daily range
         $crawler = $client->request('GET', '/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/location/' . LocationFixture::UUID_TYPICAL . '/form');
@@ -176,7 +176,7 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values);
         $this->assertResponseStatusCodeSame(303);
         $crawler = $client->followRedirect();
-        $this->assertSame('Circulation alternée du 09/06/2023 - 09h00 au 09/06/2023 - 09h00 (08h00-18h00) pour tous les véhicules', $crawler->filter('li')->eq(3)->text());
+        $this->assertSame('Circulation alternée du 09/06/2023 à 10h00 au 09/06/2023 à 10h00 (08h00-18h00) pour tous les véhicules', $crawler->filter('li')->eq(3)->text());
     }
 
     public function testRemoveTimeSlots(): void
@@ -204,7 +204,7 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
         $values['location_form']['measures'][1]['periods'][0]['timeSlots'][0]['endTime']['minute'] = '0';
         $client->request($form->getMethod(), $form->getUri(), $values);
         $crawler = $client->followRedirect();
-        $this->assertSame('Circulation alternée du 09/06/2023 - 09h00 au 09/06/2023 - 09h00, le lundi (08h00-18h00) pour tous les véhicules', $crawler->filter('li')->eq(3)->text());
+        $this->assertSame('Circulation alternée du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le lundi (08h00-18h00) pour tous les véhicules', $crawler->filter('li')->eq(3)->text());
 
         // Remove added timeslot
         $crawler = $client->request('GET', '/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/location/' . LocationFixture::UUID_TYPICAL . '/form');
@@ -216,7 +216,7 @@ final class UpdateLocationControllerTest extends AbstractWebTestCase
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values);
         $this->assertResponseStatusCodeSame(303);
         $crawler = $client->followRedirect();
-        $this->assertSame('Circulation alternée du 09/06/2023 - 09h00 au 09/06/2023 - 09h00, le lundi pour tous les véhicules', $crawler->filter('li')->eq(3)->text());
+        $this->assertSame('Circulation alternée du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le lundi pour tous les véhicules', $crawler->filter('li')->eq(3)->text());
     }
 
     public function testRemoveMeasure(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -40,7 +40,7 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertSame('Route du Grand Brossais', $location->filter('h3')->text());
         $this->assertSame('Savenay (44260)', $location->filter('li')->eq(0)->text());
         $this->assertSame('Route du Grand Brossais du n° 15 au n° 37bis', $location->filter('li')->eq(1)->text());
-        $this->assertSame('Circulation interdite du 31/10/2023 - 08h00 au 31/10/2023 - 22h00 pour tous les véhicules', $location->filter('li')->eq(2)->text());
+        $this->assertSame('Circulation interdite du 31/10/2023 à 09h00 au 31/10/2023 à 23h00 pour tous les véhicules', $location->filter('li')->eq(2)->text());
         $editLocationForm = $location->selectButton('Modifier')->form();
         $this->assertSame(
             'http://localhost/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/location/' . LocationFixture::UUID_TYPICAL . '/form',
@@ -85,7 +85,7 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         // Measures
         $this->assertSame('Circulation interdite', $measureTitle->filter('h3')->text());
         $this->assertSame('pour tous les véhicules', $measureDetail->filter('li')->eq(0)->text());
-        $this->assertSame('du 31/10/2023 - 08h00 au 31/10/2023 - 22h00', $measureDetail->filter('li')->eq(1)->text());
+        $this->assertSame('du 31/10/2023 à 09h00 au 31/10/2023 à 23h00', $measureDetail->filter('li')->eq(1)->text());
         $this->assertSame('Route du Grand Brossais du n° 15 au n° 37bis Savenay (44260)', $measureDetail->filter('li')->eq(3)->text());
     }
 

--- a/tests/Unit/Infrastructure/Symfony/DependencyInjectionTest.php
+++ b/tests/Unit/Infrastructure/Symfony/DependencyInjectionTest.php
@@ -11,6 +11,6 @@ class DependencyInjectionTest extends KernelTestCase
     public function testTimezoneParameters(): void
     {
         $this->assertSame('UTC', $this->getContainer()->getParameter('server_timezone'));
-        $this->assertSame('Europe/Paris', $this->getContainer()->getParameter('client_timezone'));
+        $this->assertSame('Etc/GMT-1', $this->getContainer()->getParameter('client_timezone'));
     }
 }

--- a/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
+++ b/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
@@ -24,7 +24,6 @@ class AppExtensionTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->setDefaultTimezone('UTC');
         $this->featureFlagService = $this->createMock(FeatureFlagService::class);
         $this->extension = new AppExtension(
             'Etc/GMT-1', // Independent of Daylight Saving Time (DST).
@@ -35,7 +34,7 @@ class AppExtensionTest extends TestCase
 
     public function testGetFunctions(): void
     {
-        $this->assertCount(6, $this->extension->getFunctions());
+        $this->assertCount(7, $this->extension->getFunctions());
     }
 
     public function testFormatDateTimeDateOnly(): void
@@ -49,12 +48,25 @@ class AppExtensionTest extends TestCase
     {
         $this->assertSame(
             '06/01/2023 à 09h30',
-            $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06 UTC'), new \DateTimeImmutable('08:30:00 UTC')),
+            $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06'), new \DateTimeImmutable('08:30:00')),
         );
         $this->assertSame(
             '07/01/2023 à 11h30',
-            $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06 23:00 UTC'), new \DateTimeImmutable('10:30:00 UTC')),
+            $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06 23:00'), new \DateTimeImmutable('10:30:00')),
         );
+    }
+
+    public function testFormatDateTimeReuseTime(): void
+    {
+        $this->assertSame(
+            '06/01/2023 à 18h00',
+            $this->extension->formatDateTime(new \DateTimeImmutable('2023-01-06 17:00'), true),
+        );
+    }
+
+    public function testFormatTime(): void
+    {
+        $this->assertSame('18h00', $this->extension->formatTime(new \DateTimeImmutable('2023-01-06 17:00')));
     }
 
     private function provideIsPast(): array

--- a/tests/e2e/regulation_edit.spec.js
+++ b/tests/e2e/regulation_edit.spec.js
@@ -108,7 +108,7 @@ test('Add a period to a measure', async ({ regulationOrderPage }) => {
         endDate: '2023-10-10',
         endTime: ['08', '30'],
     });
-    await expect(location).toContainText('Circulation interdite du 09/06/2023 - 09h00 au 09/06/2023 - 09h00, du lundi au mardi pour tous les véhicules');
+    await expect(location).toContainText('Circulation interdite du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, du lundi au mardi pour tous les véhicules');
 });
 
 test('Delete a period from a measure', async ({ regulationOrderPage }) => {
@@ -126,7 +126,7 @@ test('Delete a period from a measure', async ({ regulationOrderPage }) => {
         endDate: '2023-10-10',
         endTime: ['16', '00'],
     });
-    await expect(location).toContainText('Circulation interdite du 09/06/2023 - 09h00 au 09/06/2023 - 09h00, le lundi pour tous les véhicules');
+    await expect(location).toContainText('Circulation interdite du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le lundi pour tous les véhicules');
     await page.removePeriodFromMeasure(location, { measureIndex: 0, periodIndex: 0 });
     await expect(location).toContainText('Circulation interdite tous les jours');
 });


### PR DESCRIPTION
* Closes #624

Cette PR corrige l'affichage et la saisie des dates et heures de plages horaires ("périodes"):

* Utilisation de `app_datetime` pour le début et la fin de la période
* Création et utilisation de `app_time` pour les timeslots
* Utilisation de `view_timezone` dans PeriodFormType et TimeSlotFormType
* Correction des tests
* Passage des tests en Etc/GMT-1 au lieu de Europe/Paris pour ne pas dépendre de l'heure d'été (actuellement on a 2h de décalage avec GMT mais lors du passage à l'heure d'été on aurait eu la CI HS car on n'aurait plus que 1h de décalage...)

