### PR TITLE
Amélioration commandes de test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,10 +206,9 @@ format: php_lint ## Format code
 
 test: ## Run the test suite
 	${BIN_PHP} ${OPTIONS} ./bin/phpunit ${ARGS}
-	make test_e2e ARGS="${PLAYWRIGHT_ARGS}"
 
 test_cov: ## Run the test suite (with code coverage)
-	make test OPTIONS="-d xdebug.mode=coverage" ARGS="--coverage-html coverage --coverage-clover coverage.xml"
+	make test OPTIONS="-d xdebug.mode=coverage" ARGS="${ARGS} --coverage-html coverage --coverage-clover coverage.xml"
 
 test_unit: ## Run unit tests only
 	${BIN_PHP} ./bin/phpunit --testsuite=Unit ${ARGS}
@@ -222,6 +221,10 @@ test_e2e: ## Run end-to-end tests only
 	$(BIN_NPX) playwright test --project desktop-firefox ${ARGS}
 	make dbfixtures
 	$(BIN_NPX) playwright test --project mobile-chromium ${ARGS}
+
+test_all: ## Run the test suite (with coverage) and E2E tests
+	make test_cov
+	make test_e2e ARGS="${PLAYWRIGHT_ARGS}"
 
 report_e2e: ## Open the Playwright HTML report
 	xdg-open playwright-report/index.html
@@ -253,7 +256,7 @@ ci: ## Run CI steps
 	make dbfixtures
 	make blog_install
 	make check
-	make test_cov
+	make test_all
 
 ##
 ## ----------------


### PR DESCRIPTION
Dans cette PR:

* Création d'une commande `test_all` qui lance les tests PHPUnit ET les tests E2E. La commande `make test` ne lance donc plus que les tests PHPUnit.
  * D'une part car `make test_cov` lance `make test` mais on n'a pas de mesure de couverture sur les tests E2E, donc ce n'est pas très logique.
  * D'autre part car quand je lance `make test_cov` (donc `make test`) pour voir le coverage avant de push sur la CI, je ne souhaite pas lancer les tests E2E (je les arrête quasi systématiquement)
* On peut désormais passer des `ARGS` à `make test_cov`, par exemple pour faire `make test_cov ARGS="--testsuite=Unit"` pour mesurer le coverage sur les tests unitaires sans lancer les tests d'intégration (ou inversement), afin de gagner du temps