### PR TITLE
Skip data_install in scalingo-postdeploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,6 +268,3 @@ scalingo-node-postbuild:
 scalingo-postdeploy:
 	@echo 'Executing migrations...'
 	${BIN_CONSOLE} doctrine:migrations:migrate --no-interaction
-
-	@echo 'Installing data...'
-	make data_install


### PR DESCRIPTION
Ça fait plusieurs fois que le déploiement Scalingo échoue sur une PR de branche

En cause, l'exécution du chargement des données `fr_city`

```console
{"class":"PDOException","message":"SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: EOF detected","code":0,"file":"/app/vendor/doctrine/dbal/src/Driver/PDO/Connection.php:32"}}},"command":"app:data:fr_city","message":"An exception occurred while executing a query: SQLSTATE[HY000]: General error: 7 SSL SYSCALL error: EOF detected"},"level":500,
```

Ça peut empêcher aussi de déployer main...

Vu qu'on n'utilise jamais ces données (on les a juste utilisées pour la migration des codes Insee), cette PR arrête de l'exécution dans le déploiement