### PR TITLE
Calcule automatiquement l'état de la case "Voie entière"

### DIFF
--- a/config/validator/Application/Regulation/Command/SaveRegulationLocationCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveRegulationLocationCommand.xml
@@ -25,7 +25,7 @@
                 </option>
             </constraint>
         </property>
-        <property name="isEntireStreet">
+        <getter property="isEntireStreet">
             <constraint name="Type">
                 <option name="type">boolean</option>
             </constraint>
@@ -49,7 +49,7 @@
                     </constraint>
                 </option>
             </constraint>
-        </property>
+        </getter>
         <property name="cityCode">
             <constraint name="Length">
                 <option name="min">5</option>

--- a/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
+++ b/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
@@ -64,7 +64,6 @@ final class DuplicateRegulationCommandHandler
             $locationCommand->cityCode = $location->getCityCode();
             $locationCommand->cityLabel = $location->getCityLabel();
             $locationCommand->roadName = $location->getRoadNAme();
-            $locationCommand->isEntireStreet = $location->getIsEntireStreet();
             $locationCommand->fromHouseNumber = $location->getFromHouseNumber();
             $locationCommand->toHouseNumber = $location->getToHouseNumber();
             $locationCommand->geometry = $location->getGeometry();

--- a/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
+++ b/src/Application/Regulation/Command/SaveRegulationLocationCommand.php
@@ -17,10 +17,10 @@ final class SaveRegulationLocationCommand implements CommandInterface
     public ?string $cityCode = null;
     public ?string $cityLabel = null;
     public ?string $roadName = null;
-    public ?bool $isEntireStreet = null;
     public ?string $fromHouseNumber = null;
     public ?string $toHouseNumber = null;
     public ?string $geometry;
+    private ?bool $isEntireStreetFormValue = null;
 
     /** @var SaveMeasureCommand[] */
     public array $measures = [];
@@ -39,7 +39,6 @@ final class SaveRegulationLocationCommand implements CommandInterface
         $command->roadType = $location?->getRoadType();
         $command->administrator = $location?->getAdministrator();
         $command->roadNumber = $location?->getRoadNumber();
-        $command->isEntireStreet = $location ? $location->getIsEntireStreet() : true;
         $command->cityCode = $location?->getCityCode();
         $command->cityLabel = $location?->getCityLabel();
         $command->roadName = $location?->getRoadName();
@@ -72,9 +71,25 @@ final class SaveRegulationLocationCommand implements CommandInterface
             $this->roadNumber = null;
         }
 
-        if ($this->roadType === RoadTypeEnum::LANE->value && $this->isEntireStreet) {
+        if ($this->roadType === RoadTypeEnum::LANE->value && $this->isEntireStreetFormValue) {
             $this->fromHouseNumber = null;
             $this->toHouseNumber = null;
         }
+    }
+
+    // Used by validation layer
+
+    public function getIsEntireStreet(): bool
+    {
+        if ($this->isEntireStreetFormValue !== null) {
+            return $this->isEntireStreetFormValue;
+        }
+
+        return !$this->fromHouseNumber && !$this->toHouseNumber;
+    }
+
+    public function setIsEntireStreet(bool $value): void
+    {
+        $this->isEntireStreetFormValue = $value;
     }
 }

--- a/src/Domain/Regulation/Location.php
+++ b/src/Domain/Regulation/Location.php
@@ -81,11 +81,6 @@ class Location
         return $this->toHouseNumber;
     }
 
-    public function getIsEntireStreet(): bool
-    {
-        return \is_null($this->fromHouseNumber) && \is_null($this->toHouseNumber);
-    }
-
     public function getGeometry(): ?string
     {
         return $this->geometry;

--- a/tests/Unit/Application/Regulation/Command/SaveRegulationLocationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/SaveRegulationLocationCommandHandlerTest.php
@@ -51,7 +51,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $this->administrator = null;
         $this->roadNumber = null;
         $this->roadName = 'Route du Grand Brossais';
-        $this->isEntireStreet = false;
         $this->fromHouseNumber = '15';
         $this->toHouseNumber = '37bis';
         $this->geometry = GeoJSON::toLineString([
@@ -142,7 +141,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $command->cityCode = $this->cityCode;
         $command->cityLabel = $this->cityLabel;
         $command->roadName = $this->roadName;
-        $command->isEntireStreet = $this->isEntireStreet;
         $command->fromHouseNumber = $this->fromHouseNumber;
         $command->toHouseNumber = $this->toHouseNumber;
         $command->measures = [
@@ -225,7 +223,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $command->cityCode = $this->cityCode;
         $command->cityLabel = $this->cityLabel;
         $command->roadName = $this->roadName;
-        $command->isEntireStreet = true;
         $command->fromHouseNumber = null;
         $command->toHouseNumber = null;
         $command->measures = [
@@ -326,7 +323,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $command->cityCode = $this->cityCode;
         $command->cityLabel = $this->cityLabel;
         $command->roadName = $this->roadName;
-        $command->isEntireStreet = $this->isEntireStreet;
         $command->fromHouseNumber = $this->fromHouseNumber;
         $command->toHouseNumber = $this->toHouseNumber;
         $command->measures = [
@@ -378,7 +374,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $command->cityCode = $this->cityCode;
         $command->cityLabel = $this->cityLabel;
         $command->roadName = $this->roadName;
-        $command->isEntireStreet = true;
         $command->fromHouseNumber = null;
         $command->toHouseNumber = null;
 
@@ -428,7 +423,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $command->cityCode = $this->cityCode;
         $command->cityLabel = $this->cityLabel;
         $command->roadName = $this->roadName;
-        $command->isEntireStreet = false;
         $command->fromHouseNumber = '137';
         $command->toHouseNumber = null;
 
@@ -513,7 +507,6 @@ final class SaveRegulationLocationCommandHandlerTest extends TestCase
         $command->cityCode = $this->cityCode;
         $command->cityLabel = $this->cityLabel;
         $command->roadName = $this->roadName;
-        $command->isEntireStreet = $this->isEntireStreet;
         $command->fromHouseNumber = $this->fromHouseNumber;
         $command->toHouseNumber = $this->toHouseNumber;
 


### PR DESCRIPTION
* Correctif suite à #633 

L'import Eudonet échoue parce que j'ai oublié de donner une valeur pour `isEntireStreet` dans `EudonetParisTransformer`

Sauf que je ne devrais pas avoir à le faire : en dehors du contexte d'un formulaire, `isEntireStreet` devrait être calculé automatiquement à partir de `fromHouseNumber` et `toHouseNumber`

En réalité `isEntireStreet` n'est donc pas un champ "autonome"

Cette PR le transforme en [getter](https://symfony.com/doc/current/validation.html#getters) qui vaut soit la valeur "de formulaire" donnée explicitement (`isEntireStreetFormValue`), ou bien le calcul par défaut `!fromHouseNumber && !toHouseNumber`