### PR TITLE
Pré-géocode les voies nommées en arrière-plan

### DIFF
--- a/assets/controllers/fetch_controller.js
+++ b/assets/controllers/fetch_controller.js
@@ -1,0 +1,55 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+    static outlets = ['output'];
+    static values = {
+        trigger: String,
+        url: String,
+        queryParams: {
+            type: Object,
+            default: undefined,
+        },
+    };
+
+    connect() {
+        this.element.addEventListener(this.triggerValue, this.#onTrigger);
+    }
+
+    disconnect() {
+        this.element.removeEventListener(this.triggerValue, this.#onTrigger);
+    }
+
+    #onTrigger = async () => {
+        const params = new URLSearchParams();
+
+        if (this.queryParamsValue) {
+            for (let [name, value] of Object.entries(this.queryParamsValue)) {
+                if (value.startsWith('#')) {
+                    value = document.querySelector(value).value;
+                }
+
+                params.append(name, value);
+            }
+        }
+
+        const url = `${this.urlValue}?${params.toString()}`;
+
+        try {
+            const response = await fetch(url);
+
+            if (!response.ok) {
+                console.error(`${response.status} ${response.statusText}`);
+                return;
+            }
+
+            const tmpDiv = document.createElement('div');
+            tmpDiv.innerHTML = await response.text();
+            const output = /** @type {HTMLOutputElement} */ (tmpDiv.querySelector('output'));
+
+            this.outputOutletElement.value = output.value;
+        } catch (error) {
+            console.error(`Error: ${error}`);
+            return;
+        }
+    };
+}

--- a/assets/controllers/output_controller.js
+++ b/assets/controllers/output_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {}

--- a/src/Application/Regulation/Command/Location/SaveLocationNewCommand.php
+++ b/src/Application/Regulation/Command/Location/SaveLocationNewCommand.php
@@ -17,6 +17,7 @@ final class SaveLocationNewCommand implements CommandInterface
     public ?string $cityCode = null;
     public ?string $cityLabel = null;
     public ?string $roadName = null;
+    public ?string $preComputedRoadGeometry = null;
     public ?string $fromHouseNumber = null;
     public ?string $toHouseNumber = null;
     public ?string $geometry;

--- a/src/Application/Regulation/Command/Location/SaveLocationNewCommandHandler.php
+++ b/src/Application/Regulation/Command/Location/SaveLocationNewCommandHandler.php
@@ -85,7 +85,7 @@ final class SaveLocationNewCommandHandler
         $cityCode = $command->cityCode;
 
         if (!$command->fromHouseNumber && !$command->toHouseNumber && $roadName) {
-            return $this->roadGeocoder->computeRoadLine($roadName, $cityCode);
+            return $command->preComputedRoadGeometry ?? $this->roadGeocoder->computeRoadLine($roadName, $cityCode);
         }
 
         return null;

--- a/src/Application/Regulation/Query/GetRoadGeometryQuery.php
+++ b/src/Application/Regulation/Query/GetRoadGeometryQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\Query;
+
+use App\Application\QueryInterface;
+
+final readonly class GetRoadGeometryQuery implements QueryInterface
+{
+    public function __construct(
+        public readonly string $roadName,
+        public readonly string $cityCode,
+    ) {
+    }
+}

--- a/src/Application/Regulation/Query/GetRoadGeometryQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRoadGeometryQueryHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\Query;
+
+use App\Application\RoadGeocoderInterface;
+
+final class GetRoadGeometryQueryHandler
+{
+    public function __construct(
+        private RoadGeocoderInterface $roadGeocoder,
+    ) {
+    }
+
+    public function __invoke(GetRoadGeometryQuery $query): string
+    {
+        return $this->roadGeocoder->computeRoadLine($query->roadName, $query->cityCode);
+    }
+}

--- a/src/Infrastructure/Controller/Api/Internal/GetRoadGeometryController.php
+++ b/src/Infrastructure/Controller/Api/Internal/GetRoadGeometryController.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Controller\Api\Internal;
+
+use App\Application\QueryBusInterface;
+use App\Application\Regulation\Query\GetRoadGeometryQuery;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class GetRoadGeometryController
+{
+    public function __construct(
+        private \Twig\Environment $twig,
+        private QueryBusInterface $queryBus,
+    ) {
+    }
+
+    #[Route(
+        '/api/internal/road_geometry',
+        methods: 'GET',
+        name: 'api_internal_roadGeometry',
+    )]
+    public function __invoke(Request $request): Response
+    {
+        $roadName = $request->query->get('roadName');
+        $cityCode = $request->query->get('cityCode');
+
+        $geometry = $this->queryBus->handle(new GetRoadGeometryQuery($roadName, $cityCode));
+
+        return new Response(
+            $this->twig->render('common/fetch_result.html.twig', [
+                'value' => $geometry,
+            ]),
+        );
+    }
+}

--- a/src/Infrastructure/Form/Regulation/LocationNewFormType.php
+++ b/src/Infrastructure/Form/Regulation/LocationNewFormType.php
@@ -75,6 +75,10 @@ final class LocationNewFormType extends AbstractType
                 ],
             )
             ->add(
+                'preComputedRoadGeometry',
+                HiddenType::class,
+            )
+            ->add(
                 'isEntireStreet',
                 CheckboxType::class,
                 options: [

--- a/templates/common/fetch_result.html.twig
+++ b/templates/common/fetch_result.html.twig
@@ -1,0 +1,1 @@
+<output>{{ value }}</output>

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -237,11 +237,19 @@
                 </div>
                 <div
                     class="fr-x-autocomplete-wrapper"
-                    data-controller="autocomplete"
+                    data-controller="autocomplete fetch"
                     data-autocomplete-url-value="{{ path('fragment_roadName_completion') }}"
                     data-autocomplete-query-param-value="search"
                     data-autocomplete-extra-query-params-value="{{ {cityCode: '#' ~ form.cityCode.vars.id}|json_encode }}"
-                    data-autocomplete-min-length-value="3" data-autocomplete-delay-value="500"
+                    data-autocomplete-min-length-value="3"
+                    data-autocomplete-delay-value="500"
+                    data-fetch-trigger-value="autocomplete.change"
+                    data-fetch-url-value="{{ path('api_internal_roadGeometry') }}"
+                    data-fetch-query-params-value="{{ {
+                        roadName: '#' ~ form.roadName.vars.id,
+                        cityCode: '#' ~ form.cityCode.vars.id,
+                    }|json_encode }}"
+                    data-fetch-output-outlet="#{{ form.preComputedRoadGeometry.vars.id }}"
                 >
                     {{ form_row(form.roadName, {
                         group_class: 'fr-input-group',
@@ -258,6 +266,12 @@
                         data-autocomplete-target="results"
                     ></ul>
                 </div>
+
+                {{ form_row(form.preComputedRoadGeometry, {
+                    attr: {
+                        'data-controller': 'output',
+                    },
+                }) }}
 
                 <div data-controller="form-reveal">
                     {{ form_row(form.isEntireStreet, {


### PR DESCRIPTION
* Refs #639 

J'étais parti pour explorer la faisabilité technique de l'option 2) imaginée dans #639, et finalement j'ai eu assez vite une solution aboutie, la voici donc en PR.

TODO si on voulait merger :

* [ ] Gérer les erreurs : afficher l'erreur sans remplir le champ caché ; si l'utilisateur soumet quand même, le back va refaire la requête et renvoyer l'erreur à nouveau, et au mieux l'erreur était transitoire et ça passe.
* [ ] Sécuriser en utilisant une signature de la valeur pré-calculée
* [ ] Tests