### PR TITLE
Fix mergeDateAndTime timezone handling

### DIFF
--- a/src/Application/DateUtilsInterface.php
+++ b/src/Application/DateUtilsInterface.php
@@ -12,5 +12,5 @@ interface DateUtilsInterface
 
     public function getMicroTime(): float;
 
-    public function mergeDateAndTime(\DateTimeInterface $date1, \DateTimeInterface $date2): \DateTimeInterface;
+    public function mergeDateAndTime(\DateTimeInterface $date, \DateTimeInterface $time): \DateTimeInterface;
 }

--- a/tests/Unit/Infrastructure/Adapter/DateUtilsTest.php
+++ b/tests/Unit/Infrastructure/Adapter/DateUtilsTest.php
@@ -11,30 +11,30 @@ final class DateUtilsTest extends TestCase
 {
     public function testTomorrow(): void
     {
-        $dateUtils = new DateUtils('Europe/Paris');
+        $dateUtils = new DateUtils('Etc/GMT-1');
 
         $this->assertEquals(new \DateTimeImmutable('tomorrow'), $dateUtils->getTomorrow());
     }
 
     public function testNow(): void
     {
-        $dateUtils = new DateUtils('Europe/Paris');
+        $dateUtils = new DateUtils('Etc/GMT-1');
 
         $this->assertEquals((new \DateTimeImmutable('now'))->format('Y-m-d'), $dateUtils->getNow()->format('Y-m-d'));
     }
 
     public function testGetMicroTime(): void
     {
-        $dateUtils = new DateUtils('Europe/Paris');
+        $dateUtils = new DateUtils('Etc/GMT-1');
 
         $this->assertEqualsWithDelta(microtime(true), $dateUtils->getMicroTime(), 0.1);
     }
 
     public function testMergeDateAndTime(): void
     {
-        $dateUtils = new DateUtils('Europe/Paris');
-        $date1 = new \DateTime('2023-10-10');
-        $date2 = new \DateTime('2023-10-10 08:00:00');
+        $dateUtils = new DateUtils('Etc/GMT-1');
+        $date1 = new \DateTime('2023-10-09 23:00:00 UTC');
+        $date2 = new \DateTime('08:00:00');
 
         $this->assertEquals(new \DateTime('2023-10-10 08:00:00'), $dateUtils->mergeDateAndTime($date1, $date2));
     }


### PR DESCRIPTION
Closes #652 

Il fallait réaliser la fusion de la date et de l'heure dans le fuseau horaire de l'utilisateur, et pas en UTC.