### PR TITLE
Déplace le géocodage des intersections Eudonet vers SaveLocationCommandHandler

### DIFF
--- a/src/Application/EudonetParis/Command/ImportEudonetParisRegulationCommandHandler.php
+++ b/src/Application/EudonetParis/Command/ImportEudonetParisRegulationCommandHandler.php
@@ -31,7 +31,7 @@ final class ImportEudonetParisRegulationCommandHandler
             try {
                 $measure = $this->commandBus->handle($measureCommand);
             } catch (GeocodingFailureException $exc) {
-                throw new ImportEudonetParisRegulationFailedException($exc->getMessage());
+                throw new ImportEudonetParisRegulationFailedException($exc->getMessage(), previous: $exc);
             }
 
             $regulationOrder->addMeasure($measure);
@@ -40,7 +40,7 @@ final class ImportEudonetParisRegulationCommandHandler
         try {
             $this->commandBus->handle(new PublishRegulationCommand($regulationOrderRecord));
         } catch (RegulationOrderRecordCannotBePublishedException $exc) {
-            throw new ImportEudonetParisRegulationFailedException($exc->getMessage());
+            throw new ImportEudonetParisRegulationFailedException($exc->getMessage(), previous: $exc);
         }
     }
 }

--- a/src/Application/Regulation/Command/Location/SaveLocationCommand.php
+++ b/src/Application/Regulation/Command/Location/SaveLocationCommand.php
@@ -18,7 +18,9 @@ final class SaveLocationCommand implements CommandInterface
     public ?string $cityLabel = null;
     public ?string $roadName = null;
     public ?string $fromHouseNumber = null;
+    public ?string $fromRoadName = null;
     public ?string $toHouseNumber = null;
+    public ?string $toRoadName = null;
     public ?string $geometry;
     public ?Measure $measure;
     private ?bool $isEntireStreetFormValue = null;

--- a/src/Application/Regulation/Command/Location/SaveLocationCommandHandler.php
+++ b/src/Application/Regulation/Command/Location/SaveLocationCommandHandler.php
@@ -71,21 +71,38 @@ final class SaveLocationCommandHandler
 
     private function computeGeometry(SaveLocationCommand $command): ?string
     {
-        if ($command->fromHouseNumber && $command->toHouseNumber) {
-            $fromAddress = sprintf('%s %s', $command->fromHouseNumber, $command->roadName);
-            $toAddress = sprintf('%s %s', $command->toHouseNumber, $command->roadName);
+        $hasBothEnds = (
+            ($command->fromHouseNumber || $command->fromRoadName)
+            && ($command->toHouseNumber || $command->toRoadName)
+        );
 
-            $fromCoords = $this->geocoder->computeCoordinates($fromAddress, $command->cityCode);
-            $toCoords = $this->geocoder->computeCoordinates($toAddress, $command->cityCode);
+        if ($hasBothEnds) {
+            if ($command->fromHouseNumber) {
+                $fromAddress = sprintf('%s %s', $command->fromHouseNumber, $command->roadName);
+                $fromCoords = $this->geocoder->computeCoordinates($fromAddress, $command->cityCode);
+            } else {
+                $fromCoords = $this->geocoder->computeJunctionCoordinates($command->roadName, $command->fromRoadName, $command->cityCode);
+            }
+
+            if ($command->toHouseNumber) {
+                $toAddress = sprintf('%s %s', $command->toHouseNumber, $command->roadName);
+                $toCoords = $this->geocoder->computeCoordinates($toAddress, $command->cityCode);
+            } else {
+                $toCoords = $this->geocoder->computeJunctionCoordinates($command->roadName, $command->toRoadName, $command->cityCode);
+            }
 
             return GeoJSON::toLineString([$fromCoords, $toCoords]);
         }
 
-        $roadName = $command->roadName;
-        $cityCode = $command->cityCode;
+        $hasNoEnds = (
+            !$command->fromHouseNumber
+            && !$command->fromRoadName
+            && !$command->toHouseNumber
+            && !$command->toRoadName
+        );
 
-        if (!$command->fromHouseNumber && !$command->toHouseNumber && $roadName) {
-            return $this->roadGeocoder->computeRoadLine($roadName, $cityCode);
+        if ($hasNoEnds && $command->roadName) {
+            return $this->roadGeocoder->computeRoadLine($command->roadName, $command->cityCode);
         }
 
         return null;

--- a/tests/Unit/Infrastructure/EudonetParis/EudonetParisTransformerTest.php
+++ b/tests/Unit/Infrastructure/EudonetParis/EudonetParisTransformerTest.php
@@ -5,14 +5,10 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Infrastructure\EudonetParis;
 
 use App\Application\EudonetParis\Command\ImportEudonetParisRegulationCommand;
-use App\Application\Exception\GeocodingFailureException;
-use App\Application\GeocoderInterface;
 use App\Application\Regulation\Command\Location\SaveLocationCommand;
 use App\Application\Regulation\Command\SaveMeasureCommand;
 use App\Application\Regulation\Command\SaveRegulationGeneralInfoCommand;
 use App\Application\Regulation\Command\VehicleSet\SaveVehicleSetCommand;
-use App\Domain\Geography\Coordinates;
-use App\Domain\Geography\GeoJSON;
 use App\Domain\Regulation\Enum\MeasureTypeEnum;
 use App\Domain\Regulation\Enum\RegulationOrderCategoryEnum;
 use App\Domain\User\Organization;
@@ -23,13 +19,6 @@ use PHPUnit\Framework\TestCase;
 
 final class EudonetParisTransformerTest extends TestCase
 {
-    private $geocoder;
-
-    protected function setUp(): void
-    {
-        $this->geocoder = $this->createMock(GeocoderInterface::class);
-    }
-
     public function testTransform(): void
     {
         $roadName = 'Rue Eugène Berthoud';
@@ -96,11 +85,7 @@ final class EudonetParisTransformerTest extends TestCase
         $importCommand = new ImportEudonetParisRegulationCommand($generalInfoCommand, [$measureCommand]);
         $result = new EudonetParisTransformerResult($importCommand, []);
 
-        $this->geocoder
-            ->expects(self::never())
-            ->method('computeJunctionCoordinates');
-
-        $transformer = new EudonetParisTransformer($this->geocoder);
+        $transformer = new EudonetParisTransformer();
 
         $this->assertEquals($result, $transformer->transform($record, $organization));
     }
@@ -151,7 +136,7 @@ final class EudonetParisTransformerTest extends TestCase
             ],
         ];
 
-        $transformer = new EudonetParisTransformer($this->geocoder);
+        $transformer = new EudonetParisTransformer();
         $result = $transformer->transform($record, $organization);
 
         $this->assertEquals(
@@ -173,118 +158,6 @@ final class EudonetParisTransformerTest extends TestCase
                 'porteSur' => 'Un axe',
             ],
         ];
-    }
-
-    /**
-     * @dataProvider provideTransformHouseNumberAndJunction
-     */
-    public function testTransformHouseNumberAndJunction(string $porteSur): void
-    {
-        $organization = $this->createMock(Organization::class);
-
-        $record = [
-            'fields' => [
-                EudonetParisExtractor::ARRETE_ID => '20230514-1',
-                EudonetParisExtractor::ARRETE_DATE_DEBUT => '2023/06/05 14:30:00',
-                EudonetParisExtractor::ARRETE_DATE_FIN => '2023/07/12 18:00:00',
-                EudonetParisExtractor::ARRETE_TYPE => 'Temporaire',
-                EudonetParisExtractor::ARRETE_COMPLEMENT_DE_TITRE => 'Description',
-            ],
-            'measures' => [
-                [
-                    'fields' => [
-                        EudonetParisExtractor::MESURE_ID => 'mesure1',
-                        EudonetParisExtractor::MESURE_NOM => 'circulation interdite',
-                    ],
-                    'locations' => [
-                        [
-                            'fields' => [
-                                EudonetParisExtractor::LOCALISATION_ID => 'localisation1',
-                                EudonetParisExtractor::LOCALISATION_PORTE_SUR => $porteSur,
-                                EudonetParisExtractor::LOCALISATION_ARRONDISSEMENT => '18ème Arrondissement',
-                                EudonetParisExtractor::LOCALISATION_LIBELLE_VOIE => 'Rue Eugène Berthoud',
-                                EudonetParisExtractor::LOCALISATION_LIBELLE_VOIE_DEBUT => 'Rue Jean Perrin',
-                                EudonetParisExtractor::LOCALISATION_LIBELLE_VOIE_FIN => null,
-                                EudonetParisExtractor::LOCALISATION_N_ADRESSE_DEBUT => null,
-                                EudonetParisExtractor::LOCALISATION_N_ADRESSE_FIN => '26',
-                            ],
-                        ],
-                        [
-                            'fields' => [
-                                EudonetParisExtractor::LOCALISATION_ID => 'localisation1',
-                                EudonetParisExtractor::LOCALISATION_PORTE_SUR => $porteSur,
-                                EudonetParisExtractor::LOCALISATION_ARRONDISSEMENT => '18ème Arrondissement',
-                                EudonetParisExtractor::LOCALISATION_LIBELLE_VOIE => 'Rue Eugène Berthoud',
-                                EudonetParisExtractor::LOCALISATION_LIBELLE_VOIE_DEBUT => null,
-                                EudonetParisExtractor::LOCALISATION_LIBELLE_VOIE_FIN => 'Rue Adrien Lesesne',
-                                EudonetParisExtractor::LOCALISATION_N_ADRESSE_DEBUT => '15',
-                                EudonetParisExtractor::LOCALISATION_N_ADRESSE_FIN => null,
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
-
-        $rueEugeneBerthoudXRueJeanPerrin = Coordinates::fromLonLat(2.3453101, 48.9062362);
-        $rueEugeneBerthoud26 = Coordinates::fromLonLat(2.3453431, 48.9062625);
-        $locationCommand1 = new SaveLocationCommand();
-        $locationCommand1->roadType = 'lane';
-        $locationCommand1->cityCode = '75118';
-        $locationCommand1->cityLabel = 'Paris';
-        $locationCommand1->roadName = 'Rue Eugène Berthoud';
-        $locationCommand1->fromHouseNumber = null;
-        $locationCommand1->toHouseNumber = '26';
-        $locationCommand1->geometry = GeoJSON::toLineString([
-            $rueEugeneBerthoudXRueJeanPerrin,
-            $rueEugeneBerthoud26,
-        ]);
-
-        $rueEugeneBerthoud15 = Coordinates::fromLonLat(2.3453412, 48.9062610);
-        $rueEugeneBerthoudXRueAdrienLesesne = Coordinates::fromLonLat(2.34944, 48.9045598);
-        $locationCommand2 = new SaveLocationCommand();
-        $locationCommand2->roadType = 'lane';
-        $locationCommand2->cityCode = '75118';
-        $locationCommand2->cityLabel = 'Paris';
-        $locationCommand2->roadName = 'Rue Eugène Berthoud';
-        $locationCommand2->fromHouseNumber = '15';
-        $locationCommand2->toHouseNumber = null;
-        $locationCommand2->geometry = GeoJSON::toLineString([
-            $rueEugeneBerthoud15,
-            $rueEugeneBerthoudXRueAdrienLesesne,
-        ]);
-
-        $vehicleSet = new SaveVehicleSetCommand();
-        $vehicleSet->allVehicles = true;
-
-        $measureCommand = new SaveMeasureCommand();
-        $measureCommand->type = MeasureTypeEnum::NO_ENTRY->value;
-        $measureCommand->vehicleSet = $vehicleSet;
-        $measureCommand->locations = [$locationCommand1, $locationCommand2];
-
-        $matcher = self::exactly(2);
-        $this->geocoder
-            ->expects($matcher)
-            ->method('computeJunctionCoordinates')
-            ->willReturnCallback(fn ($address, $roadName) => match ($matcher->getInvocationCount()) {
-                1 => $this->assertEquals(['Rue Eugène Berthoud', 'Rue Jean Perrin'], [$address, $roadName]) ?: $rueEugeneBerthoudXRueJeanPerrin,
-                2 => $this->assertEquals(['Rue Eugène Berthoud', 'Rue Adrien Lesesne'], [$address, $roadName]) ?: $rueEugeneBerthoudXRueAdrienLesesne,
-            });
-
-        $matcher = self::exactly(2);
-        $this->geocoder
-            ->expects($matcher)
-            ->method('computeCoordinates')
-            ->willReturnCallback(fn ($address) => match ($matcher->getInvocationCount()) {
-                1 => $this->assertEquals('26 Rue Eugène Berthoud', $address) ?: $rueEugeneBerthoud26,
-                2 => $this->assertEquals('15 Rue Eugène Berthoud', $address) ?: $rueEugeneBerthoud15,
-            });
-
-        $transformer = new EudonetParisTransformer($this->geocoder);
-
-        $result = $transformer->transform($record, $organization);
-
-        $this->assertEquals([$measureCommand], $result->command->measureCommands);
     }
 
     public function testSkipNoMeasures(): void
@@ -310,15 +183,7 @@ final class EudonetParisTransformerTest extends TestCase
             ],
         ]);
 
-        $this->geocoder
-            ->expects(self::never())
-            ->method('computeJunctionCoordinates');
-
-        $this->geocoder
-            ->expects(self::never())
-            ->method('computeCoordinates');
-
-        $transformer = new EudonetParisTransformer($this->geocoder);
+        $transformer = new EudonetParisTransformer();
 
         $this->assertEquals($result, $transformer->transform($record, $organization));
     }
@@ -361,15 +226,7 @@ final class EudonetParisTransformerTest extends TestCase
             ],
         ]);
 
-        $this->geocoder
-            ->expects(self::never())
-            ->method('computeJunctionCoordinates');
-
-        $this->geocoder
-            ->expects(self::never())
-            ->method('computeCoordinates');
-
-        $transformer = new EudonetParisTransformer($this->geocoder);
+        $transformer = new EudonetParisTransformer();
 
         $this->assertEquals($result, $transformer->transform($record, $organization));
     }
@@ -431,15 +288,7 @@ final class EudonetParisTransformerTest extends TestCase
             ],
         ]);
 
-        $this->geocoder
-            ->expects(self::never())
-            ->method('computeJunctionCoordinates');
-
-        $this->geocoder
-            ->expects(self::never())
-            ->method('computeCoordinates');
-
-        $transformer = new EudonetParisTransformer($this->geocoder);
+        $transformer = new EudonetParisTransformer();
 
         $this->assertEquals($result, $transformer->transform($record, $organization));
     }
@@ -555,15 +404,7 @@ final class EudonetParisTransformerTest extends TestCase
             ],
         ]);
 
-        $this->geocoder
-            ->expects(self::never())
-            ->method('computeJunctionCoordinates');
-
-        $this->geocoder
-            ->expects(self::never())
-            ->method('computeCoordinates');
-
-        $transformer = new EudonetParisTransformer($this->geocoder);
+        $transformer = new EudonetParisTransformer();
 
         $this->assertEquals($result, $transformer->transform($record, $organization));
     }
@@ -628,78 +469,7 @@ final class EudonetParisTransformerTest extends TestCase
 
         $result = new EudonetParisTransformerResult(null, $errors);
 
-        $transformer = new EudonetParisTransformer($this->geocoder);
-
-        $this->assertEquals($result, $transformer->transform($record, $organization));
-    }
-
-    public function testSkipGeocodingFailure(): void
-    {
-        $organization = $this->createMock(Organization::class);
-
-        $record = [
-            'fields' => [
-                EudonetParisExtractor::ARRETE_ID => '20230514-1',
-                EudonetParisExtractor::ARRETE_DATE_DEBUT => '2023/06/05 14:30:00',
-                EudonetParisExtractor::ARRETE_DATE_FIN => '2023/07/12 18:00:00',
-                EudonetParisExtractor::ARRETE_TYPE => 'Temporaire',
-                EudonetParisExtractor::ARRETE_COMPLEMENT_DE_TITRE => str_repeat('a', 256),
-            ],
-            'measures' => [
-                [
-                    'fields' => [
-                        EudonetParisExtractor::MESURE_ID => 'mesure1',
-                        EudonetParisExtractor::MESURE_NOM => 'circulation interdite',
-                    ],
-                    'locations' => [
-                        [
-                            'fields' => [
-                                EudonetParisExtractor::LOCALISATION_ID => 'localisation1',
-                                EudonetParisExtractor::LOCALISATION_PORTE_SUR => 'Une section',
-                                EudonetParisExtractor::LOCALISATION_ARRONDISSEMENT => '18ème Arrondissement',
-                                EudonetParisExtractor::LOCALISATION_LIBELLE_VOIE => 'Rue Eugène Berthoud',
-                                EudonetParisExtractor::LOCALISATION_LIBELLE_VOIE_DEBUT => null,
-                                EudonetParisExtractor::LOCALISATION_LIBELLE_VOIE_FIN => null,
-                                EudonetParisExtractor::LOCALISATION_N_ADRESSE_DEBUT => '13',
-                                EudonetParisExtractor::LOCALISATION_N_ADRESSE_FIN => '19',
-                            ],
-                        ],
-                    ],
-                ],
-            ],
-        ];
-
-        $errors = [
-            [
-                'loc' => ['regulation_identifier' => '20230514-1'],
-                'impact' => 'skip_measure',
-                'reason' => 'measure_errors',
-                'errors' => [
-                    [
-                        'loc' => ['measure_id' => 'mesure1', 'location_id' => 'localisation1'],
-                        'reason' => 'geocoding_failure',
-                        'message' => 'Could not geocode',
-                        'index' => 2,
-                        'impact' => 'skip_location',
-                        'location_raw' => '{"fields":{"2701":"localisation1","2705":"Une section","2708":"18\u00e8me Arrondissement","2710":"Rue Eug\u00e8ne Berthoud","2730":null,"2740":null,"2720":"13","2737":"19"}}',
-                    ],
-                    [
-                        'loc' => ['measure_id' => 'mesure1', 'fieldname' => 'locations'],
-                        'reason' => 'no_locations_gathered',
-                        'impact' => 'skip_measure',
-                    ],
-                ],
-            ],
-        ];
-
-        $result = new EudonetParisTransformerResult(null, $errors);
-
-        $this->geocoder
-            ->expects(self::once())
-            ->method('computeCoordinates')
-            ->willThrowException(new GeocodingFailureException('Could not geocode', locationIndex: 2));
-
-        $transformer = new EudonetParisTransformer($this->geocoder);
+        $transformer = new EudonetParisTransformer();
 
         $this->assertEquals($result, $transformer->transform($record, $organization));
     }
@@ -719,7 +489,7 @@ final class EudonetParisTransformerTest extends TestCase
             'measures' => ['...'],
         ];
 
-        $transformer = new EudonetParisTransformer($this->geocoder);
+        $transformer = new EudonetParisTransformer();
         $result = new EudonetParisTransformerResult(
             null,
             [
@@ -750,7 +520,7 @@ final class EudonetParisTransformerTest extends TestCase
             'measures' => ['...'],
         ];
 
-        $transformer = new EudonetParisTransformer($this->geocoder);
+        $transformer = new EudonetParisTransformer();
         $result = new EudonetParisTransformerResult(
             null,
             [


### PR DESCRIPTION
* Remplace #656 

J'ai cru que le EudonetParisTransformer "oubliait" le cas du géocodage de la voie entière nommée

Mais en fait c'est juste qu'il traitait _seulement_ le cas des adresses (pour pouvoir géocoder les intersections), et qu'il laissait au code habituel le soin de géocoder les autres cas (dont la voie entière nommée)

Et alors je me suis demandé : mais pourquoi c'est pas le code habituel qui traiterait _aussi_ le cas des intersections ?

C'est l'objet de cette PR.

* Le comportement ne change pas : on ne saura géocoder les intersections que si Addok tourne en local. Sinon on aura une GeocodingFailureException avec les conséquences habituelles
* Comme on n'a pas encore les intersections dans l'UI (#419), le géocodage d'intersection ne peut se faire qu'à l'édition (car on ne stocke pas le from/toRoadName, comme c'était déjà le cas pour Eudonet)

Quel intérêt ?

* Concentrer le calcul géocodage en un seul endroit : `SaveLocationCommandHandler`
* Donc un code plus simple et plus maintenable
* Et moins de tests en double