### PR TITLE
Fix geocoder special characters

### DIFF
--- a/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
@@ -19,7 +19,7 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
 
     public function computeRoadLine(string $roadName, string $inseeCode): string
     {
-        $normalizedRoadName = str_replace(["'", '-', '’'], ["''", ' ', "'"], strtolower($roadName));
+        $normalizedRoadName = str_replace(["'", '-', '’'], ["''", ' ', "''"], strtolower($roadName));
 
         $query = [
             'SERVICE' => 'WFS',

--- a/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
@@ -19,7 +19,7 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
 
     public function computeRoadLine(string $roadName, string $inseeCode): string
     {
-        $normalizedRoadName = str_replace(["'", "-", "՚"], ["''", " ", "'"], strtolower($roadName));
+        $normalizedRoadName = str_replace(["'", '-', '’'], ["''", ' ', "'"], strtolower($roadName));
 
         $query = [
             'SERVICE' => 'WFS',
@@ -61,7 +61,7 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
             return json_encode($geometry);
         }
 
-        $message = sprintf('could not retrieve geometry for roadName="%s", inseeCode="%s", response was: %s', $roadName, $inseeCode, $body);
+        $message = sprintf('could not retrieve geometry for roadName="%s", inseeCode="%s", response was: %s', $normalizedRoadName, $inseeCode, $body);
         throw new GeocodingFailureException($message);
     }
 }

--- a/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
@@ -19,7 +19,7 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
 
     public function computeRoadLine(string $roadName, string $inseeCode): string
     {
-        $normalizedRoadName = str_replace("'", "''", strtolower($roadName));
+        $normalizedRoadName = str_replace(["'", '-'], ["''", ' '], strtolower($roadName));
 
         $query = [
             'SERVICE' => 'WFS',
@@ -27,7 +27,7 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
             'VERSION' => '2.0.0',
             'OUTPUTFORMAT' => 'application/json',
             'TYPENAME' => 'BDTOPO_V3:voie_nommee',
-            'cql_filter' => sprintf("strStripAccents(nom_minuscule)=strStripAccents('%s') AND code_insee='%s'", $normalizedRoadName, $inseeCode),
+            'cql_filter' => sprintf("strStripAccents(strReplace(nom_minuscule, '-', ' ', true))=strStripAccents(strReplace('%s', '-', ' ', true)) AND code_insee='%s'", $normalizedRoadName, $inseeCode),
             'PropertyName' => 'geometrie',
         ];
 

--- a/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
@@ -19,7 +19,7 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
 
     public function computeRoadLine(string $roadName, string $inseeCode): string
     {
-        $normalizedRoadName = str_replace(["'", '-'], ["''", ' '], strtolower($roadName));
+        $normalizedRoadName = str_replace(["'", "-", "՚"], ["''", " ", "'"], strtolower($roadName));
 
         $query = [
             'SERVICE' => 'WFS',

--- a/tests/Mock/IgnWfsMockClient.php
+++ b/tests/Mock/IgnWfsMockClient.php
@@ -26,7 +26,7 @@ final class IgnWfsMockClient extends MockHttpClient
 
     private function getWfsMock($options): MockResponse
     {
-        if (str_contains($options['query']['cql_filter'], "strStripAccents(nom_minuscule)=strStripAccents('rue saint-victor')")) {
+        if (str_contains($options['query']['cql_filter'], "strStripAccents(strReplace(nom_minuscule, '-', ' ', true))=strStripAccents(strReplace('rue saint victor', '-', ' ', true))")) {
             $body = [
                 'features' => [
                     [
@@ -46,7 +46,7 @@ final class IgnWfsMockClient extends MockHttpClient
                     ],
                 ],
             ];
-        } elseif (str_contains($options['query']['cql_filter'], "strStripAccents(nom_minuscule)=strStripAccents('rue monge')")) {
+        } elseif (str_contains($options['query']['cql_filter'], "strStripAccents(strReplace(nom_minuscule, '-', ' ', true))=strStripAccents(strReplace('rue monge', '-', ' ', true))")) {
             // E2E tests
             $body = [
                 'features' => [

--- a/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
+++ b/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
@@ -30,7 +30,7 @@ final class IgnWfsRoadGeocoderTest extends TestCase
         $this->assertSame('{"type":"MultiLineString","coordinates":["..."]}', $geometry);
         $this->assertSame('GET', $response->getRequestMethod());
         $this->assertSame(
-            'http://testserver/wfs/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=BDTOPO_V3:voie_nommee&cql_filter=strStripAccents(strReplace(nom_minuscule%2C%20%27-%27%2C%20%27%20%27%2C%20true))%3DstrStripAccents(strReplace(%27rue%20de%20l%27eglise%20saint%20victor%2059110%20la%20madeleine%27%2C%20%27-%27%2C%20%27%20%27%2C%20true))%20AND%20code_insee%3D%2759368%27&PropertyName=geometrie',
+            'http://testserver/wfs/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=BDTOPO_V3:voie_nommee&cql_filter=strStripAccents(strReplace(nom_minuscule%2C%20%27-%27%2C%20%27%20%27%2C%20true))%3DstrStripAccents(strReplace(%27rue%20de%20l%27%27eglise%20saint%20victor%2059110%20la%20madeleine%27%2C%20%27-%27%2C%20%27%20%27%2C%20true))%20AND%20code_insee%3D%2759368%27&PropertyName=geometrie',
             $response->getRequestUrl(),
         );
     }

--- a/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
+++ b/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
@@ -12,7 +12,7 @@ use Symfony\Component\HttpClient\Response\MockResponse;
 
 final class IgnWfsRoadGeocoderTest extends TestCase
 {
-    private string $address = 'Rue Saint-Victor 59110 La Madeleine';
+    private string $address = 'Rue de l’Eglise Saint-Victor 59110 La Madeleine';
     private string $inseeCode = '59368';
     private string $baseUrl = 'http://testserver';
     private string $ignWfsUrl = 'http://testserver/wfs/ows';
@@ -28,10 +28,9 @@ final class IgnWfsRoadGeocoderTest extends TestCase
         $geometry = $roadGeocoder->computeRoadLine($this->address, $this->inseeCode);
 
         $this->assertSame('{"type":"MultiLineString","coordinates":["..."]}', $geometry);
-
         $this->assertSame('GET', $response->getRequestMethod());
         $this->assertSame(
-            'http://testserver/wfs/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=BDTOPO_V3:voie_nommee&cql_filter=strStripAccents(strReplace(nom_minuscule%2C%20%27-%27%2C%20%27%20%27%2C%20true))%3DstrStripAccents(strReplace(%27rue%20saint%20victor%2059110%20la%20madeleine%27%2C%20%27-%27%2C%20%27%20%27%2C%20true))%20AND%20code_insee%3D%2759368%27&PropertyName=geometrie',
+            'http://testserver/wfs/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=BDTOPO_V3:voie_nommee&cql_filter=strStripAccents(strReplace(nom_minuscule%2C%20%27-%27%2C%20%27%20%27%2C%20true))%3DstrStripAccents(strReplace(%27rue%20de%20l%27eglise%20saint%20victor%2059110%20la%20madeleine%27%2C%20%27-%27%2C%20%27%20%27%2C%20true))%20AND%20code_insee%3D%2759368%27&PropertyName=geometrie',
             $response->getRequestUrl(),
         );
     }

--- a/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
+++ b/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
@@ -31,7 +31,7 @@ final class IgnWfsRoadGeocoderTest extends TestCase
 
         $this->assertSame('GET', $response->getRequestMethod());
         $this->assertSame(
-            'http://testserver/wfs/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=BDTOPO_V3:voie_nommee&cql_filter=strStripAccents(nom_minuscule)%3DstrStripAccents(%27rue%20saint-victor%2059110%20la%20madeleine%27)%20AND%20code_insee%3D%2759368%27&PropertyName=geometrie',
+            'http://testserver/wfs/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&OUTPUTFORMAT=application/json&TYPENAME=BDTOPO_V3:voie_nommee&cql_filter=strStripAccents(strReplace(nom_minuscule%2C%20%27-%27%2C%20%27%20%27%2C%20true))%3DstrStripAccents(strReplace(%27rue%20saint%20victor%2059110%20la%20madeleine%27%2C%20%27-%27%2C%20%27%20%27%2C%20true))%20AND%20code_insee%3D%2759368%27&PropertyName=geometrie',
             $response->getRequestUrl(),
         );
     }


### PR DESCRIPTION
Cette PR permet de corriger les problèmes de géocodage liés aux caractères `-` et `’`.