### PR TITLE
Corrige erreur SSH known_hosts lors de l'import Eudonet

### DIFF
--- a/.github/workflows/eudonet_paris_import.yml
+++ b/.github/workflows/eudonet_paris_import.yml
@@ -34,8 +34,13 @@ jobs:
       - name: Install SSH key
         # Credit: https://stackoverflow.com/a/69234389
         run: |
+          mkdir -p ~/.ssh
           install -m 600 -D /dev/null ~/.ssh/id_rsa
           echo "${{ secrets.GH_SCALINGO_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+
+      - name: Add Scalingo as a known host
+        run: |
+          ssh-keyscan -H ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
 
       - uses: actions/cache@v3
         id: addok-bundle-cache


### PR DESCRIPTION
Voir https://github.com/MTES-MCT/dialog/actions/runs/8143777720/job/22284278384

Je suppose que les lignes known_hosts de Scalingo peuvent changer entre deux exécutions (par ex si leurs IP changent, ou autre), ce qui peut créer l'erreur vue dans les logs de l'import

> Host key verification failed.

Cette PR fait en sorte qu'on enregistre proactivement le known_hosts le plus récent de Scalingo

Cette solution se base sur ce qu'ils recommandent pour les déploiements avec des CI autres que GitHub ou Gitlab, par ex https://doc.scalingo.com/platform/deployment/continuous-integration/deploy-scalingo-from-circle-ci