### PR TITLE
Gère les erreurs des réponses du géocodeur IGN

### DIFF
--- a/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
@@ -7,6 +7,7 @@ namespace App\Infrastructure\Adapter;
 use App\Application\Exception\GeocodingFailureException;
 use App\Application\RoadGeocoderInterface;
 use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
@@ -43,6 +44,9 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
         } catch (HttpExceptionInterface $exc) {
             $message = sprintf('invalid response: %s', $exc->getMessage());
             throw new GeocodingFailureException($message);
+        } catch (TransportExceptionInterface $exc) {
+            $message = sprintf('network error: %s', $exc->getMessage());
+            throw new GeocodingFailureException($message, previous: $exc);
         }
 
         try {

--- a/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/IgnWfsRoadGeocoder.php
@@ -6,8 +6,6 @@ namespace App\Infrastructure\Adapter;
 
 use App\Application\Exception\GeocodingFailureException;
 use App\Application\RoadGeocoderInterface;
-use Symfony\Contracts\HttpClient\Exception\HttpExceptionInterface;
-use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 
 final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
@@ -41,12 +39,9 @@ final class IgnWfsRoadGeocoder implements RoadGeocoderInterface
 
         try {
             $body = $response->getContent(throw: true);
-        } catch (HttpExceptionInterface $exc) {
-            $message = sprintf('invalid response: %s', $exc->getMessage());
+        } catch (\Exception $exc) {
+            $message = sprintf('error when reading response: %s: %s', (string) $exc, $exc->getMessage());
             throw new GeocodingFailureException($message);
-        } catch (TransportExceptionInterface $exc) {
-            $message = sprintf('network error: %s', $exc->getMessage());
-            throw new GeocodingFailureException($message, previous: $exc);
         }
 
         try {

--- a/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
+++ b/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
@@ -88,7 +88,7 @@ final class IgnWfsRoadGeocoderTest extends TestCase
     public function testNetworkError(): void
     {
         $this->expectException(GeocodingFailureException::class);
-        $this->expectExceptionMessageMatches('/^network error:/i');
+        $this->expectExceptionMessageMatches('/Idle timeout reached/i');
 
         $response = new MockResponse([new TransportException('Idle timeout reached')]);
         $http = new MockHttpClient([$response]);

--- a/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
+++ b/tests/Unit/Infrastructure/Adapter/IgnWfsRoadGeocoderTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Infrastructure\Adapter;
 use App\Application\Exception\GeocodingFailureException;
 use App\Infrastructure\Adapter\IgnWfsRoadGeocoder;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\Exception\TransportException;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
@@ -78,6 +79,18 @@ final class IgnWfsRoadGeocoderTest extends TestCase
         $this->expectExceptionMessageMatches($pattern);
 
         $response = new MockResponse($body, ['http_code' => 200]);
+        $http = new MockHttpClient([$response]);
+
+        $roadGeocoder = new IgnWfsRoadGeocoder($this->ignWfsUrl, $http);
+        $roadGeocoder->computeRoadLine($this->address, $this->inseeCode);
+    }
+
+    public function testNetworkError(): void
+    {
+        $this->expectException(GeocodingFailureException::class);
+        $this->expectExceptionMessageMatches('/^network error:/i');
+
+        $response = new MockResponse([new TransportException('Idle timeout reached')]);
         $http = new MockHttpClient([$response]);
 
         $roadGeocoder = new IgnWfsRoadGeocoder($this->ignWfsUrl, $http);


### PR DESCRIPTION
Motivé par https://github.com/MTES-MCT/dialog/pull/669#discussion_r1519564052

On gérait les erreurs HTTP, mais pas les erreurs réseau (timeout à la connexion, rupture de connexion, autre...).