### PR TITLE
[admin] Fix user duplication

### DIFF
--- a/src/Infrastructure/Controller/Admin/UserCrudController.php
+++ b/src/Infrastructure/Controller/Admin/UserCrudController.php
@@ -11,7 +11,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
-use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -51,13 +50,6 @@ final class UserCrudController extends AbstractCrudController
         $fields = [
             TextField::new('fullName')->setLabel('Prénom / Nom'),
             EmailField::new('email'),
-            AssociationField::new('organizations')
-                ->setFormTypeOption('by_reference', false)
-                ->setFormTypeOption('choice_label', 'name')
-                ->setLabel('Organisation(s)')
-                ->formatValue(function ($value, $entity) {
-                    return implode(', ', $entity->getOrganizations()->toArray());
-                }),
         ];
 
         $password = TextField::new('password')

--- a/src/Infrastructure/Controller/Admin/UserCrudController.php
+++ b/src/Infrastructure/Controller/Admin/UserCrudController.php
@@ -11,6 +11,7 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 use Symfony\Component\Form\Extension\Core\Type\PasswordType;
@@ -42,6 +43,7 @@ final class UserCrudController extends AbstractCrudController
         return $crud
             ->setEntityLabelInSingular('Utilisateur')
             ->setEntityLabelInPlural('Utilisateurs')
+            ->setDefaultSort(['uuid' => 'ASC'])
         ;
     }
 
@@ -50,6 +52,13 @@ final class UserCrudController extends AbstractCrudController
         $fields = [
             TextField::new('fullName')->setLabel('Prénom / Nom'),
             EmailField::new('email'),
+            AssociationField::new('organizations')
+                ->setFormTypeOption('by_reference', false)
+                ->setFormTypeOption('choice_label', 'name')
+                ->setLabel('Organisation(s)')
+                ->formatValue(function ($value, $entity) {
+                    return implode(', ', $entity->getOrganizations()->toArray());
+                }),
         ];
 
         $password = TextField::new('password')


### PR DESCRIPTION
Après avoir récupéré le dump de prod en local, je ne constate pas le bug de doublon de comptes utilisateurs dans l'admin.
Tentative de fixe en supprimant la notion d'organisation au niveau du listing utilisateur (vu avec @MathieuFV).