### PR TITLE
Fix error handling in Eudonet Addok bundle download script

### DIFF
--- a/.github/workflows/eudonet_paris_import.yml
+++ b/.github/workflows/eudonet_paris_import.yml
@@ -1,6 +1,7 @@
 name: Eudonet Paris Import
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '30 16 * * 1' # Voir https://crontab.guru/ : tous les lundis à 16h30
 

--- a/tools/download_addok_bundle.sh
+++ b/tools/download_addok_bundle.sh
@@ -1,17 +1,22 @@
 #!/bin/bash
-set -eux
+set -eux pipefail
 
 DRIVE_ID=184671
 
 ARCHIVE_ID=$(
-    curl -L \
+    curl --fail-with-body -q -L \
         -X POST \
         -H "Authorization: Bearer ${KDRIVE_TOKEN}" \
         -H "Content-Type: application/json" \
         -d "{\"file_ids\": [\"${KDRIVE_FILE_ID}\"]}" \
         "https://api.infomaniak.com/3/drive/${DRIVE_ID}/files/archives" \
-        | jq --raw-output .data.uuid
+    | jq --raw-output '.data.uuid // empty'
 )
+
+if [ -z $ARCHIVE_ID ]; then
+    echo 'ERROR: Failed to get archive ID, see error output above'
+    exit 1
+fi
 
 curl -L \
     -H "Authorization: Bearer ${KDRIVE_TOKEN}" \


### PR DESCRIPTION
* Closes #679 

Les identifiants de Drive et de File étaient bons, mais il y avait un problème de token (pour une raison que j'ignore il n'était plus dans mon compte ?)

Mais ça ne s'affichait pas dans le log car on ne gérait pas les erreurs correctement

Donc j'ai généré un nouveau token et j'ai mis à jour le secret correspondant

Puis cette PR 

* Ajoute`--fail-with-body` pour que curl échoue si on a une réponse non-200
* Ajoute `pipefail` pour que `jq` échoue si le `curl` d'obtention de l'archive a échoué
* Utilise `// empty` dans la commande jq pour que ARCHIVE_ID contienne la string vide au lieu de "null", ce qui permet ensuite de tester le contenu de ARCHIVE_ID et stopper l'exécution si il est vide (parce que la commande curl a échoué). Je n'ai pas trouvé de moyen simple de propager le statut d'erreur dans une commande exécutée avec `$(...)`.
