### PR TITLE
Eudonet: fix missing -o in script

### DIFF
--- a/tools/download_addok_bundle.sh
+++ b/tools/download_addok_bundle.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -eux pipefail
+set -euxo pipefail
 
 DRIVE_ID=184671
 


### PR DESCRIPTION
Encore un correctif suite à #680...

cf https://github.com/MTES-MCT/dialog/actions/runs/8279378420

L'usage de pipefail c'est `-o pipefail` et pas `pipefail` tout seul

Du coup `set pipefail` remplaçait les arguments et `$1` (normalement le dossier cible passé en argument dans la CI) était remplacé par `pipefail`, et donc le zip était stocké dans un fichier appelé... `pipefail`

Cette fois j'ai testé en lançant le script de download en local, et c'est bon