### PR TITLE
Corrige la déclaration de système de coordonnées de Location.geometry

### DIFF
--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.orm.xml
@@ -17,7 +17,7 @@
     <field name="geometry" type="geometry" column="geometry" nullable="true">
       <options>
         <option name="geometry_type">GEOMETRY</option>
-        <option name="srid">2154</option>
+        <option name="srid">4326</option>
       </options>
     </field>
     <many-to-one field="measure" target-entity="App\Domain\Regulation\Measure" inversed-by="locations">

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240318161612.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240318161612.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240318161612 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fix location coordinate system';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('SELECT UpdateGeometrySRID(\'location\', \'geometry\', 4326)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('SELECT UpdateGeometrySRID(\'location\', \'geometry\', 2154)');
+    }
+}

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -456,7 +456,7 @@
                             </loc:supplementaryPositionalDescription>
                             <loc:_linearLocationExtension>
                                 <loc:linearLocationExtended>
-                                    <locdx:geoJsonGeometry>{"type":"LineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[1.355,44.0163],[1.35419,44.01665]]}</locdx:geoJsonGeometry>
+                                    <locdx:geoJsonGeometry>{"type":"LineString","coordinates":[[1.355,44.0163],[1.35419,44.01665]]}</locdx:geoJsonGeometry>
                                 </loc:linearLocationExtended>
                             </loc:_linearLocationExtension>
                         </locationByOrder>
@@ -506,7 +506,7 @@
                             </loc:supplementaryPositionalDescription>
                             <loc:_linearLocationExtension>
                                 <loc:linearLocationExtended>
-                                    <locdx:geoJsonGeometry>{"type":"LineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[1.362275,44.028996],[1.35931,44.025665]]}</locdx:geoJsonGeometry>
+                                    <locdx:geoJsonGeometry>{"type":"LineString","coordinates":[[1.362275,44.028996],[1.35931,44.025665]]}</locdx:geoJsonGeometry>
                                 </loc:linearLocationExtended>
                             </loc:_linearLocationExtension>
                         </locationByOrder>
@@ -592,7 +592,7 @@
                             </loc:supplementaryPositionalDescription>
                             <loc:_linearLocationExtension>
                                 <loc:linearLocationExtended>
-                                    <locdx:geoJsonGeometry>{"type":"LineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[1.352126,44.016833],[1.353016,44.016402]]}</locdx:geoJsonGeometry>
+                                    <locdx:geoJsonGeometry>{"type":"LineString","coordinates":[[1.352126,44.016833],[1.353016,44.016402]]}</locdx:geoJsonGeometry>
                                 </loc:linearLocationExtended>
                             </loc:_linearLocationExtension>
                         </locationByOrder>
@@ -678,7 +678,7 @@
                             </loc:supplementaryPositionalDescription>
                             <loc:_linearLocationExtension>
                                 <loc:linearLocationExtended>
-                                    <locdx:geoJsonGeometry>{"type":"MultiLineString","crs":{"type":"name","properties":{"name":"EPSG:2154"}},"coordinates":[[[1.34352783,44.01741201],[1.34351021,44.01728842],[1.34344305,44.01672388]],[[1.34361127,44.01827476],[1.34363309,44.01855416],[1.34367982,44.01909228],[1.34373623,44.01964046],[1.34376444,44.02004327]],[[1.34355908,44.01762403],[1.34352783,44.01741201]],[[1.34361127,44.01827476],[1.34359579,44.01799187],[1.34355908,44.01762403]]]}</locdx:geoJsonGeometry>
+                                    <locdx:geoJsonGeometry>{"type":"MultiLineString","coordinates":[[[1.34352783,44.01741201],[1.34351021,44.01728842],[1.34344305,44.01672388]],[[1.34361127,44.01827476],[1.34363309,44.01855416],[1.34367982,44.01909228],[1.34373623,44.01964046],[1.34376444,44.02004327]],[[1.34355908,44.01762403],[1.34352783,44.01741201]],[[1.34361127,44.01827476],[1.34359579,44.01799187],[1.34355908,44.01762403]]]}</locdx:geoJsonGeometry>
                                 </loc:linearLocationExtended>
                             </loc:_linearLocationExtension>
                         </locationByOrder>


### PR DESCRIPTION
En corrigeant le problème https://github.com/MTES-MCT/dialog/pull/677/commits/8bb213b76135bcdc68f0381c6cd348df8d951534 pour la BD TOPO, je me suis rendu compte qu'il n'était pas correct de déclarer qu'on utilise le système de coordonnées N°2154 (AKA Lambert 93, le système officiel français), car en réalité on stocke bel et bien du EPSG:4326 (aka WGS84), le système de coordonnées "standard"

J'avais aussi rencontré des problèmes en travaillant sur #623 qui m'avaient obligés à "forcer" le SRID 2154 alors que clairement ce que je manipulais était du 4326 (coordonnées en angles plutôt qu'en mètres, donc 3,XXX au lieu de 7XXXX,XXX pour la latitude par ex)

Cette PR corrige donc le SRID déclaré

D'après https://postgis.net/docs/UpdateGeometrySRID.html ça équivaut à un `ST_SetSRID()` donc le SRID va juste être changé sans modifier les coordonnées (contrairement à `ST_Transform()` qui aurait recalculé les coordonnées dans le nouveau système de coordonnées)