### PR TITLE
Sélectionne les colonnes BD TOPO à importer

### DIFF
--- a/tools/bdtopo_update
+++ b/tools/bdtopo_update
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 import argparse
 import json
-import re
 import signal
-import string
 import subprocess
 import sys
 from contextlib import ExitStack
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -59,8 +57,14 @@ def _run_dockerized_ogr2ogr(database_url, directory: Path, path: Path, options: 
 
 
 @dataclass
+class Table:
+    name: str
+    columns: list[str]
+
+
+@dataclass
 class Config:
-    tables: list[str]
+    tables: list[Table]
 
 
 def main(config: Config, directory: Path, url: str | None, yes: bool) -> int:
@@ -70,8 +74,11 @@ def main(config: Config, directory: Path, url: str | None, yes: bool) -> int:
 
     search_pattern = "*/BDTOPO/1_DONNEES_LIVRAISON_*/*/TRANSPORT/*"
 
+    tablenames = set(table.name for table in config.tables)
+    columns_by_table = {table.name: table.columns for table in config.tables}
+
     geopackage_paths = [
-        path for path in directory.glob(search_pattern) if path.stem in config.tables
+        path for path in directory.glob(search_pattern) if path.stem in tablenames
     ]
 
     if not geopackage_paths:
@@ -171,8 +178,11 @@ def main(config: Config, directory: Path, url: str | None, yes: bool) -> int:
                     # (Geopackages in BD TOPO may not all use the same projection)
                     "-t_srs",
                     "EPSG:4326",
-                    # Append on subsequent calls
-                    "-append",
+                    # Append on subsequent calls, adding any new fields
+                    "-addfields",
+                    # Select columns as configured
+                    "-sql",
+                    f"SELECT {', '.join(columns_by_table[tablename])} FROM {tablename}",
                     # Enable slightly faster ingestion
                     # https://gdal.org/drivers/vector/pg.html#config-PG_USE_COPY
                     "--config",
@@ -284,7 +294,7 @@ if __name__ == "__main__":
     configdata = json.loads(args.config.read_text())
 
     config = Config(
-        tables=configdata["tables"],
+        tables=[Table(**tabledata) for tabledata in configdata["tables"]],
     )
 
     # Relative paths are OK but ogr2ogr volume will require an absolute path.

--- a/tools/bdtopo_update.config.json
+++ b/tools/bdtopo_update.config.json
@@ -1,6 +1,19 @@
 {
     "tables": [
-        "voie_nommee",
-        "route_numerotee_ou_nommee"
+        {
+            "name": "voie_nommee",
+            "columns": [
+                "nom_minuscule",
+                "code_insee"
+            ]
+        },
+        {
+            "name": "route_numerotee_ou_nommee",
+            "columns": [
+                "numero",
+                "gestionnaire",
+                "type_de_route"
+            ]
+        }
     ]
 }


### PR DESCRIPTION
* Suite à #677 

Une idée... Au lieu d'importer la table entière, on peut sélectionner les colonnes à importer avec `ogr2ogr`.

### Avantages

Le résultat :

* Un import plus rapide (en local ça prend même pas 15 secondes au total, contre 1 à 2 minutes auparavant)
* **(Beaucoup) Moins de stockage nécessaire**
  * `voie_nommee` pèse 128 MB en réduisant aux seuls champs qu'on utilise pour l'instant, au lieu de 1.8 GB si on importe tout
* Par conséquent probablement moins de pression sur la RAM aussi ? (Elle saturait souvent lors de l'import)
* Donc moins cher : une instance Starter 512M tiendra la charge pendant plus longtemps même si on rajoute quelques tables/colonnes (pour info, la table `troncon_de_route` complète pèse 14 GB, ce qu'on pourrait sûrement réduire à < 1 Go si on sélectionne les champs voulus)
* Et moins de tracas opérationnels de gestion de l'instance

### Inconvénients

* Gestion de l'évolution des champs sélectionnés
  * Ajout : l'option `-addfields` utilisée désormais sur `ogr2ogr` gère ce cas de figure
  * Retrait : la colonne ne sera plus importée mais elle restera dans le schéma et les données resteront en place. Au pire ce n'est pas grave, au mieux on peut intervenir en prod et faire un DROP COLUMN.
* On peut moins facilement importer une table pour "l'explorer" (par ex en phase de recherche dev). Mais il "suffit" de mettre explicitement la liste des colonnes qu'on veut pouvoir inspecter pendant cette phase, puis une fois qu'on a trouvé, la réduire aux seules colonnes finalement nécessaires.

### Plan en prod

* Je propose de refaire un import complet
  * Réinitialiser l'add-on Postgres sur `dialog-bdtopo`
  * Y exécuter manuellement `CREATE EXTENSION postgis`
  * Lancer l'import en local
  * Lancer `bdtopo_migrate` manuellement depuis GitHub Actions (juste pour exercer cette CI, même si on pourrait aussi les lancer en local)