### PR TITLE
Gère le calcul de section sur une voie en plusieurs morceaux disjoints

### DIFF
--- a/src/Application/LineSectionMakerInterface.php
+++ b/src/Application/LineSectionMakerInterface.php
@@ -12,5 +12,5 @@ interface LineSectionMakerInterface
         string $geometry,
         Coordinates $fromCoords,
         Coordinates $toCoords,
-    ): string;
+    ): ?string;
 }


### PR DESCRIPTION
WIP

Cette PR étend les cas de calcul de section supportés.

Jusqu'ici seules les voies "en un seul morceau" étaient supportées, dans l'autre cas on avait une erreur. Le problème technique étant que PostGIS exige de calculer une section sur une LINESTRING d'un seul tenant.

L'approche est de sélectionner la LINESTRING composant la MULTILINESTRING à laquelle se rattachent les points demandés, au sens de : la LINESTRING dont chaque point est le plus proche.

Si le point A et le point B appartiennent à une LINESTRING différente, je propose d'afficher une erreur avec l'idée que l'utilisateur devrait créer une localisation pour chaque portion. Mais du point de vue UX je ne saurais pas comment le formuler.

TODO

* Gestion de l'erreur
* Mise à jour du code et des tests
