### PR TITLE
Améliore le champ Ville

### DIFF
--- a/assets/controllers/autocomplete_controller.js
+++ b/assets/controllers/autocomplete_controller.js
@@ -6,6 +6,37 @@ export default class Autocomplete extends StimulusAutocomplete {
     extraQueryParams: { type: String, default: undefined },
   };
 
+  connect() {
+    super.connect();
+
+    this.inputTarget.addEventListener('input', this.#onInput);
+    this.inputTarget.addEventListener('focus', this.#onInputFocus);
+  }
+
+  disconnect() {
+    super.disconnect();
+
+    if (this.hasInputTarget) {
+      this.inputTarget.removeEventListener('input', this.#onInput);
+      this.inputTarget.removeEventListener('focus', this.#onInputFocus);
+    }
+  }
+
+  #onInput = () => {
+    if (this.hasHiddenTarget) {
+      // By default this is debounced, which can lead to submitting a hidden
+      // value that's out of date because we began to type something new.
+      this.hiddenTarget.value = '';
+    }
+  }
+
+  #onInputFocus = () => {
+    // Show any existing results when entering the input
+    if (this.resultsTarget.innerHTML) {
+      super.open();
+    }
+  };
+
   buildURL(query) {
     const url = new URL(super.buildURL(query));
 

--- a/assets/styles/components/autocomplete.scss
+++ b/assets/styles/components/autocomplete.scss
@@ -20,7 +20,7 @@
             background: var(--background-default-grey);
         }
 
-        li[role="option"]:hover, li[role="option"].active {
+        li[role="option"]:hover, li[role="option"].active, li[role="option"][aria-selected="true"] {
             background-color: var(--background-contrast-grey);
         }
     }

--- a/config/validator/Application/Regulation/Command/SaveLocationCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveLocationCommand.xml
@@ -94,7 +94,9 @@
             <constraint name="When">
                 <option name="expression"> this.roadType === 'lane'</option>
                 <option name="constraints">
-                    <constraint name="NotBlank" />
+                    <constraint name="NotBlank">
+                        <option name="message">regulation.location.cityCode.error.blank</option>
+                    </constraint>
                 </option>
             </constraint>
         </property>
@@ -110,8 +112,14 @@
             </constraint>
         </property>
         <property name="roadName">
-            <constraint name="Length">
-                <option name="max">255</option>
+            <constraint name="When">
+                <option name="expression"> this.roadType === 'lane' </option>
+                <option name="constraints">
+                    <constraint name="NotBlank" />
+                    <constraint name="Length">
+                        <option name="max">255</option>
+                    </constraint>
+                </option>
             </constraint>
         </property>
         <property name="fromHouseNumber">

--- a/src/Infrastructure/Form/Regulation/LocationFormType.php
+++ b/src/Infrastructure/Form/Regulation/LocationFormType.php
@@ -117,6 +117,9 @@ final class LocationFormType extends AbstractType
                     'label' => 'regulation.location.roadName',
                     'help' => 'regulation.location.roadName.help',
                     'required' => false,
+                    'label_attr' => [
+                        'class' => 'required',
+                    ],
                 ],
             )
             ->add(
@@ -209,6 +212,9 @@ final class LocationFormType extends AbstractType
         $resolver->setDefaults([
             'administrators' => [],
             'data_class' => SaveLocationCommand::class,
+            'error_mapping' => [
+                'cityCode' => 'cityLabel',
+            ],
         ]);
         $resolver->setAllowedTypes('administrators', 'array');
     }

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -273,7 +273,6 @@
                     data-autocomplete-delay-value="500"
                 >
                     {{ form_row(form.cityCode, { attr: {'data-autocomplete-target': 'hidden'} }) }}
-                    {{ form_errors(form.cityCode) }}
 
                     {{ form_row(form.cityLabel, {
                         group_class: 'fr-input-group',

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -273,6 +273,7 @@
                     data-autocomplete-delay-value="500"
                 >
                     {{ form_row(form.cityCode, { attr: {'data-autocomplete-target': 'hidden'} }) }}
+                    {{ form_errors(form.cityCode) }}
 
                     {{ form_row(form.cityLabel, {
                         group_class: 'fr-input-group',

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
@@ -668,8 +668,7 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertSame('Cette chaîne doit avoir exactement 5 caractères.', $crawler->filter('#measure_form_locations_error')->text());
-        $this->assertSame('Cette chaîne est trop longue. Elle doit avoir au maximum 255 caractères.', $crawler->filter('#measure_form_locations_0_cityLabel_error')->text());
+        $this->assertSame('Cette chaîne doit avoir exactement 5 caractères. Cette chaîne est trop longue. Elle doit avoir au maximum 255 caractères.', $crawler->filter('#measure_form_locations_0_cityLabel_error')->text());
         $this->assertSame('Cette chaîne est trop longue. Elle doit avoir au maximum 255 caractères.', $crawler->filter('#measure_form_locations_0_roadName_error')->text());
         $this->assertSame('Cette chaîne est trop longue. Elle doit avoir au maximum 8 caractères.', $crawler->filter('#measure_form_locations_0_fromHouseNumber_error')->text());
         $this->assertSame('Cette chaîne est trop longue. Elle doit avoir au maximum 8 caractères.', $crawler->filter('#measure_form_locations_0_toHouseNumber_error')->text());

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
@@ -33,6 +33,30 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $this->assertSame('Veuillez définir une ou plusieurs localisations.', $crawler->filter('#measure_form_locations_error')->text());
     }
 
+    public function testInvalidLaneBlankCityCode(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/measure/add');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+        $this->assertSame('Mesure', $crawler->filter('h3')->text());
+
+        $saveButton = $crawler->selectButton('Valider');
+        $form = $saveButton->form();
+
+        // Get the raw values.
+        $values = $form->getPhpValues();
+        $values['measure_form']['locations'][0]['roadType'] = 'lane';
+        $values['measure_form']['locations'][0]['cityCode'] = ''; // Blank
+        $values['measure_form']['locations'][0]['cityLabel'] = 'Savenay';
+        $values['measure_form']['locations'][0]['roadName'] = 'Route du Grand Manual Input';
+
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertSame('Veuillez choisir une ville ou commune parmi la liste.', $crawler->filter('#measure_form_locations_0_cityLabel_error')->text());
+    }
+
     public function testInvalidDepartmentalRoad(): void
     {
         $client = $this->login();

--- a/translations/validators.fr.xlf
+++ b/translations/validators.fr.xlf
@@ -10,6 +10,10 @@
                 <source>regulation.location.error.geocoding_failed</source>
                 <target>Cette adresse n’est pas reconnue. Vérifier le nom de la voie, et les numéros de début et fin.</target>
             </trans-unit>
+            <trans-unit id="regulation.location.cityCode.error.blank">
+                <source>regulation.location.cityCode.error.blank</source>
+                <target>Veuillez choisir une ville ou commune parmi la liste.</target>
+            </trans-unit>
             <trans-unit id="regulation.location.error.abscissa_out_of_range">
                 <source>regulation.location.error.abscissa_out_of_range</source>
                 <target>Cette abscisse n'est pas située sur la route. Veuillez vérifier votre saisie.</target>


### PR DESCRIPTION
* Closes #604 

Cette PR améliore le champ Ville et l'autocomplete :

* Quand l'utilisateur ne choisit pas une ville parmi la liste, une erreur apparaît
* Affiche la liste des résultats quand on clique ou navigue au clavier dans le champ
* Ajoute une validation manquante sur le champ Voie, qui est obligatoire pour le type de localisation Voie nommée
* Corrige le CSS pour mettre en avant l'option courante quand on navigue au clavier

## Aperçu

![Screenshot from 2024-04-11 15-22-18](https://github.com/MTES-MCT/dialog/assets/15911462/b0fc633f-5610-4274-b678-4b7ae5cb33ee)

