### PR TITLE
Retire les dates de fin sur les arrêtés BAC-IDF

### DIFF
--- a/src/Infrastructure/BacIdf/BacIdfTransformer.php
+++ b/src/Infrastructure/BacIdf/BacIdfTransformer.php
@@ -432,14 +432,11 @@ final class BacIdfTransformer
             }
 
             $periodCommand = new SavePeriodCommand();
-
+            $periodCommand->isPermanent = true;
             $periodCommand->startDate = $startDate;
             $periodCommand->startTime = $startDate;
-
-            // Workaround for https://github.com/MTES-MCT/dialog/issues/622
-            $endDate = \DateTimeImmutable::createFromFormat('Y-m-d H:i:s', '2100-01-01 00:00:00', new \DateTimeZone('Europe/Paris'));
-            $periodCommand->endDate = $endDate;
-            $periodCommand->endTime = $endDate;
+            $periodCommand->endDate = null;
+            $periodCommand->endTime = null;
 
             $days = $periodItem['JOUR'];
 

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240416135713.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240416135713.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240416135713 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'UPDATE period SET end_datetime = NULL
+            FROM measure AS m
+            JOIN regulation_order AS ro ON m.regulation_order_uuid = ro.uuid
+            JOIN regulation_order_record AS roc ON roc.regulation_order_uuid = ro.uuid
+            WHERE m.uuid = period.measure_uuid
+            AND roc.source = :source
+            ',
+            ['source' => 'bacidf'],
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+    }
+}

--- a/tests/Unit/Infrastructure/BacIdf/BacIdfTransformerTest.php
+++ b/tests/Unit/Infrastructure/BacIdf/BacIdfTransformerTest.php
@@ -836,10 +836,11 @@ final class BacIdfTransformerTest extends TestCase
         ];
 
         $periodCommand1 = new SavePeriodCommand();
+        $periodCommand1->isPermanent = true;
         $periodCommand1->startDate = new \DateTimeImmutable('2024-02-06T17:25:00Z');
         $periodCommand1->startTime = new \DateTimeImmutable('2024-02-06T17:25:00Z');
-        $periodCommand1->endDate = new \DateTimeImmutable('2100-01-01T00:00:00+01');
-        $periodCommand1->endTime = new \DateTimeImmutable('2100-01-01T00:00:00+01');
+        $periodCommand1->endDate = null;
+        $periodCommand1->endTime = null;
         $periodCommand1->recurrenceType = PeriodRecurrenceTypeEnum::EVERY_DAY->value;
         $timeSlot = new SaveTimeSlotCommand();
         $timeSlot->startTime = new \DateTimeImmutable('07:00', new \DateTimeZone('Etc/GMT-1'));
@@ -847,10 +848,11 @@ final class BacIdfTransformerTest extends TestCase
         $periodCommand1->timeSlots = [$timeSlot];
 
         $periodCommand2 = new SavePeriodCommand();
+        $periodCommand2->isPermanent = true;
         $periodCommand2->startDate = new \DateTimeImmutable('2024-02-06T17:25:00Z');
         $periodCommand2->startTime = new \DateTimeImmutable('2024-02-06T17:25:00Z');
-        $periodCommand2->endDate = new \DateTimeImmutable('2100-01-01T00:00:00+01');
-        $periodCommand2->endTime = new \DateTimeImmutable('2100-01-01T00:00:00+01');
+        $periodCommand2->endDate = null;
+        $periodCommand2->endTime = null;
         $periodCommand2->recurrenceType = PeriodRecurrenceTypeEnum::CERTAIN_DAYS->value;
         $dailyRange = new SaveDailyRangeCommand();
         $dailyRange->applicableDays = [ApplicableDayEnum::MONDAY->value, ApplicableDayEnum::TUESDAY->value];
@@ -858,10 +860,11 @@ final class BacIdfTransformerTest extends TestCase
         $periodCommand2->timeSlots = [];
 
         $periodCommand3 = new SavePeriodCommand();
+        $periodCommand3->isPermanent = true;
         $periodCommand3->startDate = new \DateTimeImmutable('2024-02-06T17:25:00Z');
         $periodCommand3->startTime = new \DateTimeImmutable('2024-02-06T17:25:00Z');
-        $periodCommand3->endDate = new \DateTimeImmutable('2100-01-01T00:00:00+01');
-        $periodCommand3->endTime = new \DateTimeImmutable('2100-01-01T00:00:00+01');
+        $periodCommand3->endDate = null;
+        $periodCommand3->endTime = null;
         $periodCommand3->recurrenceType = PeriodRecurrenceTypeEnum::CERTAIN_DAYS->value;
         $dailyRange = new SaveDailyRangeCommand();
         $dailyRange->applicableDays = [ApplicableDayEnum::WEDNESDAY->value, ApplicableDayEnum::SUNDAY->value];


### PR DESCRIPTION
* Vu https://github.com/MTES-MCT/dialog/issues/696#issuecomment-2059152337

Dans BAC-IDF on mettait une date de fin au 1er janvier 2100 Europe/Paris, mais avec https://github.com/MTES-MCT/dialog/issues/622 c'est devenu obsolète

Donc cette PR retire la date de fin sur les arrêtés BAC-IDF.