### PR TITLE
Affichage de l'ensemble des arrêtés publiés, sur une carte ; démo d'avril 2024, avec Martin Tile Server et MapLibre GL JS

### DIFF
--- a/config/martin_tile_server.yaml
+++ b/config/martin_tile_server.yaml
@@ -1,0 +1,4 @@
+cache_size_mb: 0
+
+postgres:
+  connection_string: $DATABASE_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,3 +80,6 @@ services:
       - DATABASE_URL=postgresql://dialog:dialog@database/dialog
     depends_on:
       - database
+    volumes:
+      - './config/martin_tile_server.yaml:/etc/martin_tile_server_config.yaml:r'
+    command: ["--config", "/etc/martin_tile_server_config.yaml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,3 +68,15 @@ services:
       # Allow accessing host ports from this container via host.docker.internal on Linux
       # https://stackoverflow.com/a/43541732
       - host.docker.internal:host-gateway
+  
+  martin:
+    # https://maplibre.org/martin/run-with-docker-compose.html
+    # TODO : make it wait for database with a shell script
+    image: ghcr.io/maplibre/martin:latest
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    environment:
+      - DATABASE_URL=postgresql://dialog:dialog@database/dialog
+    depends_on:
+      - database

--- a/public/map/general_map_view.sql
+++ b/public/map/general_map_view.sql
@@ -1,0 +1,10 @@
+CREATE OR REPLACE VIEW general_map_view AS
+SELECT location.road_name AS road_name, location.road_number AS road_number, measure.type AS "type",
+       regulation_order.category AS category, regulation_order.description AS description, regulation_order.identifier AS identifier,
+       (regulation_order.end_date IS NULL) AS is_permanent, (regulation_order_record.status = 'draft') AS is_draft,
+       organization.name AS organization_name, location.geometry AS geometry
+FROM location
+JOIN measure ON measure.uuid = location.measure_uuid
+JOIN regulation_order ON regulation_order.uuid = measure.regulation_order_uuid
+JOIN regulation_order_record ON regulation_order_record.regulation_order_uuid = regulation_order.uuid
+JOIN organization ON organization.uuid = regulation_order_record.organization_uuid;

--- a/public/map/general_map_view.sql
+++ b/public/map/general_map_view.sql
@@ -2,9 +2,30 @@ CREATE OR REPLACE VIEW general_map_view AS
 SELECT location.road_name AS road_name, location.road_number AS road_number, measure.type AS "type",
        regulation_order.category AS category, regulation_order.description AS description, regulation_order.identifier AS identifier,
        (regulation_order.end_date IS NULL) AS is_permanent, (regulation_order_record.status = 'draft') AS is_draft,
-       organization.name AS organization_name, location.geometry AS geometry
+       organization.name AS organization_name, location.geometry AS geometry,
+       regulation_order.uuid AS regulation_order_id
 FROM location
 JOIN measure ON measure.uuid = location.measure_uuid
 JOIN regulation_order ON regulation_order.uuid = measure.regulation_order_uuid
 JOIN regulation_order_record ON regulation_order_record.regulation_order_uuid = regulation_order.uuid
 JOIN organization ON organization.uuid = regulation_order_record.organization_uuid;
+
+
+-- location.geometry may be LineString or MultiLineString -> before applying ST_Collect, we use ST_Dump to get on LineString per row, otherwise we may get an undisplayable GeometryCollection (ST_Collect of several MultiLineString returns a GeometryCollection)
+CREATE OR REPLACE VIEW general_map_view_aggregated AS
+WITH one_line_per_row AS (
+SELECT location.road_name, location.road_number, 
+       (ST_Dump(location.geometry)).geom AS geometry_as_line, 
+       regulation_order.uuid AS regulation_order_id
+FROM location
+JOIN measure ON measure.uuid = location.measure_uuid
+JOIN regulation_order ON regulation_order.uuid = measure.regulation_order_uuid
+JOIN regulation_order_record ON regulation_order_record.regulation_order_uuid = regulation_order.uuid
+JOIN organization ON organization.uuid = regulation_order_record.organization_uuid
+)
+SELECT regulation_order.uuid AS regulation_order_id,
+       array_agg(concat(E'\'', one_line_per_row.road_name, E'\'', '[', one_line_per_row.road_number, ']')) AS named_locations, 
+       ST_Multi(ST_Collect(one_line_per_row.geometry_as_line))::Geometry(MultiLineString,4326) AS geometry
+FROM one_line_per_row
+JOIN regulation_order ON regulation_order.uuid = one_line_per_row.regulation_order_id
+GROUP BY regulation_order.uuid;

--- a/public/map/map.css
+++ b/public/map/map.css
@@ -1,0 +1,2 @@
+body { margin: 0; padding: 0; }
+html, body, #map { height: 100%; }

--- a/public/map/map.css
+++ b/public/map/map.css
@@ -1,2 +1,13 @@
 body { margin: 0; padding: 0; }
 html, body, #map { height: 100%; }
+
+.map-overlay {
+    font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
+    position: absolute;
+    width: 20%;
+    top: 0;
+    left: 0;
+    padding: 10px;
+    margin: 10px;
+    background-color: white;
+}

--- a/public/map/map.html
+++ b/public/map/map.html
@@ -12,7 +12,7 @@
 <body>
   <div id="map"></div>
   <nav class="map-overlay top">
-    <input id="display-drafts" type="checkbox" /><label>Arrêtés en état de brouillon</label>
+    <label><input id="display-drafts" type="checkbox" checked="checked" />Arrêtés en état de brouillon</label>
     <div id="regulations-permanent-and-or-temporary">
       <label><input type="radio" id="regulations-permanent-only" name="permanent-and-or-temporary" value="permanent-only" />Arrêtés permanents seulement</label>
       <label><input type="radio" id="regulations-temporary-only" name="permanent-and-or-temporary" value="temporary-only" />Arrêtés temporaires seulement</label>

--- a/public/map/map.html
+++ b/public/map/map.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <title>Carte de démo</title>
+    <meta property="og:description" content="Carte via MapLibre GL JS" />
+    <meta charset='utf-8'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel='stylesheet' href='https://unpkg.com/maplibre-gl/dist/maplibre-gl.css' />
+    <link rel='stylesheet' href='./map.css' />
+    <script src='https://unpkg.com/maplibre-gl/dist/maplibre-gl.js'></script>
+</head>
+<body>
+  <div id="map"></div>
+  <script src='./map.js'></script>
+</body>
+</html>

--- a/public/map/map.html
+++ b/public/map/map.html
@@ -12,11 +12,16 @@
 <body>
   <div id="map"></div>
   <nav class="map-overlay top">
-    <label><input id="display-drafts" type="checkbox" checked="checked" />Arrêtés en état de brouillon</label>
+    <div>
+      <label><input id="display-drafts" type="checkbox" checked="checked" />Arrêtés en état de brouillon</label>
+    </div>
     <div id="regulations-permanent-and-or-temporary">
       <label><input type="radio" id="regulations-permanent-only" name="permanent-and-or-temporary" value="permanent-only" />Arrêtés permanents seulement</label>
       <label><input type="radio" id="regulations-temporary-only" name="permanent-and-or-temporary" value="temporary-only" />Arrêtés temporaires seulement</label>
       <label><input type="radio" id="regulations-both-permanent-and-temporary" name="permanent-and-or-temporary" value="both-permanent-and-temporary" checked="checked" />Arrêtés permanents et temporaires</label>
+    </div>
+    <div>
+      <input id="organization-filter" type="text" name="organization-filter" placeholder="Filtrer par organisation …" />
     </div>
   </nav>
   <script src='./map.js'></script>

--- a/public/map/map.html
+++ b/public/map/map.html
@@ -11,6 +11,7 @@
 </head>
 <body>
   <div id="map"></div>
+  <nav class="map-overlay top"><input id="display-drafts" type="checkbox" /> Arrêtés en état de brouillon</nav>
   <script src='./map.js'></script>
 </body>
 </html>

--- a/public/map/map.html
+++ b/public/map/map.html
@@ -11,7 +11,14 @@
 </head>
 <body>
   <div id="map"></div>
-  <nav class="map-overlay top"><input id="display-drafts" type="checkbox" /> Arrêtés en état de brouillon</nav>
+  <nav class="map-overlay top">
+    <input id="display-drafts" type="checkbox" /><label>Arrêtés en état de brouillon</label>
+    <div id="regulations-permanent-and-or-temporary">
+      <label><input type="radio" id="regulations-permanent-only" name="permanent-and-or-temporary" value="permanent-only" />Arrêtés permanents seulement</label>
+      <label><input type="radio" id="regulations-temporary-only" name="permanent-and-or-temporary" value="temporary-only" />Arrêtés temporaires seulement</label>
+      <label><input type="radio" id="regulations-both-permanent-and-temporary" name="permanent-and-or-temporary" value="both-permanent-and-temporary" checked="checked" />Arrêtés permanents et temporaires</label>
+    </div>
+  </nav>
   <script src='./map.js'></script>
 </body>
 </html>

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -14,7 +14,7 @@ map.on('load', () => {
 	'regulations-source',
 	{
             type: 'vector',
-            url: 'http://localhost:3000/location'
+            url: 'http://localhost:3000/general_map_view'
 	}
     );
     // layers (i.e. styles) :
@@ -23,7 +23,7 @@ map.on('load', () => {
             'id': 'regulations-layer',
             'type': 'line',
             'source': 'regulations-source',
-            'source-layer': 'location',
+            'source-layer': 'general_map_view',
             'layout': {
 		'line-join': 'round',
 		'line-cap': 'round'
@@ -39,7 +39,7 @@ map.on('load', () => {
     map.on('click', 'regulations-layer', (e) => {
         new maplibregl.Popup()
             .setLngLat(e.lngLat)
-            .setHTML((e.features[0].properties.road_name || "''") + " [" + (e.features[0].properties.road_number || "") + "]")
+            .setHTML((e.features[0].properties.road_name || "''") + " [" + (e.features[0].properties.road_number || "") + "]" + "<h3>" + e.features[0].properties.identifier + "</h3>" + e.features[0].properties.description + "<br />" + " • arrêté permanent = " + e.features[0].properties.is_permanent + "<br /> • arrêté à l'état de brouillon = " + e.features[0].properties.is_draft)
             .addTo(map);
     });
     // change the cursor when the mouse is over the regulations layer
@@ -49,6 +49,9 @@ map.on('load', () => {
     map.on('mouseleave', 'regulations-layer', () => {
         map.getCanvas().style.cursor = '';
     });
+    // filtering :
+    // this filter will display all regulations (means : (is_draft) OR (NOT is_draft) -> always TRUE)
+    map.setFilter("regulations-layer", ["any", ["==", "is_draft", true], ["==", "is_draft", false]]);
 });
 
 map.on('idle', () => {

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -1,0 +1,30 @@
+const map = new maplibregl.Map({
+    container: 'map', // container id
+    style: 'https://demotiles.maplibre.org/style.json', // style URL
+    center: [0, 0], // starting position [lng, lat]
+    zoom: 1, // starting zoom
+    maplibreLogo: true
+});
+
+map.on('load', () => {
+    map.addSource('regulations', {
+        type: 'vector',
+        url:
+        'http://localhost:3000/location'
+    });
+    map.addLayer({
+        'id': 'terrain-data',
+        'type': 'line',
+        'source': 'regulations',
+        'source-layer': 'location',
+        'layout': {
+            'line-join': 'round',
+            'line-cap': 'round'
+        },
+        'paint': {
+            'line-color': '#ff69b4',
+            'line-width': 10
+        }
+    });
+});
+

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -13,7 +13,9 @@ const temporary_only_filter = ["==", "is_permanent", false];
 const filters_as_a_dict = {};
 
 function apply_filters() {
-    map.setFilter("regulations-layer", ["all", ...Object.values(filters_as_a_dict)]);
+    const filters_as_a_list = ["all", ...Object.values(filters_as_a_dict)];
+    map.setFilter("regulations-layer", filters_as_a_list);
+    //console.log("filters_as_a_list : ", filters_as_a_list); // for debugging purpose
 };
 
 map.on('load', () => {
@@ -73,7 +75,7 @@ map.on('load', () => {
     map.on('click', 'regulations-layer', (e) => {
         new maplibregl.Popup()
             .setLngLat(e.lngLat)
-            .setHTML((e.features[0].properties.road_name || "''") + " [" + (e.features[0].properties.road_number || "") + "]" + "<h3>" + e.features[0].properties.identifier + "</h3>" + e.features[0].properties.description + "<br />" + " • arrêté permanent = " + e.features[0].properties.is_permanent + "<br /> • arrêté à l'état de brouillon = " + e.features[0].properties.is_draft)
+            .setHTML((e.features[0].properties.road_name || "''") + " [" + (e.features[0].properties.road_number || "") + "]" + "<h3>" + e.features[0].properties.identifier + "</h3>" + "<h4>" + e.features[0].properties.organization_name + "</h4>" + e.features[0].properties.description + "<br />" + " • arrêté permanent = " + e.features[0].properties.is_permanent + "<br /> • arrêté à l'état de brouillon = " + e.features[0].properties.is_draft)
             .addTo(map);
     });    
     // change the cursor when the mouse is over the regulations layer
@@ -111,6 +113,8 @@ map.on('idle', () => {
 });
 
 // UI filtering
+// draft regulations filter
+// credits : https://maplibre.org/maplibre-gl-js/docs/examples/filter-within-layer/
 document.getElementById('display-drafts').addEventListener('change', (e) => {
     if (! e.target.checked) {  // do not display draft regulations
 	filters_as_a_dict.draft_filter = draft_filter;
@@ -119,6 +123,8 @@ document.getElementById('display-drafts').addEventListener('change', (e) => {
     };
     apply_filters();
 });
+// permanent and/or temporary regulations filter
+// credits : https://maplibre.org/maplibre-gl-js/docs/examples/filter-within-layer/
 document.getElementById('regulations-permanent-and-or-temporary').addEventListener('change', (e) => {
     switch (e.target.value) {
     case "permanent-only":
@@ -129,6 +135,18 @@ document.getElementById('regulations-permanent-and-or-temporary').addEventListen
 	break;
     default:
 	delete filters_as_a_dict.permanent_and_or_temporary_filter;
+    };
+    apply_filters();
+});
+// organization names filter
+// credits : https://maplibre.org/maplibre-gl-js/docs/examples/filter-markers-by-input/
+// fitering reference : https://maplibre.org/maplibre-style-spec/expressions/
+document.getElementById('organization-filter').addEventListener('input', (e) => {
+    if (e.target.value.length) {
+	const beginning_of_an_organization_name = e.target.value.trim().toLowerCase();
+	filters_as_a_dict.organization_filter = [">", ["index-of", beginning_of_an_organization_name, ["downcase", ["get", "organization_name"]]], -1];
+    } else {
+	delete filters_as_a_dict.organization_filter;
     };
     apply_filters();
 });

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -17,6 +17,13 @@ map.on('load', () => {
             url: 'http://localhost:3000/general_map_view'
 	}
     );
+    map.addSource(
+	'regulations-aggregated-source',
+	{
+            type: 'vector',
+            url: 'http://localhost:3000/general_map_view_aggregated'
+	}
+    );
     // layers (i.e. styles) :
     map.addLayer(
 	{
@@ -30,10 +37,29 @@ map.on('load', () => {
             },
             'paint': {
 		'line-color': '#ff69b4',
-		'line-width': 10
+		'line-width': 5
             }
 	},
 	"toponyme numéro de route - départementale" // insert this layer below the main label layers like road labels
+    );
+    // this layer 'regulations-aggregated-layer' is to display the scattered geometries of a regulation : when clicking on a single geometry, it simply shows the other geometries associated to the same regulation, if any
+    map.addLayer(
+	{
+            'id': 'regulations-aggregated-layer',
+            'type': 'line',
+            'source': 'regulations-aggregated-source',
+            'source-layer': 'general_map_view_aggregated',
+            'layout': {
+		'line-join': 'round',
+		'line-cap': 'round',
+		'visibility': 'none'  // hide this layer by default
+            },
+            'paint': {
+		'line-color': '#61B3F0',
+		'line-width': 10
+            }
+	},
+	"regulations-layer"
     );
     // popup when clicking on a feature of the regulation layer
     map.on('click', 'regulations-layer', (e) => {
@@ -41,17 +67,23 @@ map.on('load', () => {
             .setLngLat(e.lngLat)
             .setHTML((e.features[0].properties.road_name || "''") + " [" + (e.features[0].properties.road_number || "") + "]" + "<h3>" + e.features[0].properties.identifier + "</h3>" + e.features[0].properties.description + "<br />" + " • arrêté permanent = " + e.features[0].properties.is_permanent + "<br /> • arrêté à l'état de brouillon = " + e.features[0].properties.is_draft)
             .addTo(map);
-    });
+    });    
     // change the cursor when the mouse is over the regulations layer
-    map.on('mouseenter', 'regulations-layer', () => {
+    // also, highlight the geom(s) (one or many) associated to one regulation when the mouse is over one of its geometry
+    map.on('mouseenter', 'regulations-layer', (e) => {
         map.getCanvas().style.cursor = 'pointer';
+	let current_regulation_id = e.features[0].properties.regulation_order_id;
+	map.setFilter("regulations-aggregated-layer", ["==", "regulation_order_id", current_regulation_id]);
+	map.setLayoutProperty('regulations-aggregated-layer', 'visibility', 'visible');
     });
-    map.on('mouseleave', 'regulations-layer', () => {
+    map.on('mouseleave', 'regulations-layer', (e) => {
         map.getCanvas().style.cursor = '';
+	map.setFilter("regulations-aggregated-layer", null); // delete the filter
+	map.setLayoutProperty('regulations-aggregated-layer', 'visibility', 'none');
     });
     // filtering :
-    // this filter will display all regulations (means : (is_draft) OR (NOT is_draft) -> always TRUE)
-    map.setFilter("regulations-layer", ["any", ["==", "is_draft", true], ["==", "is_draft", false]]);
+    // demo : this filter will display all regulations (means : (is_draft) OR (NOT is_draft) -> always TRUE)
+    //map.setFilter("regulations-layer", ["any", ["==", "is_draft", true], ["==", "is_draft", false]]);    
 });
 
 map.on('idle', () => {

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -26,6 +26,7 @@ map.on('load', () => {
             'line-width': 10
         }
     });
+    // popup when clicking on a feature of the regulation layer
     map.on('click', 'regulations-layer', (e) => {
         new maplibregl.Popup()
             .setLngLat(e.lngLat)
@@ -41,3 +42,15 @@ map.on('load', () => {
     });
 });
 
+map.on('idle', () => {
+    // automatically pan and zoom on the regulation layer
+    // "map.getSource("regulations-source").bounds" is not defined inside "map.on('load', () => {", before the map is fully loaded
+    map.fitBounds(
+	map.getSource("regulations-source").bounds,
+	{
+	    padding: 100,
+	    animate: true,
+	    duration: 500  // duration in ms
+	}
+    );
+});

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -8,8 +8,13 @@ const map = new maplibregl.Map({
 
 let first_map_load = true;
 const draft_filter = ["==", "is_draft", false];
-const permanent_only_filter = ["==", "is_permanent", true]
-const temporary_only_filter = ["==", "is_permanent", false]
+const permanent_only_filter = ["==", "is_permanent", true];
+const temporary_only_filter = ["==", "is_permanent", false];
+const filters_as_a_dict = {};
+
+function apply_filters() {
+    map.setFilter("regulations-layer", ["all", ...Object.values(filters_as_a_dict)]);
+};
 
 map.on('load', () => {
     // sources : 
@@ -84,8 +89,8 @@ map.on('load', () => {
 	map.setFilter("regulations-aggregated-layer", null); // delete the filter
 	map.setLayoutProperty('regulations-aggregated-layer', 'visibility', 'none');
     });
-    // filtering : do not display draft regulations by default
-    map.setFilter("regulations-layer", draft_filter);    
+    // filtering : 
+    apply_filters();   
 });
 
 map.on('idle', () => {
@@ -108,20 +113,22 @@ map.on('idle', () => {
 // UI filtering
 document.getElementById('display-drafts').addEventListener('change', (e) => {
     if (! e.target.checked) {  // do not display draft regulations
-	map.setFilter("regulations-layer", draft_filter);
+	filters_as_a_dict.draft_filter = draft_filter;
     } else {
-	map.setFilter("regulations-layer", null);
+	delete filters_as_a_dict.draft_filter
     };
+    apply_filters();
 });
 document.getElementById('regulations-permanent-and-or-temporary').addEventListener('change', (e) => {
     switch (e.target.value) {
     case "permanent-only":
-	map.setFilter("regulations-layer", permanent_only_filter);
+	filters_as_a_dict.permanent_and_or_temporary_filter = permanent_only_filter;
 	break;
     case "temporary-only":
-	map.setFilter("regulations-layer", temporary_only_filter);
+	filters_as_a_dict.permanent_and_or_temporary_filter = temporary_only_filter;
 	break;
     default:
-	map.setFilter("regulations-layer", null);
+	delete filters_as_a_dict.permanent_and_or_temporary_filter;
     };
+    apply_filters();
 });

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -1,17 +1,21 @@
 const map = new maplibregl.Map({
     container: 'map', // container id
-    style: 'https://demotiles.maplibre.org/style.json', // style URL
+    style: 'https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/standard.json', // style URL
     center: [0, 0], // starting position [lng, lat]
     zoom: 1, // starting zoom
-    maplibreLogo: true
+    maplibreLogo: false
 });
 
 map.on('load', () => {
-    map.addSource('regulations-source', {
-        type: 'vector',
-        url:
-        'http://localhost:3000/location'
-    });
+    // sources : 
+    map.addSource(
+	'regulations-source',
+	{
+            type: 'vector',
+            url: 'http://localhost:3000/location'
+	}
+    );
+    // layers (i.e. styles) : 
     map.addLayer({
         'id': 'regulations-layer',
         'type': 'line',

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -17,21 +17,24 @@ map.on('load', () => {
             url: 'http://localhost:3000/location'
 	}
     );
-    // layers (i.e. styles) : 
-    map.addLayer({
-        'id': 'regulations-layer',
-        'type': 'line',
-        'source': 'regulations-source',
-        'source-layer': 'location',
-        'layout': {
-            'line-join': 'round',
-            'line-cap': 'round'
-        },
-        'paint': {
-            'line-color': '#ff69b4',
-            'line-width': 10
-        }
-    });
+    // layers (i.e. styles) :
+    map.addLayer(
+	{
+            'id': 'regulations-layer',
+            'type': 'line',
+            'source': 'regulations-source',
+            'source-layer': 'location',
+            'layout': {
+		'line-join': 'round',
+		'line-cap': 'round'
+            },
+            'paint': {
+		'line-color': '#ff69b4',
+		'line-width': 10
+            }
+	},
+	"toponyme numéro de route - départementale" // insert this layer below the main label layers like road labels
+    );
     // popup when clicking on a feature of the regulation layer
     map.on('click', 'regulations-layer', (e) => {
         new maplibregl.Popup()
@@ -50,8 +53,8 @@ map.on('load', () => {
 
 map.on('idle', () => {
     // automatically pan and zoom on the regulation layer
-    // "map.getSource("regulations-source").bounds" is not defined inside "map.on('load', () => {", before the map is fully loaded
-    // but do that only one time
+    // "map.getSource("regulations-source").bounds" is not defined inside "map.on('load', () => {", i.e. before the map is fully loaded
+    // we must do that only one time
     if (first_map_load) {
 	map.fitBounds(
 	    map.getSource("regulations-source").bounds,

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -29,7 +29,7 @@ map.on('load', () => {
     map.on('click', 'regulations-layer', (e) => {
         new maplibregl.Popup()
             .setLngLat(e.lngLat)
-            .setHTML(e.features[0].properties.road_name + " [" + e.features[0].properties.road_number + "]")
+            .setHTML((e.features[0].properties.road_name || "''") + " [" + (e.features[0].properties.road_number || "") + "]")
             .addTo(map);
     });
     // change the cursor when the mouse is over the regulations layer

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -8,6 +8,8 @@ const map = new maplibregl.Map({
 
 let first_map_load = true;
 const draft_filter = ["==", "is_draft", false];
+const permanent_only_filter = ["==", "is_permanent", true]
+const temporary_only_filter = ["==", "is_permanent", false]
 
 map.on('load', () => {
     // sources : 
@@ -108,6 +110,18 @@ document.getElementById('display-drafts').addEventListener('change', (e) => {
     if (! e.target.checked) {  // do not display draft regulations
 	map.setFilter("regulations-layer", draft_filter);
     } else {
+	map.setFilter("regulations-layer", null);
+    };
+});
+document.getElementById('regulations-permanent-and-or-temporary').addEventListener('change', (e) => {
+    switch (e.target.value) {
+    case "permanent-only":
+	map.setFilter("regulations-layer", permanent_only_filter);
+	break;
+    case "temporary-only":
+	map.setFilter("regulations-layer", temporary_only_filter);
+	break;
+    default:
 	map.setFilter("regulations-layer", null);
     };
 });

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -26,5 +26,18 @@ map.on('load', () => {
             'line-width': 10
         }
     });
+    map.on('click', 'regulations-layer', (e) => {
+        new maplibregl.Popup()
+            .setLngLat(e.lngLat)
+            .setHTML(e.features[0].properties.road_name + " [" + e.features[0].properties.road_number + "]")
+            .addTo(map);
+    });
+    // change the cursor when the mouse is over the regulations layer
+    map.on('mouseenter', 'regulations-layer', () => {
+        map.getCanvas().style.cursor = 'pointer';
+    });
+    map.on('mouseleave', 'regulations-layer', () => {
+        map.getCanvas().style.cursor = '';
+    });
 });
 

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -6,6 +6,8 @@ const map = new maplibregl.Map({
     maplibreLogo: false
 });
 
+let first_map_load = true;
+
 map.on('load', () => {
     // sources : 
     map.addSource(
@@ -49,12 +51,16 @@ map.on('load', () => {
 map.on('idle', () => {
     // automatically pan and zoom on the regulation layer
     // "map.getSource("regulations-source").bounds" is not defined inside "map.on('load', () => {", before the map is fully loaded
-    map.fitBounds(
-	map.getSource("regulations-source").bounds,
-	{
-	    padding: 100,
-	    animate: true,
-	    duration: 500  // duration in ms
-	}
-    );
+    // but do that only one time
+    if (first_map_load) {
+	map.fitBounds(
+	    map.getSource("regulations-source").bounds,
+	    {
+		padding: 100,
+		animate: true,
+		duration: 500  // duration in ms
+	    }
+	);
+	first_map_load = false;
+    };
 });

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -7,6 +7,7 @@ const map = new maplibregl.Map({
 });
 
 let first_map_load = true;
+const draft_filter = ["==", "is_draft", false];
 
 map.on('load', () => {
     // sources : 
@@ -81,9 +82,8 @@ map.on('load', () => {
 	map.setFilter("regulations-aggregated-layer", null); // delete the filter
 	map.setLayoutProperty('regulations-aggregated-layer', 'visibility', 'none');
     });
-    // filtering :
-    // demo : this filter will display all regulations (means : (is_draft) OR (NOT is_draft) -> always TRUE)
-    //map.setFilter("regulations-layer", ["any", ["==", "is_draft", true], ["==", "is_draft", false]]);    
+    // filtering : do not display draft regulations by default
+    map.setFilter("regulations-layer", draft_filter);    
 });
 
 map.on('idle', () => {
@@ -100,5 +100,14 @@ map.on('idle', () => {
 	    }
 	);
 	first_map_load = false;
+    };
+});
+
+// UI filtering
+document.getElementById('display-drafts').addEventListener('change', (e) => {
+    if (! e.target.checked) {  // do not display draft regulations
+	map.setFilter("regulations-layer", draft_filter);
+    } else {
+	map.setFilter("regulations-layer", null);
     };
 });

--- a/public/map/map.js
+++ b/public/map/map.js
@@ -7,15 +7,15 @@ const map = new maplibregl.Map({
 });
 
 map.on('load', () => {
-    map.addSource('regulations', {
+    map.addSource('regulations-source', {
         type: 'vector',
         url:
         'http://localhost:3000/location'
     });
     map.addLayer({
-        'id': 'terrain-data',
+        'id': 'regulations-layer',
         'type': 'line',
-        'source': 'regulations',
+        'source': 'regulations-source',
         'source-layer': 'location',
         'layout': {
             'line-join': 'round',


### PR DESCRIPTION
L'idée est d'afficher l'ensemble des arrêtés publiés sur une carte. La carte a pour fond la BD Topo et a en surcouche la localisation des arrêtés et leurs infos (un clic sur un élément de la carte fait apparaître les informations). 
La carte est personnalisable par l'utilisateur : il peut afficher les arrêtés permanents et/ou les temporaires par exemple (voir le pad pour [plus de détails](https://pad.incubateur.net/MaOMoW0QS82FIj5oAABVAw?view#Plan-d’action)). 

Côté technique, j'ai choisi, pour faire le lien entre l'utilisateur et la base de données PostGIS, le serveur de tuiles vectorielles [Martin Tile Server](https://github.com/maplibre/martin), la visualisation côté utilisateur se faisant avec la bibliothèque Javascript [MapLibre GL JS](https://maplibre.org/maplibre-gl-js/docs/). 

Afin que la mise à jour de la carte se fasse quand un arrêté est publié, il faut que la mise en cache soit désactivée côté Martin Tile Server. 
L'idéal étant d'avoir une mise en cache, il faudra surveiller les réflexions en cours côté MapLibre pour avoir un point d'entrée `POST /reload` : voir : https://github.com/maplibre/martin/issues/288#issuecomment-1290575622 et https://github.com/maplibre/martin/pull/1179