### PR TITLE
Corrige le parsing des organisations avec tiret

### DIFF
--- a/src/Infrastructure/Persistence/Cache/Repository/Regulation/AdministratorRepository.php
+++ b/src/Infrastructure/Persistence/Cache/Repository/Regulation/AdministratorRepository.php
@@ -25,7 +25,7 @@ final class AdministratorRepository implements AdministratorRepositoryInterface
 
             foreach (explode('|', $content) as $value) {
                 $value = trim($value); // ' Bas-\nRhin ' => 'Bas-\nRhin'
-                $value = str_replace('-' . PHP_EOL, '', $value); // => 'Bas-Rhin'
+                $value = str_replace('-' . PHP_EOL, '-', $value); // => 'Bas-Rhin'
                 $administrators[] = str_replace(PHP_EOL, ' ', $value); // 'Toulouse\nMétropole' => 'Toulouse Métropole'
             }
 

--- a/tests/Integration/Infrastructure/Repository/AdministratorRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Repository/AdministratorRepositoryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Test\Integration\Infrastructure\Templates;
+
+use App\Domain\Regulation\Repository\AdministratorRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+class AdministratorRepositoryTest extends KernelTestCase
+{
+    public function testRender(): void
+    {
+        static::bootKernel();
+        $container = static::getContainer();
+
+        /** @var AdministratorRepositoryInterface */
+        $repository = $container->get(AdministratorRepositoryInterface::class);
+
+        $administrators = $repository->findAll();
+
+        // Basic case
+        $this->assertContains('Nord', $administrators);
+        // Cases across file lines
+        $this->assertContains('Calvados', $administrators);
+        $this->assertContains('Deux-Sèvres', $administrators);
+        $this->assertContains('Haute-Saône', $administrators, implode(', ', $administrators));
+    }
+}

--- a/tests/Integration/Infrastructure/Repository/AdministratorRepositoryTest.php
+++ b/tests/Integration/Infrastructure/Repository/AdministratorRepositoryTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Test\Integration\Infrastructure\Templates;
+namespace App\Test\Integration\Infrastructure\Repository;
 
 use App\Domain\Regulation\Repository\AdministratorRepositoryInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;


### PR DESCRIPTION
Signalé par @johanricher 

La Haute-Saône était affichée dans la liste comme HauteSaône, idem pour Puy-de-Dôme qui était affiché Puy-deDôme

Cette PR ajoute aussi un test d'intégration du parsing