### PR TITLE
Evite les conflits d'identifiant lors de la duplication

### DIFF
--- a/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
+++ b/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
@@ -43,7 +43,7 @@ final class DuplicateRegulationCommandHandler
         RegulationOrder $originalRegulationOrder,
     ): RegulationOrderRecord {
         $identifier = $this->queryBus->handle(
-            new GetDuplicateIdentifierQuery($originalRegulationOrder->getIdentifier()),
+            new GetDuplicateIdentifierQuery($originalRegulationOrder->getIdentifier(), $organization),
         );
 
         $generalInfo = new SaveRegulationGeneralInfoCommand();

--- a/src/Application/Regulation/Query/GetDuplicateIdentifierQuery.php
+++ b/src/Application/Regulation/Query/GetDuplicateIdentifierQuery.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Application\Regulation\Query;
 
 use App\Application\QueryInterface;
+use App\Domain\User\Organization;
 
 final readonly class GetDuplicateIdentifierQuery implements QueryInterface
 {
     public function __construct(
         public string $identifier,
+        public Organization $organization,
     ) {
     }
 }

--- a/src/Application/Regulation/Query/GetDuplicateIdentifierQuery.php
+++ b/src/Application/Regulation/Query/GetDuplicateIdentifierQuery.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\Query;
+
+use App\Application\QueryInterface;
+
+final readonly class GetDuplicateIdentifierQuery implements QueryInterface
+{
+    public function __construct(
+        public string $identifier,
+    ) {
+    }
+}

--- a/src/Application/Regulation/Query/GetDuplicateIdentifierQueryHandler.php
+++ b/src/Application/Regulation/Query/GetDuplicateIdentifierQueryHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Regulation\Query;
+
+use App\Domain\Regulation\Repository\RegulationOrderRepositoryInterface;
+
+final class GetDuplicateIdentifierQueryHandler
+{
+    public function __construct(
+        private RegulationOrderRepositoryInterface $repository,
+    ) {
+    }
+
+    public function __invoke(GetDuplicateIdentifierQuery $query): string
+    {
+        return $this->repository->getDuplicateIdentifier($query->identifier);
+    }
+}

--- a/src/Application/Regulation/Query/GetDuplicateIdentifierQueryHandler.php
+++ b/src/Application/Regulation/Query/GetDuplicateIdentifierQueryHandler.php
@@ -15,6 +15,6 @@ final class GetDuplicateIdentifierQueryHandler
 
     public function __invoke(GetDuplicateIdentifierQuery $query): string
     {
-        return $this->repository->getDuplicateIdentifier($query->identifier);
+        return $this->repository->getDuplicateIdentifier($query->identifier, $query->organization);
     }
 }

--- a/src/Domain/Regulation/Repository/RegulationOrderRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/RegulationOrderRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\Regulation\Repository;
 
 use App\Domain\Regulation\RegulationOrder;
+use App\Domain\User\Organization;
 
 interface RegulationOrderRepositoryInterface
 {
@@ -12,5 +13,5 @@ interface RegulationOrderRepositoryInterface
 
     public function delete(RegulationOrder $regulationOrder): void;
 
-    public function getDuplicateIdentifier(string $identifier): string;
+    public function getDuplicateIdentifier(string $identifier, Organization $organization): string;
 }

--- a/src/Domain/Regulation/Repository/RegulationOrderRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/RegulationOrderRepositoryInterface.php
@@ -11,4 +11,6 @@ interface RegulationOrderRepositoryInterface
     public function add(RegulationOrder $regulationOrder): RegulationOrder;
 
     public function delete(RegulationOrder $regulationOrder): void;
+
+    public function getDuplicateIdentifier(string $identifier): string;
 }

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
@@ -37,7 +37,7 @@ final class RegulationOrderFixture extends Fixture
 
         $regulationOrderDuplicate = new RegulationOrder(
             uuid: '0658c6ab-6b49-7a3b-8000-0683622905a3',
-            identifier: 'FO2/2023 (copie)',
+            identifier: 'FO2/2023-1',
             category: RegulationOrderCategoryEnum::ROAD_MAINTENANCE->value,
             description: 'Description 2',
             startDate: new \DateTimeImmutable('2023-03-10'),

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRepository.php
@@ -27,4 +27,50 @@ final class RegulationOrderRepository extends ServiceEntityRepository implements
     {
         $this->getEntityManager()->remove($regulationOrder);
     }
+
+    public function getDuplicateIdentifier(string $identifier): string
+    {
+        return $this->getEntityManager()->getConnection()->fetchOne(
+            "WITH base AS (
+                SELECT regexp_replace(:identifier, ' \(\d+\)$', '') AS identifier
+            ),
+            ref AS (
+                SELECT '^' || base.identifier || ' \((\d+)\)$' AS regex
+                FROM base
+            ),
+            numbers AS (
+                SELECT (regexp_match(ro.identifier, ref.regex))[1]::int AS n
+                FROM regulation_order AS ro, ref
+                WHERE regexp_match(ro.identifier, ref.regex) IS NOT NULL
+            ),
+            numbers_with_prev AS (
+                SELECT n, LAG(n) OVER (ORDER BY n) AS prev_n
+                FROM numbers
+                ORDER BY n
+            ),
+            next_duplicate AS (
+                SELECT CASE
+                    -- No duplicates yet
+                    WHEN (SELECT COUNT(*) FROM numbers_with_prev) = 0 THEN 1
+                    -- Duplicate (1) is available
+                    WHEN (SELECT MIN(n) FROM numbers_with_prev) > 1 THEN 1
+                    -- Default case
+                    ELSE (
+                        SELECT prev_n + 1
+                        FROM numbers_with_prev
+                        WHERE n - prev_n >= 2
+                        UNION ALL
+                            -- When no empty duplicate slot is available,
+                            -- use last duplicate + 1
+                            (SELECT MAX(n) + 1 FROM numbers_with_prev)
+                        LIMIT 1
+                    )
+                END AS n
+            )
+            SELECT base.identifier || ' (' || next_duplicate.n || ')'
+            FROM base, next_duplicate
+            ",
+            ['identifier' => $identifier],
+        );
+    }
 }

--- a/src/Infrastructure/Validator/SaveRegulationGeneralInfoCommandConstraintValidator.php
+++ b/src/Infrastructure/Validator/SaveRegulationGeneralInfoCommandConstraintValidator.php
@@ -33,6 +33,7 @@ final class SaveRegulationGeneralInfoCommandConstraintValidator extends Constrai
             if ($this->doesOrganizationAlreadyHaveRegulationOrderWithThisIdentifier
                 ->isSatisfiedBy($command->identifier, $command->organization)) {
                 $this->context->buildViolation('regulation.general_info.error.identifier')
+                    ->setParameter('%identifier%', $command->identifier)
                     ->atPath('identifier')
                     ->addViolation();
             }

--- a/tests/Integration/Infrastructure/Controller/Regulation/AddRegulationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/AddRegulationControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Infrastructure\Controller\Regulation;
 
 use App\Domain\Regulation\Enum\RegulationOrderCategoryEnum;
 use App\Infrastructure\Persistence\Doctrine\Fixtures\OrganizationFixture;
+use App\Infrastructure\Persistence\Doctrine\Fixtures\RegulationOrderFixture;
 use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
 
 final class AddRegulationControllerTest extends AbstractWebTestCase
@@ -101,7 +102,8 @@ final class AddRegulationControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Continuer');
         $form = $saveButton->form();
-        $form['general_info_form[identifier]'] = 'FO1/2023';
+        $identifier = RegulationOrderFixture::TYPICAL_IDENTIFIER;
+        $form['general_info_form[identifier]'] = $identifier;
         $form['general_info_form[organization]'] = OrganizationFixture::MAIN_ORG_ID;
         $form['general_info_form[description]'] = 'Travaux';
         $form['general_info_form[startDate]'] = '2023-02-12';
@@ -110,7 +112,7 @@ final class AddRegulationControllerTest extends AbstractWebTestCase
 
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
-        $this->assertSame('Un arrêté avec cet identifiant existe déjà. Veuillez saisir un autre identifiant.', $crawler->filter('#general_info_form_identifier_error')->text());
+        $this->assertSame(sprintf('Un arrêté avec l\'identifiant "%s" existe déjà. Veuillez saisir un autre identifiant.', $identifier), $crawler->filter('#general_info_form_identifier_error')->text());
     }
 
     public function testCancel(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/SaveRegulationGeneralInfoControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/SaveRegulationGeneralInfoControllerTest.php
@@ -24,7 +24,8 @@ final class SaveRegulationGeneralInfoControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Valider');
         $form = $saveButton->form();
-        $form['general_info_form[identifier]'] = RegulationOrderFixture::TYPICAL_IDENTIFIER;
+        $identifier = RegulationOrderFixture::TYPICAL_IDENTIFIER;
+        $form['general_info_form[identifier]'] = $identifier;
         $form['general_info_form[organization]'] = OrganizationFixture::MAIN_ORG_ID;
         $form['general_info_form[category]'] = RegulationOrderCategoryEnum::ROAD_MAINTENANCE->value;
         $form['general_info_form[description]'] = 'Travaux';
@@ -32,7 +33,7 @@ final class SaveRegulationGeneralInfoControllerTest extends AbstractWebTestCase
         $form['general_info_form[endDate]'] = '2024-02-11';
         $crawler = $client->submit($form);
         $this->assertResponseStatusCodeSame(422);
-        $this->assertSame('Un arrêté avec cet identifiant existe déjà. Veuillez saisir un autre identifiant.', $crawler->filter('#general_info_form_identifier_error')->text());
+        $this->assertSame(sprintf('Un arrêté avec l\'identifiant "%s" existe déjà. Veuillez saisir un autre identifiant.', $identifier), $crawler->filter('#general_info_form_identifier_error')->text());
     }
 
     public function testEditDescriptionTruncated(): void

--- a/tests/Unit/Application/Regulation/Query/GetDuplicateIdentifierQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetDuplicateIdentifierQueryHandlerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Application\Regulation\Query;
+
+use App\Application\Regulation\Query\GetDuplicateIdentifierQuery;
+use App\Application\Regulation\Query\GetDuplicateIdentifierQueryHandler;
+use App\Domain\Regulation\Repository\RegulationOrderRepositoryInterface;
+use App\Domain\User\Organization;
+use PHPUnit\Framework\TestCase;
+
+final class GetDuplicateIdentifierQueryHandlerTest extends TestCase
+{
+    public function testHandler(): void
+    {
+        $organization = $this->createMock(Organization::class);
+        $regulationOrderRepository = $this->createMock(RegulationOrderRepositoryInterface::class);
+
+        $regulationOrderRepository
+            ->expects(self::once())
+            ->method('getDuplicateIdentifier')
+            ->with('identifier', $organization)
+            ->willReturn('duplicateIdentifier');
+
+        $handler = new GetDuplicateIdentifierQueryHandler($regulationOrderRepository);
+        $result = $handler(new GetDuplicateIdentifierQuery('identifier', $organization));
+
+        $this->assertEquals('duplicateIdentifier', $result);
+    }
+}

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -688,10 +688,6 @@
                 <source>regulation.stepper.next</source>
                 <target>Étape suivante :</target>
             </trans-unit>
-            <trans-unit id="regulation.identifier.copy">
-                <source>regulation.identifier.copy</source>
-                <target>%identifier% (copie)</target>
-            </trans-unit>
             <trans-unit id="pagination.first">
                 <source>pagination.first</source>
                 <target>Première page</target>

--- a/translations/validators.fr.xlf
+++ b/translations/validators.fr.xlf
@@ -48,7 +48,7 @@
             </trans-unit>
             <trans-unit id="regulation.general_info.error.identifier">
                 <source>regulation.general_info.error.identifier</source>
-                <target>Un arrêté avec cet identifiant existe déjà. Veuillez saisir un autre identifiant.</target>
+                <target>Un arrêté avec l'identifiant "%identifier%" existe déjà. Veuillez saisir un autre identifiant.</target>
             </trans-unit>
             <trans-unit id="measure.locations.error.not_blank">
                 <source>measure.locations.error.not_blank</source>


### PR DESCRIPTION
* Closes #744 

Cette PR améliore la génération d'identifiant pour les copies d'arrêtés : F01-2023 -> F01/2023-1, etc, en évitant les collisions d'identifiant