### PR TITLE
Log measure failures to Sentry

### DIFF
--- a/src/Infrastructure/Controller/Regulation/Fragments/AddMeasureController.php
+++ b/src/Infrastructure/Controller/Regulation/Fragments/AddMeasureController.php
@@ -85,6 +85,7 @@ final class AddMeasureController extends AbstractRegulationController
                 );
             } catch (LaneGeocodingFailureException $exc) {
                 $commandFailed = true;
+                \Sentry\captureException($exc);
                 $form->get('locations')->get((string) $exc->getLocationIndex())->get('namedStreet')->get('fromPointType')->addError(
                     new FormError(
                         $this->translator->trans('regulation.location.error.lane_geocoding_failed', [], 'validators'),
@@ -92,6 +93,7 @@ final class AddMeasureController extends AbstractRegulationController
                 );
             } catch (AbscissaOutOfRangeException $exc) {
                 $commandFailed = true;
+                \Sentry\captureException($exc);
                 $field = $exc instanceof StartAbscissaOutOfRangeException ? 'fromAbscissa' : 'toAbscissa';
                 $form->get('locations')->get((string) $exc->getLocationIndex())->get('numberedRoad')->get($field)->addError(
                     new FormError(
@@ -100,6 +102,7 @@ final class AddMeasureController extends AbstractRegulationController
                 );
             } catch (RoadGeocodingFailureException $exc) {
                 $commandFailed = true;
+                \Sentry\captureException($exc);
                 $form->get('locations')->get((string) $exc->getLocationIndex())->get('numberedRoad')->get('roadNumber')->addError(
                     new FormError(
                         $this->translator->trans('regulation.location.error.departmental_road_geocoding_failed', [], 'validators'),
@@ -107,6 +110,7 @@ final class AddMeasureController extends AbstractRegulationController
                 );
             } catch (GeocodingFailureException $exc) {
                 $commandFailed = true;
+                \Sentry\captureException($exc);
                 $form->get('locations')->get((string) $exc->getLocationIndex())->get('namedStreet')->get('roadName')->addError(
                     new FormError(
                         $this->translator->trans('regulation.location.error.geocoding_failed', [], 'validators'),

--- a/src/Infrastructure/Controller/Regulation/Fragments/UpdateMeasureController.php
+++ b/src/Infrastructure/Controller/Regulation/Fragments/UpdateMeasureController.php
@@ -90,6 +90,7 @@ final class UpdateMeasureController extends AbstractRegulationController
                 );
             } catch (LaneGeocodingFailureException $exc) {
                 $commandFailed = true;
+                \Sentry\captureException($exc);
                 $form->get('locations')->get((string) $exc->getLocationIndex())->get('namedStreet')->get('fromPointType')->addError(
                     new FormError(
                         $this->translator->trans('regulation.location.error.lane_geocoding_failed', [], 'validators'),
@@ -97,6 +98,7 @@ final class UpdateMeasureController extends AbstractRegulationController
                 );
             } catch (AbscissaOutOfRangeException $exc) {
                 $commandFailed = true;
+                \Sentry\captureException($exc);
                 $field = $exc instanceof StartAbscissaOutOfRangeException ? 'fromAbscissa' : 'toAbscissa';
                 $form->get('locations')->get((string) $exc->getLocationIndex())->get('numberedRoad')->get($field)->addError(
                     new FormError(
@@ -105,6 +107,7 @@ final class UpdateMeasureController extends AbstractRegulationController
                 );
             } catch (RoadGeocodingFailureException $exc) {
                 $commandFailed = true;
+                \Sentry\captureException($exc);
                 $form->get('locations')->get((string) $exc->getLocationIndex())->get('numberedRoad')->get('roadNumber')->addError(
                     new FormError(
                         $this->translator->trans('regulation.location.error.departmental_road_geocoding_failed', [], 'validators'),
@@ -112,6 +115,7 @@ final class UpdateMeasureController extends AbstractRegulationController
                 );
             } catch (GeocodingFailureException $exc) {
                 $commandFailed = true;
+                \Sentry\captureException($exc);
                 $form->get('locations')->get((string) $exc->getLocationIndex())->get('namedStreet')->get('roadName')->addError(
                     new FormError(
                         $this->translator->trans('regulation.location.error.geocoding_failed', [], 'validators'),


### PR DESCRIPTION
@MathieuFV a rencontré une erreur inattendue en rentrant les données JOP

Le 14/05/2024 à 14h59, l'enregistrement d'une mesure comportant une 20aine de localisations que MF voulait faire utiliser les intersections a échoué avec le message "Failed to load resource: the server responded with a status of 422 ()"

Il n'y a aucun détail dans les logs de l'application sur Scalingo

J'ai d'abord pensé que c'était une erreur de validation, car aucune modification n'a été enregistrée

Mais c'est probablement plutôt une erreur transitoire dans la géolocalisation, par exemple erreur réseau entre DiaLog et la BD TOPO. Comme la commande SaveMeasure s'exécute dans une transaction, aucune modification n'aurait été enregistrée dans ce cas là non plus.

Je pense aussi que l'erreur de validation aurait affiché un message détaillé quelque part, au moins dans les logs, de type : "Command xxx failed validation".

Ici on a rien et pour cause, dans le cas d'une erreur gérée par les controllers, on "avale" l'exception et on renvoie une 422 vide.

Cette PR propose de logger les exceptions dans Sentry pour qu'on puisse avoir tout le contexte et les statistiques si ce problème se reproduit (ce qui est probable)

Comme solution on pourrait envisager de mettre en place des retries dans les requêtes à la BD TOPO... (si le problème vient bien de là, à confirmer avec ce qu'indiquera Sentry)