### PR TITLE
Corrige la suppresion d'une localisation

### DIFF
--- a/src/Application/Regulation/Command/Location/SaveNamedStreetCommand.php
+++ b/src/Application/Regulation/Command/Location/SaveNamedStreetCommand.php
@@ -41,6 +41,7 @@ final class SaveNamedStreetCommand implements RoadCommandInterface
         $this->toHouseNumber = $namedStreet?->getToHouseNumber();
         $this->toRoadName = $namedStreet?->getToRoadName();
         $this->isEntireStreetFormValue = $namedStreet ? $this->computeIsEntireStreetFormValue() : null;
+        $this->roadType = $namedStreet?->getLocation()?->getRoadType();
     }
 
     public function clean(): void

--- a/src/Application/Regulation/Command/Location/SaveNumberedRoadCommand.php
+++ b/src/Application/Regulation/Command/Location/SaveNumberedRoadCommand.php
@@ -36,6 +36,7 @@ final class SaveNumberedRoadCommand implements RoadCommandInterface
         $this->toPointNumber = $numberedRoad?->getToPointNumber();
         $this->toAbscissa = $numberedRoad?->getToAbscissa();
         $this->toSide = $numberedRoad?->getToSide();
+        $this->roadType = $numberedRoad?->getLocation()?->getRoadType();
     }
 
     // Road command interface

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -176,13 +176,13 @@
                         'change->form-reveal#openByValue'
                     },
                 }) }}
-
                 <div
                     data-controller="reset"
                     data-form-reveal-target="section"
                     data-value="departmentalRoad"
                     {% if form.roadType.vars.value != 'departmentalRoad'%} hidden {% endif %}
                 >
+                    {{ form_row(form.numberedRoad.roadType) }}
                     {{ form_row(form.numberedRoad.administrator, {
                         group_class: 'fr-input-group',
                         widget_class: 'fr-input',
@@ -274,6 +274,7 @@
                         data-action="autocomplete.change->reset#reset"
                         data-reset-key-param="city"
                     >
+                        {{ form_row(form.namedStreet.roadType) }}
                         {{ form_row(form.namedStreet.cityCode, { attr: {'data-autocomplete-target': 'hidden'} }) }}
 
                         {{ form_row(form.namedStreet.cityLabel, {


### PR DESCRIPTION
* Closes #768 

Pour une raison que j'ignore encore, lors de la suppression d'une localisation, le formulaire Symfony conserve tout de même l'élément avec le roadType à null. 
![image](https://github.com/MTES-MCT/dialog/assets/2683379/d74e1025-3c9c-4c7b-a145-713a29a07b65)
