### PR TITLE
Corrige la condition de validation du point de fin

### DIFF
--- a/config/validator/Application/Regulation/Command/SaveNamedStreetCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveNamedStreetCommand.xml
@@ -71,7 +71,7 @@
                 <option name="max">8</option>
             </constraint>
             <constraint name="When">
-                <option name="expression">this.roadType === 'lane' and this.fromPointType === 'houseNumber'</option>
+                <option name="expression">this.roadType === 'lane' and this.toPointType === 'houseNumber'</option>
                 <option name="constraints">
                     <constraint name="NotBlank" />
                 </option>
@@ -82,7 +82,7 @@
                 <option name="max">255</option>
             </constraint>
             <constraint name="When">
-                <option name="expression">this.roadType === 'lane' and this.fromPointType === 'intersection'</option>
+                <option name="expression">this.roadType === 'lane' and this.toPointType === 'intersection'</option>
                 <option name="constraints">
                     <constraint name="NotBlank" />
                 </option>

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
@@ -229,7 +229,7 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#measure_form_locations_0_namedStreet_toHouseNumber_error')->text());
     }
 
-    public function testAddLaneWithBlankIntersectionRoadNames(): void
+    public function testAddLaneWithBlankFromRoadName(): void
     {
         $client = $this->login();
         $crawler = $client->request('GET', '/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/measure/add');
@@ -249,13 +249,41 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         unset($values['measure_form']['locations'][0]['namedStreet']['isEntireStreet']);
         $values['measure_form']['locations'][0]['namedStreet']['fromPointType'] = 'intersection';
         $values['measure_form']['locations'][0]['namedStreet']['fromRoadName'] = '';
+        $values['measure_form']['locations'][0]['namedStreet']['toPointType'] = 'houseNumber';
+        $values['measure_form']['locations'][0]['namedStreet']['toRoadName'] = '15';
+
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#measure_form_locations_0_namedStreet_fromRoadName_error')->text());
+    }
+
+    public function testAddLaneWithBlankToRoadName(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/measure/add');
+        $this->assertResponseStatusCodeSame(200);
+
+        $saveButton = $crawler->selectButton('Valider');
+        $form = $saveButton->form();
+
+        // Get the raw values.
+        $values = $form->getPhpValues();
+        $values['measure_form']['type'] = 'noEntry';
+        $values['measure_form']['locations'][0]['roadType'] = 'lane';
+        $values['measure_form']['locations'][0]['namedStreet']['roadType'] = 'lane';
+        $values['measure_form']['locations'][0]['namedStreet']['cityCode'] = '44195';
+        $values['measure_form']['locations'][0]['namedStreet']['cityLabel'] = 'Savenay (44260)';
+        $values['measure_form']['locations'][0]['namedStreet']['roadName'] = 'Route du Grand Brossais';
+        unset($values['measure_form']['locations'][0]['namedStreet']['isEntireStreet']);
+        $values['measure_form']['locations'][0]['namedStreet']['fromPointType'] = 'houseNumber';
+        $values['measure_form']['locations'][0]['namedStreet']['fromRoadName'] = '15';
         $values['measure_form']['locations'][0]['namedStreet']['toPointType'] = 'intersection';
         $values['measure_form']['locations'][0]['namedStreet']['toRoadName'] = '';
 
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#measure_form_locations_0_namedStreet_fromRoadName_error')->text());
         $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#measure_form_locations_0_namedStreet_toRoadName_error')->text());
     }
 


### PR DESCRIPTION
Bug de faute de frappe pas vu lors de la review de #762 

Il n'était pas catché par les tests car il y avait un seul test pour les deux cas fromPointType/toPointType

Cette PR sépare donc ce test en 2 pour éviter la régression