### PR TITLE
Sections : applique une tolérance pour le calcul des morceaux de rattachement

### DIFF
--- a/src/Infrastructure/Adapter/LineSectionMaker.php
+++ b/src/Infrastructure/Adapter/LineSectionMaker.php
@@ -23,6 +23,7 @@ final class LineSectionMaker implements LineSectionMakerInterface
         string $lineGeometry,
         Coordinates $fromCoords,
         Coordinates $toCoords,
+        int|float $tolerance = 1, // Meters
     ): string {
         $includeCrs = str_contains($lineGeometry, '"crs"');
 
@@ -30,32 +31,44 @@ final class LineSectionMaker implements LineSectionMakerInterface
         $pointB = $toCoords->asGeoJSON($includeCrs);
 
         $row = $this->em->getConnection()->fetchAssociative(
-            'WITH linestring AS (
+            'WITH a AS (
+                SELECT ST_SetSRID(ST_GeomFromGeoJSON(:point_a), 4326) AS geom
+            ),
+            b AS (
+                SELECT ST_SetSRID(ST_GeomFromGeoJSON(:point_b), 4326) AS geom
+            ),
+            linestring AS (
                 -- Split the line geometry into its individual LINESTRING components
                 SELECT (components.dump).geom AS geom FROM (
-                    SELECT ST_Dump(ST_LineMerge(:geom)) AS dump
+                    SELECT ST_Dump(ST_LineMerge(ST_SetSRID(ST_GeomFromGeoJSON(:geom), 4326))) AS dump
                 ) AS components
             ),
-            -- For each point, find the LINESTRING(s) it is closest to (multiple closest line strings is a mostly theoretical case)
+            -- For each point, find the LINESTRING(s) it is closest to, within a tolerance radius
             linestring_a AS (
                 SELECT l.geom
                 FROM linestring AS l
-                WHERE ST_Distance(:point_a, l.geom) = (SELECT MIN(ST_Distance(:point_a, geom)) FROM linestring)
+                JOIN a ON true
+                -- ::geography ensures distances are computed in meters
+                WHERE ST_Distance(a.geom::geography, l.geom::geography) <= (SELECT MIN(ST_Distance(a.geom::geography, geom::geography)) FROM linestring) + :tolerance
             ),
             linestring_b AS (
                 SELECT l.geom
                 FROM linestring AS l
-                WHERE ST_Distance(:point_b, l.geom) = (SELECT MIN(ST_Distance(:point_b, geom)) FROM linestring)
+                JOIN b ON true
+                -- ::geography ensures distances are computed in meters
+                WHERE ST_Distance(b.geom::geography, l.geom::geography) <= (SELECT MIN(ST_Distance(b.geom::geography, geom::geography)) FROM linestring) + :tolerance
             )
             -- Compute the section on the LINESTRING to which both points belong to.
             SELECT ST_AsGeoJSON(
                 ST_LineSubstring(
                     l.geom,
-                    LEAST(ST_LineLocatePoint(l.geom, :point_a), ST_LineLocatePoint(l.geom, :point_b)),
-                    GREATEST(ST_LineLocatePoint(l.geom, :point_a), ST_LineLocatePoint(l.geom, :point_b))
+                    LEAST(ST_LineLocatePoint(l.geom, a.geom), ST_LineLocatePoint(l.geom, b.geom)),
+                    GREATEST(ST_LineLocatePoint(l.geom, a.geom), ST_LineLocatePoint(l.geom, b.geom))
                 )
             ) AS section
             FROM linestring_a AS l
+            JOIN a ON true
+            JOIN b ON true
             -- If the points belong to different LINESTRINGs, this join will be empty.
             INNER JOIN linestring_b ON l.geom = linestring_b.geom
             LIMIT 1
@@ -64,6 +77,7 @@ final class LineSectionMaker implements LineSectionMakerInterface
                 'geom' => $lineGeometry,
                 'point_a' => $pointA,
                 'point_b' => $pointB,
+                'tolerance' => $tolerance,
             ],
         );
 

--- a/tests/Integration/Infrastructure/Adapter/LineSectionMakerTest.php
+++ b/tests/Integration/Infrastructure/Adapter/LineSectionMakerTest.php
@@ -7,11 +7,14 @@ namespace App\Tests\Integration\Infrastructure\Adapter;
 use App\Application\Exception\GeocodingFailureException;
 use App\Domain\Geography\Coordinates;
 use App\Infrastructure\Adapter\LineSectionMaker;
+use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 final class LineSectionMakerTest extends KernelTestCase
 {
+    /** @var Connection */
+    private $bdtopoConnection;
     private $lineGeometry;
     private $em;
     private $lineSectionMaker;
@@ -20,17 +23,20 @@ final class LineSectionMakerTest extends KernelTestCase
     {
         $container = self::getContainer();
 
+        $this->bdtopoConnection = $container->get('doctrine.dbal.bdtopo_connection');
+
         $lineStrings = [
             /*
-             * The coordinates below represent the 3 line strings "a", "b" and "c".
-             * They all intersect at the point marked as "+" (belongs to all line strings).
+             * The coordinates below represent the line strings "a", "b", "c" and "d".
+             * Line strings "a", "b" and "c" all intersect at the point marked as "+" (belongs to all line strings).
+             * There is a gap between "c" and "d".
              *
              * y (lat)
              * ^
-             * 3....b...
-             * 2aaa.+..c
-             * 1a......c
-             * 012345678> x (lon)
+             * 3....b.......
+             * 2aaa-+-c....d
+             * 1a.....c.....
+             * 0123456789012> x (lon)
              */
             [
                 // a
@@ -48,8 +54,13 @@ final class LineSectionMakerTest extends KernelTestCase
             [
                 // c
                 [5, 2],
-                [8, 2],
-                [8, 1],
+                [7, 2],
+                [7, 1],
+            ],
+            [
+                // d
+                [12, 2],
+                [13, 2],
             ],
         ];
 
@@ -62,6 +73,30 @@ final class LineSectionMakerTest extends KernelTestCase
 
         $this->em = $container->get(EntityManagerInterface::class);
         $this->lineSectionMaker = new LineSectionMaker($this->em);
+    }
+
+    /**
+     * Return the tolerance radius to apply so that $pointA and $pointB are exactly equally distant to $point.
+     */
+    private static function getThresholdTolerance(Connection $bdtopoConnection, Coordinates $point, Coordinates $pointA, Coordinates $pointB): float
+    {
+        $distA = $bdtopoConnection->fetchOne(
+            'SELECT ST_Distance(ST_GeomFromGeoJSON(:p)::geography, ST_GeomFromGeoJSON(:a)::geography)',
+            [
+                'p' => $point->asGeoJSON(),
+                'a' => $pointA->asGeoJSON(),
+            ],
+        );
+
+        $distB = $bdtopoConnection->fetchOne(
+            'SELECT ST_Distance(ST_GeomFromGeoJSON(:p)::geography, ST_GeomFromGeoJSON(:b)::geography)',
+            [
+                'p' => $point->asGeoJSON(),
+                'b' => $pointB->asGeoJSON(),
+            ],
+        );
+
+        return abs($distB - $distA);
     }
 
     private function provideComputeSection(): array
@@ -81,13 +116,13 @@ final class LineSectionMakerTest extends KernelTestCase
                 ]),
             ],
             'pointsNearSameLine' => [
-                'fromCoords' => Coordinates::fromLonLat(6, 1), // Maps to (6, 2) on b
-                'toCoords' => Coordinates::fromLonLat(9, 2), // Maps to (8, 2) on b
+                'fromCoords' => Coordinates::fromLonLat(6, 1), // Maps to (6, 2) and (7, 1) on c
+                'toCoords' => Coordinates::fromLonLat(9, 2), // Maps to (7, 2) on c
                 'section' => json_encode([
                     'type' => 'LineString',
                     'coordinates' => [
                         [6, 2],
-                        [8, 2],
+                        [7, 2],
                     ],
                 ]),
             ],
@@ -111,9 +146,27 @@ final class LineSectionMakerTest extends KernelTestCase
                     'type' => 'LineString',
                     'coordinates' => [
                         [5, 2],
-                        [8, 2],
+                        [7, 2],
                     ],
                 ]),
+            ],
+            'pointNearSameLineWithinTolerance' => [
+                'fromCoords' => Coordinates::fromLonLat(7, 1),
+                'toCoords' => Coordinates::fromLonLat(9.6, 2), // P
+                'section' => json_encode([
+                    'type' => 'LineString',
+                    'coordinates' => [
+                        [7, 2],
+                        [7, 1],
+                    ],
+                ]),
+                'getTolerance' => fn ($bdtopoConnection) => 1.01 // Just above
+                    * self::getThresholdTolerance(
+                        $bdtopoConnection,
+                        point: Coordinates::fromLonLat(9.6, 2), // P
+                        pointA: Coordinates::fromLonLat(7, 2), // Point of c that is closest to P
+                        pointB: Coordinates::fromLonLat(12, 2), // Point of d that is closest to P
+                    ),
             ],
         ];
     }
@@ -121,17 +174,30 @@ final class LineSectionMakerTest extends KernelTestCase
     /**
      * @dataProvider provideComputeSection
      */
-    public function testComputeSection(Coordinates $fromCoords, Coordinates $toCoords, string $section): void
+    public function testComputeSection(Coordinates $fromCoords, Coordinates $toCoords, string $section, ?\Closure $getTolerance = null): void
     {
-        $this->assertSame($section, $this->lineSectionMaker->computeSection($this->lineGeometry, $fromCoords, $toCoords));
+        $tolerance = $getTolerance ? $getTolerance($this->bdtopoConnection) : 1;
+
+        $this->assertSame($section, $this->lineSectionMaker->computeSection($this->lineGeometry, $fromCoords, $toCoords, $tolerance));
     }
 
     private function provideComputeSectionError(): array
     {
         return [
-            'pointsDoNotBelongToSameSegment' => [
-                'fromCoords' => Coordinates::fromLonLat(1, 1),
-                'toCoords' => Coordinates::fromLonLat(7, 3),
+            'pointsDoNotMapToSameSegment' => [
+                'fromCoords' => Coordinates::fromLonLat(1, 1), // Belongs to a
+                'toCoords' => Coordinates::fromLonLat(7, 3), // Maps to c
+            ],
+            'pointsMapOutsideTolerance' => [
+                'fromCoords' => Coordinates::fromLonLat(7, 1),
+                'toCoords' => Coordinates::fromLonLat(9.6, 2), // P
+                'getTolerance' => fn ($bdtopoConnection) => 0.99 // Just below
+                    * self::getThresholdTolerance(
+                        $bdtopoConnection,
+                        point: Coordinates::fromLonLat(9.6, 2), // P
+                        pointA: Coordinates::fromLonLat(7, 2), // Point of c that is closest to P
+                        pointB: Coordinates::fromLonLat(12, 2), // Point of d that is closest to P
+                    ),
             ],
         ];
     }
@@ -139,10 +205,11 @@ final class LineSectionMakerTest extends KernelTestCase
     /**
      * @dataProvider provideComputeSectionError
      */
-    public function testComputeSectionError(Coordinates $fromCoords, Coordinates $toCoords): void
+    public function testComputeSectionError(Coordinates $fromCoords, Coordinates $toCoords, ?\Closure $getTolerance = null): void
     {
-        $this->expectException(GeocodingFailureException::class);
+        $tolerance = $getTolerance ? $getTolerance($this->bdtopoConnection) : 1;
 
-        $this->lineSectionMaker->computeSection($this->lineGeometry, $fromCoords, $toCoords);
+        $this->expectException(GeocodingFailureException::class);
+        $this->lineSectionMaker->computeSection($this->lineGeometry, $fromCoords, $toCoords, $tolerance);
     }
 }


### PR DESCRIPTION
Corrige un bug détecté par @MathieuFV 

On pouvait le voir sur le cas de la Rue Bayard à Paris 8, en saisissant début = Place François 1er, fin = numéro 30

La Rue Bayard est en deux "morceaux" : un morceau au nord de la place, et un morceau au sud

Or le point représentant la Rue Bayard dans l'API Adresse est _quelques centimètres plus proche du morceau sud que le morceau nord

Donc l'algorithme de calcul de section le rattachait au morceau sud alors que ce qu'on voudrait c'est le rattacher au deux puisque la différence de distance est minuscule

Cette PR introduit donc une tolérance de 1m dans le choix des morceaux candidats sur la base de leur distance au point

## Pour tester

Prendre ce cas-ci:

* Commune : Paris 8ème Arrondissement
* Voie : Rue Bayard
* Point de début : Numéro 30
* Point de fin : Intersection avec la Place François 1er

Sur main, le géocodage échoue

Sur cette PR, il réussit, et on peut vérifier qu'il est correct

![Capture d’écran du 2024-05-15 15-55-51](https://github.com/MTES-MCT/dialog/assets/15911462/d52ac902-c6b1-4c2a-99b2-a1b2efcff3ae)
