### PR TITLE
Permet de limiter les arrêtés exportés en CIFS

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,6 +8,7 @@ parameters:
     client_timezone: '%env(APP_CLIENT_TIMEZONE)%'
     admin_email: '%env(ADMIN_EMAIL)%'
     features: []
+    _empty_array: []
 
 services:
     # default configuration for services in *this* file
@@ -23,7 +24,7 @@ services:
             $bacIdfDecreesFile: '%env(APP_BAC_IDF_DECREES_FILE)%'
             $bacIdfCitiesFile: '%env(APP_BAC_IDF_CITIES_FILE)%'
             $featureMap: '%features%'
-            $cifsAllowedRegulationOrderRecordIds: '%env(default::json:APP_CIFS_ALLOWED_REGULATION_ORDER_RECORD_IDS)%'
+            $cifsAllowedRegulationOrderRecordIds: '%env(default:_empty_array:json:APP_CIFS_ALLOWED_REGULATION_ORDER_RECORD_IDS)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -23,6 +23,7 @@ services:
             $bacIdfDecreesFile: '%env(APP_BAC_IDF_DECREES_FILE)%'
             $bacIdfCitiesFile: '%env(APP_BAC_IDF_CITIES_FILE)%'
             $featureMap: '%features%'
+            $cifsAllowedRegulationOrderRecordIds: '%env(default::json:APP_CIFS_ALLOWED_REGULATION_ORDER_RECORD_IDS)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -95,6 +95,7 @@ Chaque application peut être configurée avec les variables d'environnement sui
 | `APP_EUDONET_PARIS_BASE_URL` | URL de l'API Eudonet Paris | https://eudonet-partage.apps.paris.fr | |
 | `APP_EUDONET_PARIS_ORG_ID` | Utiliser l'UUID de l'organisation Ville de Paris | _Vide_ | |
 | `APP_SECRET` | Correspond au paramètre Symfony [`secret`](https://symfony.com/doc/current/reference/configuration/framework.html#secret) | _(Obligatoire)_ | Longueur recommandée : 32 caractères. Exemple : générer avec `python3 -c 'import secrets; print(secrets.token_hex(16))'` |
+| `APP_CIFS_REGULATION_ORDER_RECORD_IDS` | N'exporte en CIFS que les arrêtés dont le `regulation_order_record.uuid` est parmi cette liste | | Format JSON. La liste vide `[]` a pour effet de continuer d'exporter tous les arrêtés |
 | `DATABASE_URL` | URL vers le serveur PostgreSQL | _(Obligatoire)_ `$SCALINGO_POSTGRESQL_URL` | La variable `$SCALINGO_POSTGRESQL_URL` est configurée automatiquement par Scalingo |
 | `MATOMO_ENABLED` | `true` (ou autre valeur truthy) pour activer les [analytics](../tools/analytics.md), `false` pour ne pas les activer | `false` | |
 | `PHP_BUILDPACK_NO_NODE` | Désactive le support Node.js dans le buildpack PHP, puisqu'on utilise le buildpack Node.js complet (voir `.buildpacks`). | _(Obligatoire)_ `true` | Voir : [PHP application with Node.js (Scalingo docs)](https://doc.scalingo.com/languages/php/php-nodejs) |

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -95,7 +95,7 @@ Chaque application peut être configurée avec les variables d'environnement sui
 | `APP_EUDONET_PARIS_BASE_URL` | URL de l'API Eudonet Paris | https://eudonet-partage.apps.paris.fr | |
 | `APP_EUDONET_PARIS_ORG_ID` | Utiliser l'UUID de l'organisation Ville de Paris | _Vide_ | |
 | `APP_SECRET` | Correspond au paramètre Symfony [`secret`](https://symfony.com/doc/current/reference/configuration/framework.html#secret) | _(Obligatoire)_ | Longueur recommandée : 32 caractères. Exemple : générer avec `python3 -c 'import secrets; print(secrets.token_hex(16))'` |
-| `APP_CIFS_REGULATION_ORDER_RECORD_IDS` | N'exporte en CIFS que les arrêtés dont le `regulation_order_record.uuid` est parmi cette liste | | Format JSON. La liste vide `[]` a pour effet de continuer d'exporter tous les arrêtés |
+| `APP_CIFS_REGULATION_ORDER_RECORD_IDS` | N'exporte en CIFS que les arrêtés dont le `regulation_order_record.uuid` est parmi cette liste | `[]` | Format JSON. La liste vide `[]` a pour effet de continuer d'exporter tous les arrêtés |
 | `DATABASE_URL` | URL vers le serveur PostgreSQL | _(Obligatoire)_ `$SCALINGO_POSTGRESQL_URL` | La variable `$SCALINGO_POSTGRESQL_URL` est configurée automatiquement par Scalingo |
 | `MATOMO_ENABLED` | `true` (ou autre valeur truthy) pour activer les [analytics](../tools/analytics.md), `false` pour ne pas les activer | `false` | |
 | `PHP_BUILDPACK_NO_NODE` | Désactive le support Node.js dans le buildpack PHP, puisqu'on utilise le buildpack Node.js complet (voir `.buildpacks`). | _(Obligatoire)_ `true` | Voir : [PHP application with Node.js (Scalingo docs)](https://doc.scalingo.com/languages/php/php-nodejs) |

--- a/src/Application/Regulation/Query/GetCifsIncidentsQueryHandler.php
+++ b/src/Application/Regulation/Query/GetCifsIncidentsQueryHandler.php
@@ -20,12 +20,15 @@ final class GetCifsIncidentsQueryHandler
     public function __construct(
         private RegulationOrderRecordRepositoryInterface $repository,
         private PolylineMakerInterface $polylineMaker,
+        private ?array $cifsAllowedRegulationOrderRecordIds = null,
     ) {
     }
 
     public function __invoke(GetCifsIncidentsQuery $query): array
     {
-        $regulationOrderRecords = $this->repository->findRegulationOrdersForCifsIncidentFormat();
+        $regulationOrderRecords = $this->repository->findRegulationOrdersForCifsIncidentFormat(
+            allowedIds: $this->cifsAllowedRegulationOrderRecordIds ?: [],
+        );
 
         // Reference: https://developers.google.com/waze/data-feed/cifs-specification?hl=fr
         $incidents = [];

--- a/src/Application/Regulation/Query/GetCifsIncidentsQueryHandler.php
+++ b/src/Application/Regulation/Query/GetCifsIncidentsQueryHandler.php
@@ -20,14 +20,14 @@ final class GetCifsIncidentsQueryHandler
     public function __construct(
         private RegulationOrderRecordRepositoryInterface $repository,
         private PolylineMakerInterface $polylineMaker,
-        private ?array $cifsAllowedRegulationOrderRecordIds = null,
+        private array $cifsAllowedRegulationOrderRecordIds = [],
     ) {
     }
 
     public function __invoke(GetCifsIncidentsQuery $query): array
     {
         $regulationOrderRecords = $this->repository->findRegulationOrdersForCifsIncidentFormat(
-            allowedIds: $this->cifsAllowedRegulationOrderRecordIds ?: [],
+            allowedIds: $this->cifsAllowedRegulationOrderRecordIds,
         );
 
         // Reference: https://developers.google.com/waze/data-feed/cifs-specification?hl=fr

--- a/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
@@ -24,7 +24,7 @@ interface RegulationOrderRecordRepositoryInterface
 
     public function findRegulationOrdersForDatexFormat(): array;
 
-    public function findRegulationOrdersForCifsIncidentFormat(): array;
+    public function findRegulationOrdersForCifsIncidentFormat(array $allowedIds = []): array;
 
     public function doesOneExistInOrganizationWithIdentifier(Organization $organization, string $identifier): bool;
 

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -159,7 +159,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
         ;
     }
 
-    public function findRegulationOrdersForCifsIncidentFormat(): array
+    public function findRegulationOrdersForCifsIncidentFormat(array $allowedIds = []): array
     {
         return $this->createQueryBuilder('roc')
             ->addSelect('ro', 'loc', 'm', 'p', 'd', 't')
@@ -171,6 +171,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->leftJoin('p.dailyRange', 'd')
             ->leftJoin('p.timeSlots', 't')
             ->where(
+                $allowedIds ? 'roc.uuid IN (:uuids)' : null,
                 'roc.status = :status',
                 'ro.endDate IS NOT NULL',
                 'loc.geometry IS NOT NULL',
@@ -178,6 +179,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
                 'v IS NULL or (v.restrictedTypes = \'a:0:{}\' AND v.exemptedTypes = \'a:0:{}\')',
             )
             ->setParameters([
+                ...($allowedIds ? ['uuids' => $allowedIds] : []),
                 'status' => RegulationOrderRecordStatusEnum::PUBLISHED,
                 'measureType' => MeasureTypeEnum::NO_ENTRY->value,
             ])

--- a/tests/Unit/Application/Regulation/Query/GetCifsIncidentsQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetCifsIncidentsQueryHandlerTest.php
@@ -524,7 +524,6 @@ final class GetCifsIncidentsQueryHandlerTest extends TestCase
     private function provideTestAllowedIds(): array
     {
         return [
-            [null, []],
             [[], []],
             [['id'], ['id']],
         ];


### PR DESCRIPTION
Refs #716 

Comme discuté en daily et sur Mattermost:

Cette PR permet de n'exporter que certains arrêtés dans le CIFS, identifiés par l'UUID du RegulationOrderRecord (récupérable dans l'URL de la page de détail de l'arrêté)

On va s'en servir pour ne laisser passer que l'arrêté `018ea930-dfb5-78c5-9f04-f243628d59f3`, qui a été reconnu comme valide, afin de le faire publier dans Waze et confirmer l'intégration de bout en bout

En effet, Waze exige un taux de succès de 80% dans le feed CIFS pour effectivement intégrer les  à ses cartes, donc la localisation valide de cet arrêté n'est pas encore intégré à Waze car il y a trop d'erreurs dans le feed (dont la résolution est en cours cependant).

## Plan de déploiement

1. Définir `APP_CIFS_ALLOWED_REGULATION_RECORD_IDS='["018ea930-dfb5-78c5-9f04-f243628d59f3"]'` dans l'app `dialog` sur Scalingo
2. Merger cette PR afin de la déployer