### PR TITLE
Ajoute des liens d'évitement (skiplinks)

### DIFF
--- a/templates/accessibility_statement.html.twig
+++ b/templates/accessibility_statement.html.twig
@@ -4,115 +4,124 @@
     Accessibilité : non conforme - {{ parent() }}
 {% endblock %}
 
+{% set definesContentSkiplink = true %}
+
 {% block body %}
     <div class="fr-container fr-mt-3w">
-        <h1>Accessibilité</h1>
+        {% include "common/breadcrumb.html.twig" with { items: [
+            { title: 'home.breadcrumb'|trans, path: 'app_landing'},
+            { title: 'ecodesign_statement.breadcrumb'|trans },
+        ]} %}
 
-        <h2>Qu'est-ce que l'accessibilité numérique ?</h2>
+        <div id="content">
+            <h1>Accessibilité</h1>
 
-        <p>
-            Un site web accessible suit un ensemble de règles et de bonnes pratiques pour
-            s'assurer qu'il puisse être utilisé sans difficulté par les personnes en situation de handicap.
-        </p>
+            <h2>Qu'est-ce que l'accessibilité numérique ?</h2>
 
-        <h2>Démarche d'accessibilité</h2>
+            <p>
+                Un site web accessible suit un ensemble de règles et de bonnes pratiques pour
+                s'assurer qu'il puisse être utilisé sans difficulté par les personnes en situation de handicap.
+            </p>
 
-        <p>
-            Le site <a href="{{ path('app_landing') }}">DiaLog</a> n'a pas fait l'objet d'un audit RGAA 4.1. Il est donc impossible
-            en l'état d'en évaluer la conformité avec le référentiel. Par défaut, le site est donc considéré comme <strong>non conforme</strong>.
-        </p>
+            <h2>Démarche d'accessibilité</h2>
 
-        <p>
-            Il a cependant été conçu pour être accessible au plus grand nombre. Pour cela, nous avons veillé à :
-        </p>
+            <p>
+                Le site <a href="{{ path('app_landing') }}">DiaLog</a> n'a pas fait l'objet d'un audit RGAA 4.1. Il est donc impossible
+                en l'état d'en évaluer la conformité avec le référentiel. Par défaut, le site est donc considéré comme <strong>non conforme</strong>.
+            </p>
 
-        <ul>
-            <li>produire un code source HTML valide ;</li>
-            <li>structurer chaque page avec titres et sémantique ;</li>
-            <li>faire en sorte que la navigation au clavier soit fonctionnelle et visible ;</li>
-            <li>respecter les règles de contraste pour que le site soit lisibile.</li>
-        </ul>
+            <p>
+                Il a cependant été conçu pour être accessible au plus grand nombre. Pour cela, nous avons veillé à :
+            </p>
 
-        <p>Vous devriez donc pouvoir, par exemple :</p>
+            <ul>
+                <li>produire un code source HTML valide ;</li>
+                <li>structurer chaque page avec titres et sémantique ;</li>
+                <li>faire en sorte que la navigation au clavier soit fonctionnelle et visible ;</li>
+                <li>respecter les règles de contraste pour que le site soit lisibile.</li>
+            </ul>
 
-        <ul>
-            <li>Changer les couleurs, les niveaux de contraste et les polices de caractères via le navigateur ou le système d'exploitation ;</li>
-            <li>Naviguer sur le site site sans utiliser la souris, par exemple avec le clavier ou via un écran tactile.</li>
-        </ul>
+            <p>Vous devriez donc pouvoir, par exemple :</p>
 
-        <h3>Défauts d'accessibilité</h3>
+            <ul>
+                <li>Changer les couleurs, les niveaux de contraste et les polices de caractères via le navigateur ou le système d'exploitation ;</li>
+                <li>Naviguer sur le site site sans utiliser la souris, par exemple avec le clavier ou via un écran tactile.</li>
+            </ul>
 
-        <p>
-            Nous ne pouvons pas garantir l'accessibilité des pages ou portions de pages suivantes :
-        </p>
+            <h3>Défauts d'accessibilité</h3>
 
-        <ul>
-            <li>Liste des arrêtés avec lecteur d'écran.</li>
-        </ul>
+            <p>
+                Nous ne pouvons pas garantir l'accessibilité des pages ou portions de pages suivantes :
+            </p>
 
-        <hr class="fr-mt-5w" />
+            <ul>
+                <li>Liste des arrêtés avec lecteur d'écran.</li>
+            </ul>
 
-        <h2>Déclaration de conformité RGAA</h2>
-        <p>Établie le <span>24 avril 2023</span>.</p>
-        <p>
-            Le <span>Ministère de la Transition écologique et de la Cohésion des territoires</span>
-            s'engage à rendre son service accessible, conformément à l'article 47 de la
-            loi n° 2005-102 du 11 février 2005.
-        </p>
-        <p>
-            Cette déclaration d'accessibilité s'applique à <strong>DiaLog</strong><span>
-                (<span>https://dialog.beta.gouv.fr</span>)</span>.
-        </p>
-        <h3>État de conformité</h3>
-        <p>
-            <strong>DiaLog</strong> est
-            <strong><span data-printfilter="lowercase">non conforme</span></strong> avec
-            le
-            <abbr title="Référentiel général d'amélioration de l'accessibilité">RGAA</abbr>.
-            <span>Le site n'a encore pas été audité.</span>
-        </p>
-        <h3>Amélioration et contact</h3>
-        <p>
-            Si vous n'arrivez pas à accéder à un contenu ou à un service, vous pouvez
-            contacter le responsable de <span>DiaLog</span> pour être orienté vers une
-            alternative accessible ou obtenir le contenu sous une autre forme.
-        </p>
-        <ul class="basic-information feedback h-card">
-            <li>
-                E-mail&nbsp;: <a href="mailto:dialog@beta.gouv.fr">dialog@beta.gouv.fr</a>
-            </li>
-        </ul>
-        <h3>Voie de recours</h3>
-        <p>
-            Cette procédure est à utiliser dans le cas suivant&nbsp;: vous avez signalé au
-            responsable du site internet un défaut d'accessibilité qui vous empêche
-            d'accéder à un contenu ou à un des services du portail et vous n'avez pas
-            obtenu de réponse satisfaisante.
-        </p>
-        <p>Vous pouvez&nbsp;:</p>
-        <ul>
-            <li>
-                Écrire un message au
-                <a href="https://formulaire.defenseurdesdroits.fr/">Défenseur des droits</a>
-            </li>
-            <li>
-                Contacter
-                <a href="https://www.defenseurdesdroits.fr/saisir/delegues">le délégué du Défenseur des droits dans votre
-                    région</a>
-            </li>
-            <li>
-                Envoyer un courrier par la poste (gratuit, ne pas mettre de
-                timbre)&nbsp;:<br />
-                Défenseur des droits<br />
-                Libre réponse 71120 75342 Paris CEDEX 07
-            </li>
-        </ul>
-        <hr />
-        <p>
-            Cette déclaration d'accessibilité a été créé le
-            <span>24 avril 2023</span> grâce au
-            <a href="https://betagouv.github.io/a11y-generateur-declaration/#create">Générateur de Déclaration d'Accessibilité
-                de BetaGouv</a>.
-        </p>
+            <hr class="fr-mt-5w" />
+
+            <h2>Déclaration de conformité RGAA</h2>
+            <p>Établie le <span>24 avril 2023</span>.</p>
+            <p>
+                Le <span>Ministère de la Transition écologique et de la Cohésion des territoires</span>
+                s'engage à rendre son service accessible, conformément à l'article 47 de la
+                loi n° 2005-102 du 11 février 2005.
+            </p>
+            <p>
+                Cette déclaration d'accessibilité s'applique à <strong>DiaLog</strong><span>
+                    (<span>https://dialog.beta.gouv.fr</span>)</span>.
+            </p>
+            <h3>État de conformité</h3>
+            <p>
+                <strong>DiaLog</strong> est
+                <strong><span data-printfilter="lowercase">non conforme</span></strong> avec
+                le
+                <abbr title="Référentiel général d'amélioration de l'accessibilité">RGAA</abbr>.
+                <span>Le site n'a encore pas été audité.</span>
+            </p>
+            <h3>Amélioration et contact</h3>
+            <p>
+                Si vous n'arrivez pas à accéder à un contenu ou à un service, vous pouvez
+                contacter le responsable de <span>DiaLog</span> pour être orienté vers une
+                alternative accessible ou obtenir le contenu sous une autre forme.
+            </p>
+            <ul class="basic-information feedback h-card">
+                <li>
+                    E-mail&nbsp;: <a href="mailto:dialog@beta.gouv.fr">dialog@beta.gouv.fr</a>
+                </li>
+            </ul>
+            <h3>Voie de recours</h3>
+            <p>
+                Cette procédure est à utiliser dans le cas suivant&nbsp;: vous avez signalé au
+                responsable du site internet un défaut d'accessibilité qui vous empêche
+                d'accéder à un contenu ou à un des services du portail et vous n'avez pas
+                obtenu de réponse satisfaisante.
+            </p>
+            <p>Vous pouvez&nbsp;:</p>
+            <ul>
+                <li>
+                    Écrire un message au
+                    <a href="https://formulaire.defenseurdesdroits.fr/">Défenseur des droits</a>
+                </li>
+                <li>
+                    Contacter
+                    <a href="https://www.defenseurdesdroits.fr/saisir/delegues">le délégué du Défenseur des droits dans votre
+                        région</a>
+                </li>
+                <li>
+                    Envoyer un courrier par la poste (gratuit, ne pas mettre de
+                    timbre)&nbsp;:<br />
+                    Défenseur des droits<br />
+                    Libre réponse 71120 75342 Paris CEDEX 07
+                </li>
+            </ul>
+            <hr />
+            <p>
+                Cette déclaration d'accessibilité a été créé le
+                <span>24 avril 2023</span> grâce au
+                <a href="https://betagouv.github.io/a11y-generateur-declaration/#create">Générateur de Déclaration d'Accessibilité
+                    de BetaGouv</a>.
+            </p>
+        </div>
     </div>
 {% endblock %}

--- a/templates/common/skiplinks.html.twig
+++ b/templates/common/skiplinks.html.twig
@@ -1,0 +1,11 @@
+<div class="fr-skiplinks">
+    <nav class="fr-container" role="navigation" aria-label="{{ 'common.skiplinks'|trans }}">
+        <ul class="fr-skiplinks__list">
+            {% for skipLink in skipLinks|default([]) %}
+                <li>
+                    <a class="fr-link" href="{{ skipLink.href }}">{{ skipLink.label }}</a>
+                </li>
+            {% endfor %}
+        </ul>
+    </nav>
+</div>

--- a/templates/ecodesign_statement.html.twig
+++ b/templates/ecodesign_statement.html.twig
@@ -6,6 +6,8 @@
     {{ title }} - {{ parent() }}
 {% endblock %}
 
+{% set definesContentSkiplink = true %}
+
 {% block body %}
     <div class="fr-container fr-py-2w fr-py-md-5w">
         {% include "common/breadcrumb.html.twig" with { items: [
@@ -13,161 +15,163 @@
             { title: 'ecodesign_statement.breadcrumb'|trans },
         ]} %}
 
-        <h1>{{ title }}</h1>
+        <div id="content">
+            <h1>{{ title }}</h1>
 
-        <p>
-            Ce service numérique a été pensé et développé dans une logique d'écoconception de services numériques.
-        </p>
+            <p>
+                Ce service numérique a été pensé et développé dans une logique d'écoconception de services numériques.
+            </p>
 
-        <h2>Qu'est-ce que l'écoconception de services numériques ?</h2>
+            <h2>Qu'est-ce que l'écoconception de services numériques ?</h2>
 
-        <p>
-            <strong>L'écoconception de services numériques est une démarche d'amélioration continue</strong>.
-            L'objectif est de limiter les ressources informatiques.
-            L'écoconception agit sur 3 niveaux : terminaux utilisateurs, réseau, et centres de données informatiques (datacenters).
-            Dans une démarche d'écoconception, on s'intéresse au service numérique dans sa globalité.
-        </p>
+            <p>
+                <strong>L'écoconception de services numériques est une démarche d'amélioration continue</strong>.
+                L'objectif est de limiter les ressources informatiques.
+                L'écoconception agit sur 3 niveaux : terminaux utilisateurs, réseau, et centres de données informatiques (datacenters).
+                Dans une démarche d'écoconception, on s'intéresse au service numérique dans sa globalité.
+            </p>
 
-        <p>
-            L'écoconception de services numériques est une branche du  <a href="https://ecoresponsable.numerique.gouv.fr/publications/guide-pratique-achats-numeriques-responsables/demarche-numerique-responsable/definition/">Numérique responsable</a>.
-            Le Numérique responsable est une démarche d'amélioration continue qui vise à améliorer l'empreinte écologique et sociale du numérique.
-        </p>
+            <p>
+                L'écoconception de services numériques est une branche du  <a href="https://ecoresponsable.numerique.gouv.fr/publications/guide-pratique-achats-numeriques-responsables/demarche-numerique-responsable/definition/">Numérique responsable</a>.
+                Le Numérique responsable est une démarche d'amélioration continue qui vise à améliorer l'empreinte écologique et sociale du numérique.
+            </p>
 
-        <h2>Raison d'être de ce service</h2>
+            <h2>Raison d'être de ce service</h2>
 
-        <p>
-            Le service <a href="{{ path('app_landing') }}">DiaLog</a> vise à numériser et diffuser la réglementation de circulation afin de garantir la sécurité du public et de préserver les infrastructures routières.
-        </p>
+            <p>
+                Le service <a href="{{ path('app_landing') }}">DiaLog</a> vise à numériser et diffuser la réglementation de circulation afin de garantir la sécurité du public et de préserver les infrastructures routières.
+            </p>
 
-        <p>Il y a 2 cibles utilisatrices principales :</p>
+            <p>Il y a 2 cibles utilisatrices principales :</p>
 
-        <ul>
-            <li>Les <strong>agents publics</strong> qui souhaitent communiquer à des tiers la réglementation de circulation sous format numérique ;</li>
-            <li>Les <strong>services tiers</strong> qui intègrent cette réglementation dans leurs services numériques à destination du public.</li>
-        </ul>
+            <ul>
+                <li>Les <strong>agents publics</strong> qui souhaitent communiquer à des tiers la réglementation de circulation sous format numérique ;</li>
+                <li>Les <strong>services tiers</strong> qui intègrent cette réglementation dans leurs services numériques à destination du public.</li>
+            </ul>
 
-        <p>
-            Le besoin métier est de permettre la numérisation et la diffusion de la réglementation de circulation de manière la plus accessible possible.
-        </p>
+            <p>
+                Le besoin métier est de permettre la numérisation et la diffusion de la réglementation de circulation de manière la plus accessible possible.
+            </p>
 
-        <p>
-            Les bénéficiaires finaux du service sont les usagers de la route, y compris les chauffeurs routiers, qui voient sur leurs outils de navigation les dernières reglementations en place (travaux, limitation de vitesse, circulation réduite, etc).
-        </p>
+            <p>
+                Les bénéficiaires finaux du service sont les usagers de la route, y compris les chauffeurs routiers, qui voient sur leurs outils de navigation les dernières reglementations en place (travaux, limitation de vitesse, circulation réduite, etc).
+            </p>
 
-        <h2>Stratégie et objectifs en matière de réduction ou de limitation des impacts environnementaux</h2>
+            <h2>Stratégie et objectifs en matière de réduction ou de limitation des impacts environnementaux</h2>
 
-        <p>
-            Ce service doit fonctionner sur des terminaux les plus anciens possibles et dans des conditions de connectivité variées.
-        </p>
+            <p>
+                Ce service doit fonctionner sur des terminaux les plus anciens possibles et dans des conditions de connectivité variées.
+            </p>
 
-        <p>
-            Plusieurs mesures sont mises en place. En voici une liste non exhaustive :
-        </p>
+            <p>
+                Plusieurs mesures sont mises en place. En voici une liste non exhaustive :
+            </p>
 
-        <ul>
-            <li>Utilisation des composants d'interfaces du système de design de l'Etat (DSFR) : ils sont accessibles et leur empreinte est minimale.</li>
-            <li>Navigation la plus intuitive possible, pour réduire le temps passé à trouver une information.</li>
-            <li>Nombre de requêtes serveurs maximum par écran : 30.</li>
-            <li>Poids des ressources maximum par écran : 300 ko.</li>
-            <li>Le service s'adapte à toutes les tailles d'écran.</li>
-            <li>Utilisation limitée d'images et compression des images.</li>
-        </ul>
+            <ul>
+                <li>Utilisation des composants d'interfaces du système de design de l'Etat (DSFR) : ils sont accessibles et leur empreinte est minimale.</li>
+                <li>Navigation la plus intuitive possible, pour réduire le temps passé à trouver une information.</li>
+                <li>Nombre de requêtes serveurs maximum par écran : 30.</li>
+                <li>Poids des ressources maximum par écran : 300 ko.</li>
+                <li>Le service s'adapte à toutes les tailles d'écran.</li>
+                <li>Utilisation limitée d'images et compression des images.</li>
+            </ul>
 
-        <p>La mise en place de cette stratégie est supervisée par Florimond Manca, désigné le 23/08/2023 comme personne référente pour l'écoconception du service.</p>
+            <p>La mise en place de cette stratégie est supervisée par Florimond Manca, désigné le 23/08/2023 comme personne référente pour l'écoconception du service.</p>
 
-        <h2>État de conformité au référentiel d'écoconception</h2>
+            <h2>État de conformité au référentiel d'écoconception</h2>
 
-        <p>
-            Le service <a href="{{ path('app_landing') }}">DiaLog</a> est <strong>partiellement conforme</strong> en regard
-            des critères du Référentiel Général d'Écoconception des Services Numériques (RGESN).
-            Le taux de conformité général actuel du service est estimé à <strong>43 %</strong>.
-        </p>
+            <p>
+                Le service <a href="{{ path('app_landing') }}">DiaLog</a> est <strong>partiellement conforme</strong> en regard
+                des critères du Référentiel Général d'Écoconception des Services Numériques (RGESN).
+                Le taux de conformité général actuel du service est estimé à <strong>43 %</strong>.
+            </p>
 
-        <p>
-            L'équipe vise une <strong>mise en conformité progressive</strong> du service via une démarche d'amélioration continue.
-        </p>
+            <p>
+                L'équipe vise une <strong>mise en conformité progressive</strong> du service via une démarche d'amélioration continue.
+            </p>
 
-        <h3>Résultat des tests conduits sur le service</h3>
+            <h3>Résultat des tests conduits sur le service</h3>
 
-        <p>
-            À l'aide de <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/numecodiag/">NumEcoDiag</a>,
-            l'auto-diagnostic initial donne un taux de conformité au RGESN de 43 %.
-        </p>
+            <p>
+                À l'aide de <a href="https://ecoresponsable.numerique.gouv.fr/publications/referentiel-general-ecoconception/numecodiag/">NumEcoDiag</a>,
+                l'auto-diagnostic initial donne un taux de conformité au RGESN de 43 %.
+            </p>
 
-        <p>
-            <a href="{{ asset('files/2023-08-21 - Audit RGESN DiaLog.pdf') }}">Télécharger l'audit de conformité RGESN initial à date de juillet 2023 (PDF - 208 ko)</a>
-        </p>
+            <p>
+                <a href="{{ asset('files/2023-08-21 - Audit RGESN DiaLog.pdf') }}">Télécharger l'audit de conformité RGESN initial à date de juillet 2023 (PDF - 208 ko)</a>
+            </p>
 
-        <p>
-            Le diagnostic a porté sur l'échantillon suivant :
-        </p>
+            <p>
+                Le diagnostic a porté sur l'échantillon suivant :
+            </p>
 
-        <ul>
-            <li>
-                Page d'accueil
-            </li>
-            <li>
-                Liste des arrêtés
-            </li>
-            <li>
-                Page d'un arrêté
-            </li>
-            <li>
-                Déclaration d'accessibilité
-            </li>
-        </ul>
+            <ul>
+                <li>
+                    Page d'accueil
+                </li>
+                <li>
+                    Liste des arrêtés
+                </li>
+                <li>
+                    Page d'un arrêté
+                </li>
+                <li>
+                    Déclaration d'accessibilité
+                </li>
+            </ul>
 
-        <p>
-            Les outils utilisés pour évaluer certains indicateurs techniques sont
-            l'inspecteur "Réseau" des outils de développement du navigateur
-            et l'extension <a href="https://ecoresponsable.numerique.gouv.fr/publications/boite-outils/fiches/greenitanalysis/">Green IT Analysis</a> (disponible sous Firefox, Chrome).
-        </p>
+            <p>
+                Les outils utilisés pour évaluer certains indicateurs techniques sont
+                l'inspecteur "Réseau" des outils de développement du navigateur
+                et l'extension <a href="https://ecoresponsable.numerique.gouv.fr/publications/boite-outils/fiches/greenitanalysis/">Green IT Analysis</a> (disponible sous Firefox, Chrome).
+            </p>
 
-        <h3>Evaluation du parcours avec GreenIT Analysis</h3>
+            <h3>Evaluation du parcours avec GreenIT Analysis</h3>
 
-        <p>
-            L'<strong>unité fonctionnelle</strong> choisie pour l'évaluation du parcours est : "Saisir un arrêté temporaire de circulation".
-        </p>
+            <p>
+                L'<strong>unité fonctionnelle</strong> choisie pour l'évaluation du parcours est : "Saisir un arrêté temporaire de circulation".
+            </p>
 
-        <p>
-            L'évaluation du parcours a été faite le 21/08/2023 sur Firefox, après nettoyage du cache en début de parcours.
-            Afin d'éviter l'incrémentation des résultats sur ce parcours, les données réseaux sont nettoyées entre chaque étape.
-        </p> 
+            <p>
+                L'évaluation du parcours a été faite le 21/08/2023 sur Firefox, après nettoyage du cache en début de parcours.
+                Afin d'éviter l'incrémentation des résultats sur ce parcours, les données réseaux sont nettoyées entre chaque étape.
+            </p> 
 
-        <p>Les étapes suivies sont : </p>
+            <p>Les étapes suivies sont : </p>
 
-        <ul>
-            <li>
-                <strong>Accéder à la page d'accueil de Dialog :</strong> score <strong>EcoIndex A</strong>
-                (23 requêtes, 752 Ko de données transférées, 155 éléments DOM) ;
-            </li>
-            <li>
-                <strong>Se connecter à Dialog :</strong> score <strong>EcoIndex A</strong>
-                (6 requêtes, 68 Ko, 119 éléments DOM) ;
-            </li>
-            <li>
-                <strong>Accéder à la liste des arrêtés et ajouter un arrêté :</strong> score <strong>EcoIndex A</strong>
-                (7 requêtes, 381 Ko, 283 éléments DOM) ;
-            </li>
-            <li>
-                <strong>Saisir un nouvel arrêté de travaux </strong> (circulation interdite sur 1 rue, à tous les véhicules sauf vélos et piétons) :
-                score <strong>EcoIndex A</strong> (25 requêtes, 575 Ko, 206 éléments DOM).
-            </li>
-        </ul>
+            <ul>
+                <li>
+                    <strong>Accéder à la page d'accueil de Dialog :</strong> score <strong>EcoIndex A</strong>
+                    (23 requêtes, 752 Ko de données transférées, 155 éléments DOM) ;
+                </li>
+                <li>
+                    <strong>Se connecter à Dialog :</strong> score <strong>EcoIndex A</strong>
+                    (6 requêtes, 68 Ko, 119 éléments DOM) ;
+                </li>
+                <li>
+                    <strong>Accéder à la liste des arrêtés et ajouter un arrêté :</strong> score <strong>EcoIndex A</strong>
+                    (7 requêtes, 381 Ko, 283 éléments DOM) ;
+                </li>
+                <li>
+                    <strong>Saisir un nouvel arrêté de travaux </strong> (circulation interdite sur 1 rue, à tous les véhicules sauf vélos et piétons) :
+                    score <strong>EcoIndex A</strong> (25 requêtes, 575 Ko, 206 éléments DOM).
+                </li>
+            </ul>
 
-        <h3>Date de cette déclaration de conformité</h3>
+            <h3>Date de cette déclaration de conformité</h3>
 
-        <p>
-            Cette déclaration est établie en version initiale le 21/08/2023.
-        </p>
+            <p>
+                Cette déclaration est établie en version initiale le 21/08/2023.
+            </p>
 
-        <h2>Et après ?</h2>
+            <h2>Et après ?</h2>
 
-        <p>
-            Nous mettons en place une démarche d'amélioration continue grâce à une évaluation de l'impact
-            environnemental et social de notre service de manière régulière.
-            Nos outils nous fournissent des indicateurs de suivi pour adapter nos méthodes et nos contenus
-            tout au long du cycle de vie.
-        </p>
+            <p>
+                Nous mettons en place une démarche d'amélioration continue grâce à une évaluation de l'impact
+                environnemental et social de notre service de manière régulière.
+                Nos outils nous fournissent des indicateurs de suivi pour adapter nos méthodes et nos contenus
+                tout au long du cycle de vie.
+            </p>
+        </div>
     </div>
 {% endblock %}

--- a/templates/layouts/_base.html.twig
+++ b/templates/layouts/_base.html.twig
@@ -25,9 +25,15 @@
     {% endblock %}
   </head>
   <body>
+    {% include 'common/skiplinks.html.twig' with {skipLinks: [
+        {href: '#content', label: 'common.skiplinks.content'|trans},
+        ...(skipLinks|default([])),
+        {href: '#footer', label: 'common.skiplinks.footer'|trans},
+    ]} only %}
+
     {% block header %}{% endblock %}
 
-    <main id="contenu" class="{% block page_class %}{% endblock page_class %}">
+    <main class="{% block page_class %}{% endblock page_class %}">
         <noscript>
             <section class="fr-container fr-mt-3w">
                 <div class="fr-alert fr-alert--info">
@@ -45,7 +51,9 @@
             {% if loop.last %}</div>{% endif %}
         {% endfor %}
 
-        {% block body %}{% endblock %}
+        <div {% if not definesContentSkiplink|default(false) %}id="content"{% endif %}>
+            {% block body %}{% endblock %}
+        </div>
     </main>
     {% include 'common/footer.html.twig' %}
 

--- a/templates/layouts/_base.html.twig
+++ b/templates/layouts/_base.html.twig
@@ -25,7 +25,7 @@
     {% endblock %}
   </head>
   <body>
-    {% include 'common/skiplinks.html.twig' with {skipLinks: [
+    {% include 'common/skiplinks.html.twig' with { skipLinks: [
         {href: '#content', label: 'common.skiplinks.content'|trans},
         ...(skipLinks|default([])),
         {href: '#footer', label: 'common.skiplinks.footer'|trans},

--- a/templates/layouts/public.html.twig
+++ b/templates/layouts/public.html.twig
@@ -1,5 +1,9 @@
 {% extends 'layouts/_base.html.twig' %}
 
+{% set skipLinks = [
+    {href: '#header-navigation', label: 'public.skiplinks.menu'|trans},
+] %}
+
 {% block header %}
     {% embed 'common/header.html.twig' %}
         {% block navigation %}

--- a/templates/legal.html.twig
+++ b/templates/legal.html.twig
@@ -6,6 +6,8 @@
     {{ title }} - {{ parent() }}
 {% endblock %}
 
+{% set definesContentSkiplink = true %}
+
 {% block body %}
     <div class="fr-container fr-py-2w fr-py-md-5w">
         {% include "common/breadcrumb.html.twig" with { items: [
@@ -13,44 +15,46 @@
             { title },
         ]} %}
 
-        {% apply markdown_to_html %}
-        # {{ title }}
+        <div id="content">
+            {% apply markdown_to_html %}
+            # {{ title }}
 
-        ## Édition
+            ## Édition
 
-        Ce site est édité par la [Direction générale des infrastructures, des transports et des mobilités (DGITM)](https://www.ecologie.gouv.fr/direction-generale-des-infrastructures-des-transports-et-des-mobilites-dgitm), domiciliée dans la tour Séquoia au 1 place Carpeaux 92800 Puteaux.
+            Ce site est édité par la [Direction générale des infrastructures, des transports et des mobilités (DGITM)](https://www.ecologie.gouv.fr/direction-generale-des-infrastructures-des-transports-et-des-mobilites-dgitm), domiciliée dans la tour Séquoia au 1 place Carpeaux 92800 Puteaux.
 
-        Le directeur de la publication du site est son directeur général Rodolphe Gintz.
+            Le directeur de la publication du site est son directeur général Rodolphe Gintz.
 
-        ## Réalisation
+            ## Réalisation
 
-        [DiaLog](https://beta.gouv.fr/startups/dialogue.html) est un service numérique développé par la Fabrique numérique de l'écologie, incubateur [beta.gouv.fr](https://beta.gouv.fr/) du [ministère de la Transition écologique et de la Cohésion des territoires](https://www.ecologie.gouv.fr/) (MTE-MCT).
+            [DiaLog](https://beta.gouv.fr/startups/dialogue.html) est un service numérique développé par la Fabrique numérique de l'écologie, incubateur [beta.gouv.fr](https://beta.gouv.fr/) du [ministère de la Transition écologique et de la Cohésion des territoires](https://www.ecologie.gouv.fr/) (MTE-MCT).
 
-        [Son code source](https://github.com/MTES-MCT/dialog/) est distribué sous licence libre [AGPLv3](https://www.gnu.org/licenses/agpl-3.0.fr.html).
+            [Son code source](https://github.com/MTES-MCT/dialog/) est distribué sous licence libre [AGPLv3](https://www.gnu.org/licenses/agpl-3.0.fr.html).
 
-        [Nous vous invitons à signaler tout problème que vous rencontrerez](https://github.com/MTES-MCT/dialog/issues/new/choose).
+            [Nous vous invitons à signaler tout problème que vous rencontrerez](https://github.com/MTES-MCT/dialog/issues/new/choose).
 
-        Pour toute autre demande, vous pouvez contacter l'équipe [par email](mailto:dialog@beta.gouv.fr).
+            Pour toute autre demande, vous pouvez contacter l'équipe [par email](mailto:dialog@beta.gouv.fr).
 
-        ## Hébergement
+            ## Hébergement
 
-        Ce site est hébergé en France par l'entreprise Scalingo, domiciliée au 15 avenue du Rhin 67000 Strasbourg.
+            Ce site est hébergé en France par l'entreprise Scalingo, domiciliée au 15 avenue du Rhin 67000 Strasbourg.
 
-        ## Crédits
+            ## Crédits
 
-        L'image représentant le Capitole à Toulouse (`toulouse.webp`) sur [la page Collectivités](https://dialog.beta.gouv.fr/collectivites) est une adaptation d'[une œuvre de Ceridwen](https://commons.wikimedia.org/wiki/File:Le_Capitole_de_Toulouse.jpg) publiée sous licence [CC BY-SA 2.0 FR](https://creativecommons.org/licenses/by-sa/2.0/fr/deed.fr).
+            L'image représentant le Capitole à Toulouse (`toulouse.webp`) sur [la page Collectivités](https://dialog.beta.gouv.fr/collectivites) est une adaptation d'[une œuvre de Ceridwen](https://commons.wikimedia.org/wiki/File:Le_Capitole_de_Toulouse.jpg) publiée sous licence [CC BY-SA 2.0 FR](https://creativecommons.org/licenses/by-sa/2.0/fr/deed.fr).
 
-        L'image représentant l'église Saint-Martin de Savenay (`savenay.webp`) sur [la page Collectivités](https://dialog.beta.gouv.fr/collectivites) est une adaptation d'[une œuvre de KaTeznik](https://commons.wikimedia.org/wiki/File:Savenay-Eglise.jpg) publiée sous licence [CC BY-SA 2.0 FR](https://creativecommons.org/licenses/by-sa/2.0/fr/deed.fr).
+            L'image représentant l'église Saint-Martin de Savenay (`savenay.webp`) sur [la page Collectivités](https://dialog.beta.gouv.fr/collectivites) est une adaptation d'[une œuvre de KaTeznik](https://commons.wikimedia.org/wiki/File:Savenay-Eglise.jpg) publiée sous licence [CC BY-SA 2.0 FR](https://creativecommons.org/licenses/by-sa/2.0/fr/deed.fr).
 
-        L'image représentant une maison de Saint-Rome (`saint-rome.webp`) sur [la page Collectivités](https://dialog.beta.gouv.fr/collectivites) est une adaptation d'[une œuvre de Et caetera](https://commons.wikimedia.org/wiki/File:Maison_de_Saint-Rome.jpg) publiée sous licence [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/deed.fr).
+            L'image représentant une maison de Saint-Rome (`saint-rome.webp`) sur [la page Collectivités](https://dialog.beta.gouv.fr/collectivites) est une adaptation d'[une œuvre de Et caetera](https://commons.wikimedia.org/wiki/File:Maison_de_Saint-Rome.jpg) publiée sous licence [CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/deed.fr).
 
-        Les pictogrammes sont issus du [système de design de l'Etat](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/pictogramme) publié sous licence [MIT](https://opensource.org/license/mit/).
+            Les pictogrammes sont issus du [système de design de l'Etat](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/pictogramme) publié sous licence [MIT](https://opensource.org/license/mit/).
 
-        Les icones sont issues : 
-        * du [système de design de l'Etat](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/icone) publié sous licence [MIT](https://opensource.org/license/mit/),
-        * de [Remix Icon](https://remixicon.com/) publié sous licence [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+            Les icones sont issues : 
+            * du [système de design de l'Etat](https://www.systeme-de-design.gouv.fr/elements-d-interface/fondamentaux-techniques/icone) publié sous licence [MIT](https://opensource.org/license/mit/),
+            * de [Remix Icon](https://remixicon.com/) publié sous licence [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0).
 
-        Les illustrations sont issues de [Storyset](https://storyset.com/) et utilisées dans le respect des [conditions contractuelles](https://storyset.com/terms).
-        {% endapply %}
+            Les illustrations sont issues de [Storyset](https://storyset.com/) et utilisées dans le respect des [conditions contractuelles](https://storyset.com/terms).
+            {% endapply %}
+        </div>
     </div>
 {% endblock body %}

--- a/templates/regulation/create.html.twig
+++ b/templates/regulation/create.html.twig
@@ -6,6 +6,8 @@
      {{ title }} - {{ parent() }}
 {% endblock %}
 
+{% set definesContentSkiplink = true %}
+
 {% block page_class %}fr-background-alt--grey{% endblock %}
 
 {% block body %}
@@ -15,45 +17,47 @@
             { title },
         ]} %}
 
-        <h2 id="add-title">
-            {{ title }}
-        </h2>
+        <div id="content">
+            <h2 id="add-title">
+                {{ title }}
+            </h2>
 
-        <div class="fr-grid-row fr-grid-row--gutters">
-            <div class="fr-col-12 fr-col-md-8 fr-col-xl-9">
-                <div class="fr-mx-n4v fr-mx-md-0">
-                    {% include "regulation/_general_info_form.html.twig" with { form, cancelUrl } only %}
-                </div>
-            </div>
-
-            <aside class="fr-col fr-col-md-4 fr-col-xl-3 fr-mt-8w fr-mx-n4v fr-mx-md-0 fr-mt-md-0">
-                <div class="app-card app-card--raised">
-                    <div class="app-card__content">
-                        <h3 class="fr-h4">{{ 'regulation.status'|trans }}</h3>
-                            {% include 'regulation/_status_badge.html.twig' with { status: 'draft', withHint: true } %}
-                        <hr class="fr-mt-2w"/>
-
-                        <h3 class="fr-h4">{{ 'common.actions'|trans }}</h3>
-                        <ul class="fr-btns-group fr-btns-group--icon-left">
-                            <li>
-                                <button class="fr-btn fr-btn--secondary" disabled>
-                                    {{ 'common.publish'|trans }}
-                                </button>
-                            </li>
-                            <li>
-                                <button class="fr-btn fr-btn--secondary" disabled>
-                                    {{ 'common.duplicate'|trans }}
-                                </button>
-                            </li>
-                            <li>
-                                <a href="{{ path('app_regulations_list') }}" class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-delete-bin-line">
-                                    {{'common.delete'|trans}}
-                                </a>
-                            </li>
-                        </ul>
+            <div class="fr-grid-row fr-grid-row--gutters">
+                <div class="fr-col-12 fr-col-md-8 fr-col-xl-9">
+                    <div class="fr-mx-n4v fr-mx-md-0">
+                        {% include "regulation/_general_info_form.html.twig" with { form, cancelUrl } only %}
                     </div>
                 </div>
-            </aside>
+
+                <aside class="fr-col fr-col-md-4 fr-col-xl-3 fr-mt-8w fr-mx-n4v fr-mx-md-0 fr-mt-md-0">
+                    <div class="app-card app-card--raised">
+                        <div class="app-card__content">
+                            <h3 class="fr-h4">{{ 'regulation.status'|trans }}</h3>
+                                {% include 'regulation/_status_badge.html.twig' with { status: 'draft', withHint: true } %}
+                            <hr class="fr-mt-2w"/>
+
+                            <h3 class="fr-h4">{{ 'common.actions'|trans }}</h3>
+                            <ul class="fr-btns-group fr-btns-group--icon-left">
+                                <li>
+                                    <button class="fr-btn fr-btn--secondary" disabled>
+                                        {{ 'common.publish'|trans }}
+                                    </button>
+                                </li>
+                                <li>
+                                    <button class="fr-btn fr-btn--secondary" disabled>
+                                        {{ 'common.duplicate'|trans }}
+                                    </button>
+                                </li>
+                                <li>
+                                    <a href="{{ path('app_regulations_list') }}" class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-delete-bin-line">
+                                        {{'common.delete'|trans}}
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </aside>
+            </div>
         </div>
     </div>
 {% endblock %}

--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -10,6 +10,8 @@
 
 {% block page_class %}fr-background-alt--grey{% endblock %}
 
+{% set definesContentSkiplink = true %}
+
 {% block body %}
     {% set isDraft = generalInfo.isDraft %}
     <section class="fr-container fr-py-2w fr-py-md-5w" aria-labelledby="regulation-detail">
@@ -18,7 +20,7 @@
             { title: 'regulation.detail.breadcrumb'|trans({ '%identifier%': generalInfo.identifier }) },
         ]} %}
 
-        <div>
+        <div id="content">
             <h2 id="regulation-detail">{{ title }}</h2>
 
             <div class="fr-grid-row fr-grid-row--gutters">

--- a/tests/Integration/Infrastructure/Controller/AbstractWebTestCase.php
+++ b/tests/Integration/Infrastructure/Controller/AbstractWebTestCase.php
@@ -91,4 +91,14 @@ abstract class AbstractWebTestCase extends WebTestCase
 
         $this->assertEquals($expectedStructure, $actualStructure);
     }
+
+    protected function assertSkipLinks(array $expectedSkipLinks, Crawler $crawler): void
+    {
+        $actualSkipLinks = $crawler
+            ->filter('nav[role=navigation][aria-label="Accès rapide"]')
+            ->filter('ul > li > a')
+            ->each(fn (Crawler $node, int $i): array => [$node->text(), $node->attr('href')]);
+
+        $this->assertEquals($expectedSkipLinks, $actualSkipLinks);
+    }
 }

--- a/tests/Integration/Infrastructure/Controller/LandingControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/LandingControllerTest.php
@@ -15,6 +15,14 @@ final class LandingControllerTest extends AbstractWebTestCase
 
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
+        $this->assertSkipLinks(
+            [
+                ['Contenu', '#content'],
+                ['Menu', '#header-navigation'],
+                ['Pied de page', '#footer'],
+            ],
+            $crawler,
+        );
         $this->assertSame('Numériser la réglementation de circulation routière avec DiaLog', $crawler->filter('h1')->text());
         $this->assertSame('/collectivites', $crawler->selectLink('Pour les collectivités')->attr('href'));
         $this->assertSame('/services-numeriques', $crawler->selectLink('Pour les services numériques')->attr('href'));

--- a/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
@@ -20,6 +20,13 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
         $this->assertSecurityHeaders();
         $this->assertSame('Arrêtés de circulation', $crawler->filter('h3')->text());
         $this->assertMetaTitle('Arrêtés de circulation - DiaLog', $crawler);
+        $this->assertSkipLinks(
+            [
+                ['Contenu', '#content'],
+                ['Pied de page', '#footer'],
+            ],
+            $crawler,
+        );
 
         $tabs = $crawler->filter('.fr-tabs__list')->eq(0);
         $this->assertSame('tablist', $tabs->attr('role'));

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -216,6 +216,22 @@
                 <source>common.unit.meters</source>
                 <target>mètres</target>
             </trans-unit>
+            <trans-unit id="common.skiplinks">
+                <source>common.skiplinks</source>
+                <target>Accès rapide</target>
+            </trans-unit>
+            <trans-unit id="common.skiplinks.content">
+                <source>common.skiplinks.content</source>
+                <target>Contenu</target>
+            </trans-unit>
+            <trans-unit id="common.skiplinks.footer">
+                <source>common.skiplinks.footer</source>
+                <target>Pied de page</target>
+            </trans-unit>
+            <trans-unit id="public.skiplinks.menu">
+                <source>public.skiplinks.menu</source>
+                <target>Menu</target>
+            </trans-unit>
             <trans-unit id="accessibility.status">
                 <source>accessibility.status</source>
                 <target>Accessibilité : non conforme</target>


### PR DESCRIPTION
* Closes #781 

Cette PR ajoute des [skiplinks](https://www.systeme-de-design.gouv.fr/elements-d-interface/composants/lien-d-evitement/) sur toutes les pages de DiaLog

Fonctionnement:

* Par défaut on a les skiplinks "Contenu" (pointe sur `#contenu`) et "Pied de page" (pointe sur `#footer`)
* Une page peut définir d'autres skiplinks en définissant la variable Twig `skipLinks`
* La bonne pratique concernant le skiplink "Contenu" est de zapper tout ce qui ne change pas d'une page à l'autre. Certaines pages sont donc réorganisées pour zapper les breadcrumbs.

## Pour la review

Utiliser le mode "Hide whitespace"

Pour tester : ouvrir une page, puis directement faire <kbd>Tab</kbd> : les skiplinks doivent apparaître avec "Contenu" en 1ère position