### PR TITLE
Corrige le recalcul des géométries de type Voie nommée

### DIFF
--- a/config/validator/Application/Regulation/Command/SaveNamedStreetCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveNamedStreetCommand.xml
@@ -49,7 +49,7 @@
                 <option name="max">8</option>
             </constraint>
             <constraint name="When">
-                <option name="expression">this.roadType === 'lane' and this.fromPointType === 'houseNumber'</option>
+                <option name="expression">this.roadType === 'lane' and !this.getIsEntireStreet() and this.fromPointType === 'houseNumber'</option>
                 <option name="constraints">
                     <constraint name="NotBlank" />
                 </option>
@@ -60,7 +60,7 @@
                 <option name="max">255</option>
             </constraint>
             <constraint name="When">
-                <option name="expression">this.roadType === 'lane' and this.fromPointType === 'intersection'</option>
+                <option name="expression">this.roadType === 'lane' and !this.getIsEntireStreet() and this.fromPointType === 'intersection'</option>
                 <option name="constraints">
                     <constraint name="NotBlank" />
                 </option>
@@ -71,7 +71,7 @@
                 <option name="max">8</option>
             </constraint>
             <constraint name="When">
-                <option name="expression">this.roadType === 'lane' and this.toPointType === 'houseNumber'</option>
+                <option name="expression">this.roadType === 'lane' and !this.getIsEntireStreet() and this.toPointType === 'houseNumber'</option>
                 <option name="constraints">
                     <constraint name="NotBlank" />
                 </option>
@@ -82,7 +82,7 @@
                 <option name="max">255</option>
             </constraint>
             <constraint name="When">
-                <option name="expression">this.roadType === 'lane' and this.toPointType === 'intersection'</option>
+                <option name="expression">this.roadType === 'lane' and !this.getIsEntireStreet() and this.toPointType === 'intersection'</option>
                 <option name="constraints">
                     <constraint name="NotBlank" />
                 </option>

--- a/src/Application/Regulation/Command/Location/RoadCommandInterface.php
+++ b/src/Application/Regulation/Command/Location/RoadCommandInterface.php
@@ -13,4 +13,6 @@ interface RoadCommandInterface extends CommandInterface
     public function setLocation(Location $location): void;
 
     public function getGeometryQuery(): QueryInterface;
+
+    public function clean(): void;
 }

--- a/src/Application/Regulation/Command/Location/SaveLocationCommandHandler.php
+++ b/src/Application/Regulation/Command/Location/SaveLocationCommandHandler.php
@@ -24,6 +24,7 @@ final class SaveLocationCommandHandler
     {
         $command->clean();
         $roadCommand = $command->getRoadCommand();
+        $roadCommand->clean();
 
         // Update location
 

--- a/src/Application/Regulation/Command/Location/SaveNumberedRoadCommand.php
+++ b/src/Application/Regulation/Command/Location/SaveNumberedRoadCommand.php
@@ -50,4 +50,8 @@ final class SaveNumberedRoadCommand implements RoadCommandInterface
     {
         return new GetNumberedRoadGeometryQuery($this, $this->location, $this->geometry);
     }
+
+    public function clean(): void
+    {
+    }
 }


### PR DESCRIPTION
Bug signalé ici https://github.com/MTES-MCT/dialog/pull/773#issuecomment-2122660625

On n'exécutait pas `$roadCommand->clean()` avant de vérifier s'il fallait recalculer la géométrie

Par conséquent dans le cas Voie nommée, on ne recalculait pas la géométrie quand on passait d'une section à une voie entière (les houseNumbers n'étaient pas mis à null par le clean donc la condition de changement était fausse)