### PR TITLE
Restreint le CIFS par loc.uuid plutôt que roc.uuid

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -24,7 +24,7 @@ services:
             $bacIdfDecreesFile: '%env(APP_BAC_IDF_DECREES_FILE)%'
             $bacIdfCitiesFile: '%env(APP_BAC_IDF_CITIES_FILE)%'
             $featureMap: '%features%'
-            $cifsAllowedRegulationOrderRecordIds: '%env(default:_empty_array:json:APP_CIFS_ALLOWED_REGULATION_ORDER_RECORD_IDS)%'
+            $cifsAllowedLocationIds: '%env(default:_empty_array:json:APP_CIFS_ALLOWED_LOCATION_IDS)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -95,7 +95,7 @@ Chaque application peut être configurée avec les variables d'environnement sui
 | `APP_EUDONET_PARIS_BASE_URL` | URL de l'API Eudonet Paris | https://eudonet-partage.apps.paris.fr | |
 | `APP_EUDONET_PARIS_ORG_ID` | Utiliser l'UUID de l'organisation Ville de Paris | _Vide_ | |
 | `APP_SECRET` | Correspond au paramètre Symfony [`secret`](https://symfony.com/doc/current/reference/configuration/framework.html#secret) | _(Obligatoire)_ | Longueur recommandée : 32 caractères. Exemple : générer avec `python3 -c 'import secrets; print(secrets.token_hex(16))'` |
-| `APP_CIFS_REGULATION_ORDER_RECORD_IDS` | N'exporte en CIFS que les arrêtés dont le `regulation_order_record.uuid` est parmi cette liste | `[]` | Format JSON. La liste vide `[]` a pour effet de continuer d'exporter tous les arrêtés |
+| `APP_CIFS_ALLOWED_LOCATION_IDS` | N'exporte en CIFS que les localisations dont le `uuid` est parmi cette liste | `[]` | Format JSON. La liste vide `[]` a pour effet de continuer de toute exporter. |
 | `DATABASE_URL` | URL vers le serveur PostgreSQL | _(Obligatoire)_ `$SCALINGO_POSTGRESQL_URL` | La variable `$SCALINGO_POSTGRESQL_URL` est configurée automatiquement par Scalingo |
 | `MATOMO_ENABLED` | `true` (ou autre valeur truthy) pour activer les [analytics](../tools/analytics.md), `false` pour ne pas les activer | `false` | |
 | `PHP_BUILDPACK_NO_NODE` | Désactive le support Node.js dans le buildpack PHP, puisqu'on utilise le buildpack Node.js complet (voir `.buildpacks`). | _(Obligatoire)_ `true` | Voir : [PHP application with Node.js (Scalingo docs)](https://doc.scalingo.com/languages/php/php-nodejs) |

--- a/src/Application/Regulation/Query/GetCifsIncidentsQueryHandler.php
+++ b/src/Application/Regulation/Query/GetCifsIncidentsQueryHandler.php
@@ -20,14 +20,14 @@ final class GetCifsIncidentsQueryHandler
     public function __construct(
         private RegulationOrderRecordRepositoryInterface $repository,
         private PolylineMakerInterface $polylineMaker,
-        private array $cifsAllowedRegulationOrderRecordIds = [],
+        private array $cifsAllowedLocationIds = [],
     ) {
     }
 
     public function __invoke(GetCifsIncidentsQuery $query): array
     {
         $regulationOrderRecords = $this->repository->findRegulationOrdersForCifsIncidentFormat(
-            allowedIds: $this->cifsAllowedRegulationOrderRecordIds,
+            allowedLocationIds: $this->cifsAllowedLocationIds,
         );
 
         // Reference: https://developers.google.com/waze/data-feed/cifs-specification?hl=fr

--- a/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
@@ -24,7 +24,7 @@ interface RegulationOrderRecordRepositoryInterface
 
     public function findRegulationOrdersForDatexFormat(): array;
 
-    public function findRegulationOrdersForCifsIncidentFormat(array $allowedIds = []): array;
+    public function findRegulationOrdersForCifsIncidentFormat(array $allowedLocationIds = []): array;
 
     public function doesOneExistInOrganizationWithIdentifier(Organization $organization, string $identifier): bool;
 

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -159,7 +159,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
         ;
     }
 
-    public function findRegulationOrdersForCifsIncidentFormat(array $allowedIds = []): array
+    public function findRegulationOrdersForCifsIncidentFormat(array $allowedLocationIds = []): array
     {
         return $this->createQueryBuilder('roc')
             ->addSelect('ro', 'loc', 'm', 'p', 'd', 't')
@@ -171,15 +171,15 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->leftJoin('p.dailyRange', 'd')
             ->leftJoin('p.timeSlots', 't')
             ->where(
-                $allowedIds ? 'roc.uuid IN (:uuids)' : null,
                 'roc.status = :status',
                 'ro.endDate IS NOT NULL',
                 'loc.geometry IS NOT NULL',
+                $allowedLocationIds ? 'loc.uuid IN (:locationIds)' : null,
                 'm.type = :measureType',
                 'v IS NULL or (v.restrictedTypes = \'a:0:{}\' AND v.exemptedTypes = \'a:0:{}\')',
             )
             ->setParameters([
-                ...($allowedIds ? ['uuids' => $allowedIds] : []),
+                ...($allowedLocationIds ? ['locationIds' => $allowedLocationIds] : []),
                 'status' => RegulationOrderRecordStatusEnum::PUBLISHED,
                 'measureType' => MeasureTypeEnum::NO_ENTRY->value,
             ])

--- a/tests/Unit/Application/Regulation/Query/GetCifsIncidentsQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetCifsIncidentsQueryHandlerTest.php
@@ -521,26 +521,15 @@ final class GetCifsIncidentsQueryHandlerTest extends TestCase
         );
     }
 
-    private function provideTestAllowedIds(): array
-    {
-        return [
-            [[], []],
-            [['id'], ['id']],
-        ];
-    }
-
-    /**
-     * @dataProvider provideTestAllowedIds
-     */
-    public function testAllowedIds(?array $allowedIdsParam, array $allowedIdsValue): void
+    public function testAllowedLocationIds(): void
     {
         $this->regulationOrderRecordRepository
             ->expects(self::once())
             ->method('findRegulationOrdersForCifsIncidentFormat')
-            ->with($allowedIdsValue)
-            ->willReturn([]); // Don't care, we just test that the correct value was passed to the repository method
+            ->with(['id1'])
+            ->willReturn([]); // Don't care, we just test that the IDs were passed to the repository method
 
-        $handler = new GetCifsIncidentsQueryHandler($this->regulationOrderRecordRepository, $this->polylineMaker, $allowedIdsParam);
+        $handler = new GetCifsIncidentsQueryHandler($this->regulationOrderRecordRepository, $this->polylineMaker, ['id1']);
         $incidents = $handler(new GetCifsIncidentsQuery());
 
         $this->assertEquals([], $incidents);


### PR DESCRIPTION
* Correctif suite à #776 
* Refs #716 

En fait l'arrêté qui contient la localisation valide contient 2 localisations, dont une invalide... donc en l'état on ne peut pas atteindre les 80% de success rate (on n'aurait que 50%)

Je n'avais pas testé le résultat en local avant de merger #776

Cette PR permet de limiter par Location.uuid et donc on cible directement la localisation Rue Esclangon