### PR TITLE
Allow to have max_input_var to 5000

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,7 +112,8 @@
         },
         "paas": {
             "php-config": [
-                "session.gc_maxlifetime = 86400"
+                "session.gc_maxlifetime = 86400",
+                "max_input_vars = 5000"
             ],
             "nginx-includes": [
                 "paas/server.locations"

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -18,6 +18,7 @@ memory_limit = 1G
 post_max_size = 128M
 file_uploads = On
 upload_max_filesize = 128M
+max_input_vars=5000
 
 ; ====
 ; ERRORS


### PR DESCRIPTION
* Closes #775 

Par défaut, la configuration PHP limite le nombre max d'input à 1000. 

Avant :
![image](https://github.com/MTES-MCT/dialog/assets/2683379/c65c166f-28f3-40b7-83bb-b82125567adc)

Après : 
![image](https://github.com/MTES-MCT/dialog/assets/2683379/b132daeb-8d8a-4b82-9b54-81bb69cf3732)

Dans le cadre de l'arrêté `2022-03704-1-1` de la ville de Nice qui contient 1000+ input, nous obtenons des erreurs CSRF ou de validation.

Cette PR propose un fix en augmentant la valeur du nombre d'input que peut traiter PHP en la passant à 5000 (recommandation PHP8).