### PR TITLE
Améliore accessibilité des champs avec autocomplétion

### DIFF
--- a/assets/controllers/autocomplete_controller.js
+++ b/assets/controllers/autocomplete_controller.js
@@ -75,7 +75,7 @@ export default class Autocomplete extends StimulusAutocomplete {
   // Action callbacks
 
   reset() {
-    this.resultsTarget.innerHTML = '';
+    this.resetOptions();
     this._fetchManager.reset();
   }
 }

--- a/assets/styles/components/autocomplete.scss
+++ b/assets/styles/components/autocomplete.scss
@@ -13,15 +13,26 @@
         z-index: 3;
         position: absolute;
 
-        li[role="option"] {
+        li[role="option"], li[role="status"] {
             border-bottom: 1px solid var(--background-contrast-grey-active);
             padding: 10px;
-            cursor: pointer;
             background: var(--background-default-grey);
+        }
+        
+        li[role="option"] {
+            cursor: pointer;
         }
 
         li[role="option"]:hover, li[role="option"].active, li[role="option"][aria-selected="true"] {
             background-color: var(--background-contrast-grey);
+        }
+
+        li[role="status"] {
+            font-style: italic;
+            cursor: default;
+        }
+        li[role="status"]:empty {
+            display: none;
         }
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
         "": {
             "dependencies": {
                 "@gouvfr/dsfr": "^1.7.2",
-                "idiomorph": "^0.3.0",
                 "remixicon": "^2.5.0"
             },
             "devDependencies": {
@@ -22,6 +21,7 @@
                 "dotenv": "^16.3.1",
                 "file-loader": "^6.0.0",
                 "husky": "^8.0.3",
+                "idiomorph": "^0.3.0",
                 "purgecss-webpack-plugin": "^5.0.0",
                 "regenerator-runtime": "^0.13.9",
                 "sass": "^1.56.1",
@@ -4945,7 +4945,8 @@
         "node_modules/idiomorph": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/idiomorph/-/idiomorph-0.3.0.tgz",
-            "integrity": "sha512-UhV1Ey5xCxIwR9B+OgIjQa+1Jx99XQ1vQHUsKBU1RpQzCx1u+b+N6SOXgf5mEJDqemUI/ffccu6+71l2mJUsRA=="
+            "integrity": "sha512-UhV1Ey5xCxIwR9B+OgIjQa+1Jx99XQ1vQHUsKBU1RpQzCx1u+b+N6SOXgf5mEJDqemUI/ffccu6+71l2mJUsRA==",
+            "dev": true
         },
         "node_modules/immutable": {
             "version": "4.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,6 +6,7 @@
         "": {
             "dependencies": {
                 "@gouvfr/dsfr": "^1.7.2",
+                "idiomorph": "^0.3.0",
                 "remixicon": "^2.5.0"
             },
             "devDependencies": {
@@ -4941,6 +4942,11 @@
                 "postcss": "^8.1.0"
             }
         },
+        "node_modules/idiomorph": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/idiomorph/-/idiomorph-0.3.0.tgz",
+            "integrity": "sha512-UhV1Ey5xCxIwR9B+OgIjQa+1Jx99XQ1vQHUsKBU1RpQzCx1u+b+N6SOXgf5mEJDqemUI/ffccu6+71l2mJUsRA=="
+        },
         "node_modules/immutable": {
             "version": "4.3.6",
             "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.6.tgz",
@@ -8524,6 +8530,7 @@
             }
         },
         "vendor/symfony/stimulus-bundle/assets": {
+            "name": "@symfony/stimulus-bundle",
             "version": "1.0.0",
             "dev": true,
             "license": "MIT",
@@ -8533,6 +8540,7 @@
             }
         },
         "vendor/symfony/ux-turbo/assets": {
+            "name": "@symfony/ux-turbo",
             "version": "0.1.0",
             "dev": true,
             "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     },
     "dependencies": {
         "@gouvfr/dsfr": "^1.7.2",
+        "idiomorph": "^0.3.0",
         "remixicon": "^2.5.0"
     },
     "engines": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
         "dotenv": "^16.3.1",
         "file-loader": "^6.0.0",
         "husky": "^8.0.3",
+        "idiomorph": "^0.3.0",
         "purgecss-webpack-plugin": "^5.0.0",
         "regenerator-runtime": "^0.13.9",
         "sass": "^1.56.1",
@@ -33,7 +34,6 @@
     },
     "dependencies": {
         "@gouvfr/dsfr": "^1.7.2",
-        "idiomorph": "^0.3.0",
         "remixicon": "^2.5.0"
     },
     "engines": {

--- a/templates/location/named_street/_from_point.html.twig
+++ b/templates/location/named_street/_from_point.html.twig
@@ -56,6 +56,8 @@
             }|json_encode }}"
             data-autocomplete-min-length-value="3"
             data-autocomplete-delay-value="500"
+            data-autocomplete-loading-status-value="{{ 'common.autocomplete.status.loading'|trans }}"
+            data-autocomplete-empty-status-value="{{ 'common.autocomplete.status.min_chars'|trans({ '%minChars%': 3 }) }}"
             data-autocomplete-prefetch-value="true"
             data-autocomplete-fetch-empty-value="true"
         >
@@ -82,7 +84,9 @@
                 aria-label="{{ 'regulation.location.named_street.intersection.results_label'|trans }}"
                 class="fr-x-autocomplete"
                 data-autocomplete-target="results"
-            ></ul>
+            >
+                <li role="status" data-autocomplete-target="status"></li>
+            </ul>
         </div>
     </div>
 </fieldset>

--- a/templates/location/named_street/_to_point.html.twig
+++ b/templates/location/named_street/_to_point.html.twig
@@ -57,6 +57,8 @@
             }|json_encode }}"
             data-autocomplete-min-length-value="3"
             data-autocomplete-delay-value="500"
+            data-autocomplete-loading-status-value="{{ 'common.autocomplete.status.loading'|trans }}"
+            data-autocomplete-empty-status-value="{{ 'common.autocomplete.status.min_chars'|trans({ '%minChars%': 3 }) }}"
             data-autocomplete-prefetch-value="true"
             data-autocomplete-fetch-empty-value="true"
         >
@@ -83,7 +85,9 @@
                 aria-label="{{ 'regulation.location.named_street.intersection.results_label'|trans }}"
                 class="fr-x-autocomplete"
                 data-autocomplete-target="results"
-            ></ul>
+            >
+                <li role="status" data-autocomplete-target="status"></li>
+            </ul>
         </div>
     </div>
 </fieldset>

--- a/templates/regulation/fragments/_city_completions.html.twig
+++ b/templates/regulation/fragments/_city_completions.html.twig
@@ -1,3 +1,7 @@
 {% for city in cities %}
     <li role="option" data-autocomplete-value="{{ city.code }}">{{ city.label }}</li>
 {% endfor %}
+
+<template id="status">
+    {{ 'common.autocomplete.results_count'|trans({ '%count%': cities|length }) }}
+</template>

--- a/templates/regulation/fragments/_intersection_completions.html.twig
+++ b/templates/regulation/fragments/_intersection_completions.html.twig
@@ -1,3 +1,7 @@
 {% for roadName in roadNames %}
     <li role="option">{{ roadName }}</li>
 {% endfor %}
+
+<template id="status">
+    {{ 'common.autocomplete.results_count'|trans({ '%count%': roadNames|length }) }}
+</template>

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -199,6 +199,8 @@
                         data-autocomplete-extra-query-params-value="{{ {administrator: '#' ~ form.numberedRoad.administrator.vars.id}|json_encode }}"
                         data-autocomplete-min-length-value="2"
                         data-autocomplete-delay-value="500"
+                        data-autocomplete-loading-status-value="{{ 'common.autocomplete.status.loading'|trans }}"
+                        data-autocomplete-empty-status-value="{{ 'common.autocomplete.status.min_chars'|trans({ '%minChars%': 2 }) }}"
                         data-action="autocomplete.change->reset#reset"
                         data-reset-key-param="roadNumber"
                     >
@@ -216,7 +218,9 @@
                                 role="listbox"
                                 aria-label="{{ 'regulation.location.roadNumber.results_label'|trans }}"
                                 class="fr-x-autocomplete"
-                                data-autocomplete-target="results">
+                                data-autocomplete-target="results"
+                            >
+                                <li role="status" data-autocomplete-target="status"></li>
                             </ul>
                     </div>
 
@@ -271,6 +275,8 @@
                         data-autocomplete-query-param-value="search"
                         data-autocomplete-min-length-value="3"
                         data-autocomplete-delay-value="500"
+                        data-autocomplete-loading-status-value="{{ 'common.autocomplete.status.loading'|trans }}"
+                        data-autocomplete-empty-status-value="{{ 'common.autocomplete.status.min_chars'|trans({ '%minChars%': 3 }) }}"
                         data-action="autocomplete.change->reset#reset"
                         data-reset-key-param="city"
                     >
@@ -290,7 +296,9 @@
                             aria-label="{{ 'regulation.location.city.results_label'|trans }}"
                             class="fr-x-autocomplete"
                             data-autocomplete-target="results"
-                        ></ul>
+                        >
+                            <li role="status" data-autocomplete-target="status"></li>
+                        </ul>
                     </div>
 
                     <div
@@ -299,7 +307,10 @@
                         data-autocomplete-url-value="{{ path('fragment_roadName_completion') }}"
                         data-autocomplete-query-param-value="search"
                         data-autocomplete-extra-query-params-value="{{ {cityCode: '#' ~ form.namedStreet.cityCode.vars.id}|json_encode }}"
-                        data-autocomplete-min-length-value="3" data-autocomplete-delay-value="500"
+                        data-autocomplete-min-length-value="3"
+                        data-autocomplete-delay-value="500"
+                        data-autocomplete-loading-status-value="{{ 'common.autocomplete.status.loading'|trans }}"
+                        data-autocomplete-empty-status-value="{{ 'common.autocomplete.status.min_chars'|trans({ '%minChars%': 3 }) }}"
                         data-action="autocomplete.change->reset#reset"
                         data-reset-key-param="roadName"
                     >
@@ -318,7 +329,9 @@
                             aria-label="{{ 'regulation.location.roadName.results_label'|trans }}"
                             class="fr-x-autocomplete"
                             data-autocomplete-target="results"
-                        ></ul>
+                        >
+                            <li role="status" data-autocomplete-target="status"></li>
+                        </ul>
                     </div>
 
                     <div data-controller="form-reveal">

--- a/templates/regulation/fragments/_road_name_completions.html.twig
+++ b/templates/regulation/fragments/_road_name_completions.html.twig
@@ -1,3 +1,7 @@
 {% for roadName in roadNames %}
     <li role="option">{{ roadName }}</li>
 {% endfor %}
+
+<template id="status">
+    {{ 'common.autocomplete.results_count'|trans({ '%count%': roadNames|length }) }}
+</template>

--- a/templates/regulation/fragments/_road_numbers_completions.html.twig
+++ b/templates/regulation/fragments/_road_numbers_completions.html.twig
@@ -1,3 +1,7 @@
 {% for roadNumber in departmentalRoadNumbers %}
     <li role="option" data-autocomplete-value="{{ roadNumber.roadNumber }}">{{ roadNumber.roadNumber }}</li>
 {% endfor %}
+
+<template id="status">
+    {{ 'common.autocomplete.results_count'|trans({ '%count%': departmentalRoadNumbers|length }) }}
+</template>

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetAddressCompletionFragmentControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetAddressCompletionFragmentControllerTest.php
@@ -16,9 +16,10 @@ final class GetAddressCompletionFragmentControllerTest extends AbstractWebTestCa
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $li = $crawler->filter('li');
-        $this->assertSame(1, $li->count());
-        $this->assertSame('Rue Eugène Berthoud', $li->eq(0)->text());
+        $this->assertSame('1 résultat trouvé', $crawler->filter('template[id="status"]')->text());
+        $options = $crawler->filter('li[role="option"]');
+        $this->assertSame(1, $options->count());
+        $this->assertSame('Rue Eugène Berthoud', $options->eq(0)->text());
     }
 
     public function testBadRequest(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetAddressCompletionFragmentControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetAddressCompletionFragmentControllerTest.php
@@ -16,7 +16,7 @@ final class GetAddressCompletionFragmentControllerTest extends AbstractWebTestCa
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $this->assertSame('1 résultat trouvé', $crawler->filter('template[id="status"]')->text());
+        $this->assertSame('1 résultat', $crawler->filter('template[id="status"]')->text());
         $options = $crawler->filter('li[role="option"]');
         $this->assertSame(1, $options->count());
         $this->assertSame('Rue Eugène Berthoud', $options->eq(0)->text());

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetCityCompletionFragmentControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetCityCompletionFragmentControllerTest.php
@@ -16,17 +16,31 @@ final class GetCityCompletionFragmentControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $li = $crawler->filter('li');
-        $this->assertSame(3, $li->count());
+        $this->assertSame('3 résultats trouvés', $crawler->filter('template[id="status"]')->text());
+        $options = $crawler->filter('li[role="option"]');
+        $this->assertSame(3, $options->count());
 
-        $this->assertSame('Blanc Mesnil (93150)', $li->eq(0)->text());
-        $this->assertSame('93007', $li->eq(0)->attr('data-autocomplete-value'));
+        $this->assertSame('Blanc Mesnil (93150)', $options->eq(0)->text());
+        $this->assertSame('93007', $options->eq(0)->attr('data-autocomplete-value'));
 
-        $this->assertSame('Le Mesnil-Esnard (76240)', $li->eq(1)->text());
-        $this->assertSame('76429', $li->eq(1)->attr('data-autocomplete-value'));
+        $this->assertSame('Le Mesnil-Esnard (76240)', $options->eq(1)->text());
+        $this->assertSame('76429', $options->eq(1)->attr('data-autocomplete-value'));
 
-        $this->assertSame('Le Mesnil-le-Roi (78600)', $li->eq(2)->text());
-        $this->assertSame('78396', $li->eq(2)->attr('data-autocomplete-value'));
+        $this->assertSame('Le Mesnil-le-Roi (78600)', $options->eq(2)->text());
+        $this->assertSame('78396', $options->eq(2)->attr('data-autocomplete-value'));
+    }
+
+    public function testCityAutoCompleteNoResults(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/_fragment/city-completions?search=BlahBlah');
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+
+        $this->assertSame('0 résultat trouvé', $crawler->filter('template[id="status"]')->text());
+        $options = $crawler->filter('li[role="option"]');
+        $this->assertSame(0, $options->count());
     }
 
     public function testBadRequest(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetCityCompletionFragmentControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetCityCompletionFragmentControllerTest.php
@@ -16,7 +16,7 @@ final class GetCityCompletionFragmentControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $this->assertSame('3 résultats trouvés', $crawler->filter('template[id="status"]')->text());
+        $this->assertSame('3 résultats', $crawler->filter('template[id="status"]')->text());
         $options = $crawler->filter('li[role="option"]');
         $this->assertSame(3, $options->count());
 
@@ -38,7 +38,7 @@ final class GetCityCompletionFragmentControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $this->assertSame('Aucun résultat trouvé', $crawler->filter('template[id="status"]')->text());
+        $this->assertSame('Aucun résultat', $crawler->filter('template[id="status"]')->text());
         $options = $crawler->filter('li[role="option"]');
         $this->assertSame(0, $options->count());
     }

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetCityCompletionFragmentControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetCityCompletionFragmentControllerTest.php
@@ -38,7 +38,7 @@ final class GetCityCompletionFragmentControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $this->assertSame('0 résultat trouvé', $crawler->filter('template[id="status"]')->text());
+        $this->assertSame('Aucun résultat trouvé', $crawler->filter('template[id="status"]')->text());
         $options = $crawler->filter('li[role="option"]');
         $this->assertSame(0, $options->count());
     }

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetDepartmentalRoadCompletionFragmentControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetDepartmentalRoadCompletionFragmentControllerTest.php
@@ -16,13 +16,14 @@ final class GetDepartmentalRoadCompletionFragmentControllerTest extends Abstract
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $li = $crawler->filter('li');
-        $this->assertSame(4, $li->count());
+        $this->assertSame('4 résultats trouvés', $crawler->filter('template[id="status"]')->text());
+        $options = $crawler->filter('li[role="option"]');
+        $this->assertSame(4, $options->count());
 
-        $this->assertSame('D32', $li->eq(0)->text());
-        $this->assertSame('D322', $li->eq(1)->text());
-        $this->assertSame('D322A', $li->eq(2)->text());
-        $this->assertSame('D324', $li->eq(3)->text());
+        $this->assertSame('D32', $options->eq(0)->text());
+        $this->assertSame('D322', $options->eq(1)->text());
+        $this->assertSame('D322A', $options->eq(2)->text());
+        $this->assertSame('D324', $options->eq(3)->text());
     }
 
     public function testBadRequest(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetDepartmentalRoadCompletionFragmentControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetDepartmentalRoadCompletionFragmentControllerTest.php
@@ -16,7 +16,7 @@ final class GetDepartmentalRoadCompletionFragmentControllerTest extends Abstract
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $this->assertSame('4 résultats trouvés', $crawler->filter('template[id="status"]')->text());
+        $this->assertSame('4 résultats', $crawler->filter('template[id="status"]')->text());
         $options = $crawler->filter('li[role="option"]');
         $this->assertSame(4, $options->count());
 

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetIntersectionCompletionFragmentControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetIntersectionCompletionFragmentControllerTest.php
@@ -16,10 +16,11 @@ final class GetIntersectionCompletionFragmentControllerTest extends AbstractWebT
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $li = $crawler->filter('li');
-        $this->assertSame(2, $li->count());
-        $this->assertSame('Boulevard Morland', $li->eq(0)->text());
-        $this->assertSame('Quai Henri Iv', $li->eq(1)->text());
+        $this->assertSame('2 résultats trouvés', $crawler->filter('template[id="status"]')->text());
+        $options = $crawler->filter('li[role="option"]');
+        $this->assertSame(2, $options->count());
+        $this->assertSame('Boulevard Morland', $options->eq(0)->text());
+        $this->assertSame('Quai Henri Iv', $options->eq(1)->text());
     }
 
     public function testIntersectionsAutoCompleteWithSearch(): void
@@ -30,9 +31,10 @@ final class GetIntersectionCompletionFragmentControllerTest extends AbstractWebT
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $li = $crawler->filter('li');
-        $this->assertSame(1, $li->count());
-        $this->assertSame('Boulevard Morland', $li->eq(0)->text());
+        $this->assertSame('1 résultat trouvé', $crawler->filter('template[id="status"]')->text());
+        $options = $crawler->filter('li[role="option"]');
+        $this->assertSame(1, $options->count());
+        $this->assertSame('Boulevard Morland', $options->eq(0)->text());
     }
 
     private function provideTestBadRequest(): array

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetIntersectionCompletionFragmentControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetIntersectionCompletionFragmentControllerTest.php
@@ -16,7 +16,7 @@ final class GetIntersectionCompletionFragmentControllerTest extends AbstractWebT
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $this->assertSame('2 résultats trouvés', $crawler->filter('template[id="status"]')->text());
+        $this->assertSame('2 résultats', $crawler->filter('template[id="status"]')->text());
         $options = $crawler->filter('li[role="option"]');
         $this->assertSame(2, $options->count());
         $this->assertSame('Boulevard Morland', $options->eq(0)->text());
@@ -31,7 +31,7 @@ final class GetIntersectionCompletionFragmentControllerTest extends AbstractWebT
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
-        $this->assertSame('1 résultat trouvé', $crawler->filter('template[id="status"]')->text());
+        $this->assertSame('1 résultat', $crawler->filter('template[id="status"]')->text());
         $options = $crawler->filter('li[role="option"]');
         $this->assertSame(1, $options->count());
         $this->assertSame('Boulevard Morland', $options->eq(0)->text());

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -170,7 +170,7 @@
             </trans-unit>
             <trans-unit id="common.autocomplete.results_count">
                 <source>common.autocomplete.results_count</source>
-                <target>{0} Aucun résultat trouvé | {1} 1 résultat trouvé | ]1,Inf[ %count% résultats trouvés</target>
+                <target>{0} Aucun résultat | {1} 1 résultat | ]1,Inf[ %count% résultats</target>
             </trans-unit>
             <trans-unit id="common.autocomplete.status.loading">
                 <source>common.autocomplete.status.loading</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -170,7 +170,7 @@
             </trans-unit>
             <trans-unit id="common.autocomplete.results_count">
                 <source>common.autocomplete.results_count</source>
-                <target>%count% résultat trouvé|%count% résultats trouvés</target>
+                <target>{0} Aucun résultat trouvé | {1} 1 résultat trouvé | ]1,Inf[ %count% résultats trouvés</target>
             </trans-unit>
             <trans-unit id="common.autocomplete.status.loading">
                 <source>common.autocomplete.status.loading</source>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -168,6 +168,18 @@
                 <source>common.form.validate</source>
                 <target>Valider</target>
             </trans-unit>
+            <trans-unit id="common.autocomplete.results_count">
+                <source>common.autocomplete.results_count</source>
+                <target>%count% résultat trouvé|%count% résultats trouvés</target>
+            </trans-unit>
+            <trans-unit id="common.autocomplete.status.loading">
+                <source>common.autocomplete.status.loading</source>
+                <target>Chargement en cours...</target>
+            </trans-unit>
+            <trans-unit id="common.autocomplete.status.min_chars">
+                <source>common.autocomplete.status.min_chars</source>
+                <target>Commencez à saisir au moins %minChars% caractères</target>
+            </trans-unit>
             <trans-unit id="common.date.from">
                 <source>common.date.from</source>
                 <target>du %date%</target>


### PR DESCRIPTION
* Closes #779 

Cette PR met en conformité nos champs autocomplete avec les attendus du pattern [Editable combobox with list autocomplete](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/examples/combobox-autocomplete-list/)

En fait le `stimulus-autocomplete` faisait déjà pas mal de choses, mais pas forcément correctement. J'ai dû ajouter / corriger quelques attributs et comportements clavier.

Pour faire annoncer le statut "Chargement en cours..." / "N résultats trouvés", il était important que l'élément `<li role="status>` ne change pas de référence dans le DOM, donc `.innerHTML = '...'` ne fonctionnait pas. Je suis passé par [idiomorph](https://github.com/bigskysoftware/idiomorph) (librairie qui sera utilisée dans Turbo dans la prochaine version, auquel cas on pourrait alors passer par Turbo Streams).

## Aperçu

![Screenshot 2024-05-22 at 17-19-26 Arrêté temporaire TEST-1 - DiaLog](https://github.com/MTES-MCT/dialog/assets/15911462/62fe3944-e7b6-4b62-9a34-bad1b332d076)

## Pour tester

Sur Linux Mint (pour Mathieu), activer le lecteur d'écran : Paramètres système > Accessibilité > Lecteur d'écran

(Pour afficher une icône de raccourci dans la barre de tâches, cliquer droit dessus puis "Applets" et cocher "Accessibilité")

**Important** De mon côté j'ai eu besoin de redémarrer Firefox pour que le lecteur d'écran commence à énoncer les pages

## Pour la review

Dispo pour parcourir de vive voix les changements si besoin