### PR TITLE
Rend accessible le statut required des champs

### DIFF
--- a/assets/styles/components/form.css
+++ b/assets/styles/components/form.css
@@ -1,7 +1,6 @@
 /* .required is set by Symfony for form types with 'required => true' */
-label.required > .fr-x-label-content::after,
-legend.required > .fr-x-label-content::after {
-  content: " *";
+:where(label, legend).required .fr-x-required-marker[aria-hidden="true"]::after {
+  content: ' *';
 }
 
 @supports not selector(::-webkit-calendar-picker-indicator) {

--- a/src/Infrastructure/Form/Regulation/NamedStreetFormType.php
+++ b/src/Infrastructure/Form/Regulation/NamedStreetFormType.php
@@ -30,10 +30,6 @@ final class NamedStreetFormType extends AbstractType
                 TextType::class,
                 options: [
                     'label' => 'regulation.location.city',
-                    'label_attr' => [
-                        'class' => 'required',
-                    ],
-                    'required' => false,
                 ],
             )
             ->add(
@@ -42,10 +38,6 @@ final class NamedStreetFormType extends AbstractType
                 options: [
                     'label' => 'regulation.location.roadName',
                     'help' => 'regulation.location.roadName.help',
-                    'required' => false,
-                    'label_attr' => [
-                        'class' => 'required',
-                    ],
                 ],
             )
             ->add(
@@ -65,22 +57,14 @@ final class NamedStreetFormType extends AbstractType
                 'fromHouseNumber',
                 TextType::class,
                 options: [
-                    'required' => false,
                     'label' => 'regulation.location.named_street.house_number',
-                    'label_attr' => [
-                        'class' => 'required',
-                    ],
                 ],
             )
             ->add(
                 'fromRoadName',
                 TextType::class,
                 options: [
-                    'required' => false,
                     'label' => 'regulation.location.named_street.intersection',
-                    'label_attr' => [
-                        'class' => 'required',
-                    ],
                 ],
             )
             ->add(
@@ -92,22 +76,14 @@ final class NamedStreetFormType extends AbstractType
                 'toHouseNumber',
                 TextType::class,
                 options: [
-                    'required' => false,
                     'label' => 'regulation.location.named_street.house_number',
-                    'label_attr' => [
-                        'class' => 'required',
-                    ],
                 ],
             )
             ->add(
                 'toRoadName',
                 TextType::class,
                 options: [
-                    'required' => false,
                     'label' => 'regulation.location.named_street.intersection',
-                    'label_attr' => [
-                        'class' => 'required',
-                    ],
                 ],
             )
             ->add('roadType', HiddenType::class)
@@ -141,11 +117,7 @@ final class NamedStreetFormType extends AbstractType
                     'disabled' => true,
                 ],
             ],
-            'required' => false,
             'label' => 'regulation.location.named_street.point_type',
-            'label_attr' => [
-                'class' => 'required',
-            ],
         ];
     }
 

--- a/src/Infrastructure/Form/Regulation/NumberedRoadFormType.php
+++ b/src/Infrastructure/Form/Regulation/NumberedRoadFormType.php
@@ -32,10 +32,6 @@ final class NumberedRoadFormType extends AbstractType
                 options: [
                     'label' => 'regulation.location.roadNumber',
                     'help' => 'regulation.location.roadNumber.help',
-                    'required' => false, // Due to error "An invalid form control with name='x' is not focusable"
-                    'label_attr' => [
-                        'class' => 'required',
-                    ],
                 ],
             )
             ->add(
@@ -44,10 +40,6 @@ final class NumberedRoadFormType extends AbstractType
                 options: [
                     'label' => 'regulation.location.referencePoint.pointNumber',
                     'help' => 'regulation.location.referencePoint.pointNumber.help',
-                    'required' => false,
-                    'label_attr' => [
-                        'class' => 'required',
-                    ],
                 ],
             )
             ->add(
@@ -61,10 +53,6 @@ final class NumberedRoadFormType extends AbstractType
                 options: [
                     'label' => 'regulation.location.referencePoint.pointNumber',
                     'help' => 'regulation.location.referencePoint.pointNumber.help',
-                    'required' => false,
-                    'label_attr' => [
-                        'class' => 'required',
-                    ],
                 ],
             )
             ->add(
@@ -128,10 +116,6 @@ final class NumberedRoadFormType extends AbstractType
 
         return [
             'label' => 'regulation.location.administrator',
-            'label_attr' => [
-                'class' => 'required',
-            ],
-            'required' => false, // Due to error "An invalid form control with name='x' is not focusable"
             'help' => 'regulation.location.administrator.help',
             'choices' => array_merge(
                 ['regulation.location.administrator.placeholder' => ''],

--- a/templates/common/form/dsfr_theme.html.twig
+++ b/templates/common/form/dsfr_theme.html.twig
@@ -95,9 +95,8 @@ https://github.com/symfony/symfony/blob/6.3/src/Symfony/Bridge/Twig/Resources/vi
 {% endblock %}
 
 {% block form_label_content %}
-  {%- set label_content_attr = label_content_attr|default({})|merge({class: label_content_attr.class|default('') ~ ' fr-x-label-content'}) -%}
-  <span {% with {attr: label_content_attr} %}{{ block('attributes')}}{% endwith %}>
-    {{ parent() }}
+  <span>
+    {{ parent() }}{% if required %}<span class="fr-x-required-marker" aria-hidden="true"></span>{% endif %}
   </span>
   {{- form_help(form) -}}
 {% endblock %}

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -176,19 +176,30 @@
                         'change->form-reveal#openByValue'
                     },
                 }) }}
+
+                {% set isDepartmentalRoad = form.roadType.vars.value == 'departmentalRoad' %}
                 <div
                     data-controller="reset"
                     data-form-reveal-target="section"
                     data-value="departmentalRoad"
-                    {% if form.roadType.vars.value != 'departmentalRoad'%} hidden {% endif %}
+                    {% if not isDepartmentalRoad%}hidden{% endif %}
                 >
-                    {{ form_row(form.numberedRoad.roadType) }}
+                    {{ form_row(form.numberedRoad.roadType, {
+                        attr: {
+                            'data-form-reveal-target': 'formControl',
+                            'data-value': 'departmentalRoad',
+                            'disabled': not isDepartmentalRoad,
+                        }
+                    }) }}
                     {{ form_row(form.numberedRoad.administrator, {
                         group_class: 'fr-input-group',
                         widget_class: 'fr-input',
                         attr: {
                             'data-action': 'change->reset#reset',
                             'data-reset-key-param': 'administrator',
+                            'data-form-reveal-target': 'formControl',
+                            'data-value': 'departmentalRoad',
+                            'disabled': not isDepartmentalRoad,
                         }
                     }) }}
                     <div
@@ -211,6 +222,9 @@
                                 'data-autocomplete-target': 'input',
                                 'data-reset-target': 'element',
                                 'data-reset-keys': ['administrator']|json_encode,
+                                'data-form-reveal-target': 'formControl',
+                                'data-value': 'departmentalRoad',
+                                'disabled': not isDepartmentalRoad,
                             },
                         }) }}
                             <ul
@@ -228,9 +242,12 @@
                         aria-labelledby="regulation-location-{{ index }}-reference-point"
                         data-reset-target="element"
                         data-reset-keys="{{ ['administrator', 'roadNumber']|json_encode }}"
+                        data-form-reveal-target="formControl"
+                        data-value="departmentalRoad"
+                        {% if not isDepartmentalRoad %}disabled{% endif %}
                     >
                         <legend id="regulation-location-{{ index }}-reference-point">
-                            <span class="fr-x-label-content">{{ 'regulation.location.referencePoint'|trans }}</span>
+                           {{ 'regulation.location.referencePoint'|trans }}
                         </legend>
                         <div class="fr-hint-text help-text">{{ 'regulation.location.referencePoint.help'|trans }}</div>
                         <fieldset
@@ -262,11 +279,12 @@
                     </fieldset>
                 </div>
 
+                {% set isLane = form.roadType.vars.value == 'lane' %}
                 <div
                     data-controller="reset"
                     data-form-reveal-target="section"
                     data-value="lane"
-                    {% if form.roadType.vars.value != 'lane'%} hidden {% endif%}
+                    {% if not isLane %}hidden{% endif %}
                 >
                     <div
                         class="fr-x-autocomplete-wrapper"
@@ -280,14 +298,30 @@
                         data-action="autocomplete.change->reset#reset"
                         data-reset-key-param="city"
                     >
-                        {{ form_row(form.namedStreet.roadType) }}
-                        {{ form_row(form.namedStreet.cityCode, { attr: {'data-autocomplete-target': 'hidden'} }) }}
+                        {{ form_row(form.namedStreet.roadType, {
+                            attr: {
+                                'data-form-reveal-target': 'formControl',
+                                'data-value': 'lane',
+                                'disabled': not isLane,
+                            }
+                        }) }}
+                        {{ form_row(form.namedStreet.cityCode, {
+                            attr: {
+                                'data-autocomplete-target': 'hidden',
+                                'data-form-reveal-target': 'formControl',
+                                'data-value': 'lane',
+                                'disabled': not isLane,
+                            }
+                        }) }}
 
                         {{ form_row(form.namedStreet.cityLabel, {
                             group_class: 'fr-input-group',
                             widget_class: 'fr-input',
                             attr: {
                                 'data-autocomplete-target': 'input',
+                                'data-form-reveal-target': 'formControl',
+                                'data-value': 'lane',
+                                'disabled': not isLane,
                             },
                         }) }}
                         <ul
@@ -321,6 +355,9 @@
                                 'data-autocomplete-target': 'input',
                                 'data-reset-target': 'element',
                                 'data-reset-keys': ['city']|json_encode,
+                                'data-form-reveal-target': 'formControl',
+                                'data-value': 'lane',
+                                'disabled': not isLane,
                             },
                         }) }}
                         <ul
@@ -334,24 +371,39 @@
                         </ul>
                     </div>
 
-                    <div data-controller="form-reveal">
-                        {{ form_row(form.namedStreet.isEntireStreet, {
-                            group_class: 'fr-checkbox-group',
-                            attr: {
-                                'data-controller': 'condition',
-                                'data-condition-equals-value': true,
-                                'data-action': 'change->condition#dispatchFromCheckboxChange condition:yes->form-reveal#close condition:no->form-reveal#open'
-                            }
-                        }) }}
+                    <fieldset
+                        aria-labelledby="{{ form.namedStreet.vars.id }}-section-legend"
+                        data-form-reveal-target="formControl"
+                        data-value="lane"
+                        {% if not isLane %}disabled{% endif %}
+                    >
+                        <legend id="{{ form.namedStreet.vars.id }}-section-legend" class="app-sr-only">
+                            {{ 'regulation.location.named_street.section'|trans }}
+                        </legend>
 
-                        <div
-                            class="fr-mt-3w"
-                            data-form-reveal-target="section"
-                            {% if form.namedStreet.isEntireStreet.vars.checked %}hidden{% endif %}
-                        >
-                            {% include 'location/named_street/points_form.html.twig' with { form } only %}
+                        <div data-controller="form-reveal">
+                            {{ form_row(form.namedStreet.isEntireStreet, {
+                                group_class: 'fr-checkbox-group',
+                                attr: {
+                                    'data-controller': 'condition',
+                                    'data-condition-equals-value': true,
+                                    'data-action': 'change->condition#dispatchFromCheckboxChange condition:yes->form-reveal#close condition:no->form-reveal#open'
+                                }
+                            }) }}
+
+                            <fieldset
+                                aria-labelledby="{{ form.namedStreet.vars.id }}-points-legend"
+                                data-form-reveal-target="section formControl"
+                                {% if form.namedStreet.isEntireStreet.vars.checked %}hidden{% endif %}
+                            >
+                                <legend id="{{ form.namedStreet.vars.id }}-points-legend" class="app-sr-only">
+                                    {{ 'regulation.location.named_street.points'|trans }}
+                                </legend>
+                                {% include 'location/named_street/points_form.html.twig' with { form } only %}
+                            </fieldset>
                         </div>
-                    </div>
+                    </fieldset>
+
                 </div>
             </div>
         </div>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -534,6 +534,14 @@
                 <source>regulation.location.roadName.results_label</source>
                 <target>Noms de voies suggérés</target>
             </trans-unit>
+            <trans-unit id="regulation.location.named_street.section">
+                <source>regulation.location.named_street.section</source>
+                <target>Section concernée</target>
+            </trans-unit>
+            <trans-unit id="regulation.location.named_street.points">
+                <source>regulation.location.named_street.points</source>
+                <target>Points de la section concernée</target>
+            </trans-unit>
             <trans-unit id="regulation.location.named_street.point_type">
                 <source>regulation.location.named_street.point_type</source>
                 <target>Type de point</target>


### PR DESCRIPTION
* Refs #730 

Jusqu'ici, quand on avait un champ dont l'affichage ou non dépendait d'un select (par ex les champs des sections Voie nommée vs Route départementale), on le mettait en `required => false` avec un `label_attr.class = 'required'`

Cette approche n'est pas accessible car l'attribut `required` n'est pas mis sur les input/select/etc dont les lecteurs d'écran n'annoncent pas

Pire, les lecteurs d'écran annonçaient l'étoile en disant par exemple "Commune astérisque"

Donc cette PR:

* Traite l'étoile comme un indice visuel ce qui nécessite de la passer dans un span avec `aria-hidden="true"`
* Remet l'attribut `required` là où les champs, au sein d'une section conditionnelle, sont obligatoires
  * Cela nécessite de bien utiliser `data-form-reveal-target="formControl"` afin de mettre les champs non-visibles en `disabled` (ainsi le navigateur ne les envoie pas au serveur lors de la requête et Symfmony est content même s'il n'y a pas de `required => false`)

## Pour tester

* Vérifier que les champs obligatoires n'ont pas changé
* Vérifier que quand un champ obligatoire est visible, on ne peut pas soumettre le formulaire s'il est vide (effet de l'atttribut `required`) - auparavant on pouvait le soumettre et une erreur nous ervenait
* Vérifier que quand un champ obligatoire laissé vide est caché par un changement de section (par ex voie nommée -> route départementale), il ne bloque plus la soumission du formulauire