### PR TITLE
Expose l'UUID localisation dans la page de détail arrêté

### DIFF
--- a/src/Application/Regulation/View/Measure/LocationView.php
+++ b/src/Application/Regulation/View/Measure/LocationView.php
@@ -7,6 +7,7 @@ namespace App\Application\Regulation\View\Measure;
 final readonly class LocationView
 {
     public function __construct(
+        public string $uuid,
         public string $roadType,
         public ?NamedStreetView $namedStreet = null,
         public ?NumberedRoadView $numberedRoad = null,

--- a/src/Application/Regulation/View/Measure/MeasureView.php
+++ b/src/Application/Regulation/View/Measure/MeasureView.php
@@ -51,6 +51,7 @@ readonly class MeasureView
         foreach ($measure->getLocations() as $location) {
             if ($namedStreet = $location->getNamedStreet()) {
                 $locations[] = new LocationView(
+                    uuid: $location->getUuid(),
                     roadType: $location->getRoadType(),
                     namedStreet: new NamedStreetView(
                         cityLabel: $namedStreet->getCityLabel(),
@@ -63,6 +64,7 @@ readonly class MeasureView
                 );
             } elseif ($numberedRoad = $location->getNumberedRoad()) {
                 $locations[] = new LocationView(
+                    uuid: $location->getUuid(),
                     roadType: $location->getRoadType(),
                     numberedRoad: new NumberedRoadView(
                         administrator: $numberedRoad->getAdministrator(),

--- a/templates/regulation/fragments/_measure.html.twig
+++ b/templates/regulation/fragments/_measure.html.twig
@@ -36,7 +36,7 @@
                 </ul>
                 <ul class="fr-raw-list d-stack" style="--stack-gap: var(--1w)">
                     {% for location in measure.locations %}
-                        <li>
+                        <li data-location-uuid="{{ location.uuid }}">
                             <span class="app-card__img fr-icon-map-pin-2-line fr-x-icon--dark-border fr-pr-1w" aria-hidden="true"></span>
                             {% if location.roadType == 'lane' %}
                                 {{ location.namedStreet.roadName }}

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetMeasureControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/GetMeasureControllerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Infrastructure\Controller\Regulation\Fragments;
 
+use App\Infrastructure\Persistence\Doctrine\Fixtures\LocationFixture;
 use App\Infrastructure\Persistence\Doctrine\Fixtures\MeasureFixture;
 use App\Infrastructure\Persistence\Doctrine\Fixtures\RegulationOrderRecordFixture;
 use App\Infrastructure\Persistence\Doctrine\Fixtures\UserFixture;
@@ -26,6 +27,7 @@ final class GetMeasureControllerTest extends AbstractWebTestCase
         $this->assertSame('pour tous les véhicules', $measure1Content->filter('li')->eq(0)->text());
         $this->assertSame('du 31/10/2023 à 09h00 au 31/10/2023 à 23h00', $measure1Content->filter('li')->eq(1)->text());
         $this->assertSame('Rue Victor Hugo Savenay (44260)', $measure1Content->filter('li')->eq(3)->text());
+        $this->assertSame(LocationFixture::UUID_TYPICAL, $measure1Content->filter('li')->eq(4)->attr('data-location-uuid'));
         $this->assertSame('Route du Grand Brossais du n° 15 au n° 37bis Savenay (44260)', $measure1Content->filter('.app-card__content li')->eq(4)->text());
 
         $editForm = $crawler->selectButton('Modifier')->form();

--- a/tests/Unit/Application/Regulation/Query/Measure/GetMeasuresQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/Measure/GetMeasuresQueryHandlerTest.php
@@ -152,6 +152,10 @@ final class GetMeasuresQueryHandlerTest extends TestCase
         $namedStreet = $this->createMock(NamedStreet::class);
         $location
             ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('12fca512-dee7-4b3d-9c86-59b03a88d8d2');
+        $location
+            ->expects(self::once())
             ->method('getRoadType')
             ->willReturn('lane');
         $location
@@ -247,6 +251,7 @@ final class GetMeasuresQueryHandlerTest extends TestCase
                     null,
                     [
                         new LocationView(
+                            uuid: '12fca512-dee7-4b3d-9c86-59b03a88d8d2',
                             roadType: 'lane',
                             namedStreet: new NamedStreetView(
                                 cityLabel: 'Montauban',


### PR DESCRIPTION
Dans le cadre de l'export sélectif d'incidents dans le CIFS (#716), on a besoin de l'UUID de la localisation afin de l'ajouter à `APP_CIFS_ALLOWED_LOCATION_IDS`

Actuellement il faut se connecter en DB et faire une jointure allant de `regulation_order_record` à `location` pour le récupérer à partir du regulationOrderRecordId

Cette PR propose d'exposer ledit ID dans le HTML pour qu'on ait qu'à ouvrir la console web.

![Capture d’écran du 2024-05-28 10-25-53](https://github.com/MTES-MCT/dialog/assets/15911462/57ceb752-41d6-4b20-a58e-99637c2d3b5b)
