### PR TITLE
Fix bug on carte page

### DIFF
--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
@@ -56,6 +56,7 @@ final class LocationRepository extends ServiceEntityRepository implements Locati
                ->innerJoin('m.regulationOrder', 'ro')
                ->innerJoin('ro.regulationOrderRecord', 'roc')
                ->where('roc.status = :status')
+               ->andWhere('l.geometry IS NOT NULL')
                ->setParameter('status', RegulationOrderRecordStatusEnum::PUBLISHED);
 
         if ($permanentRegulationsOnly && !$temporaryRegulationsOnly) {


### PR DESCRIPTION
Suite à https://github.com/MTES-MCT/dialog/pull/796

Il n'y avait pas de filtre sur les localisations ayant des géométries à `null`