### PR TITLE
Corrige les erreurs de CSP sur /carte

### DIFF
--- a/assets/customElements/map.js
+++ b/assets/customElements/map.js
@@ -75,12 +75,6 @@ class MapLibreMap {
                 const maplibregl = exports.default;
                 this.#maplibregl = maplibregl;
 
-                // Load MapLibre styles
-                const styleLink = document.createElement('link');
-                styleLink.rel = 'stylesheet';
-                styleLink.href = 'https://unpkg.com/maplibre-gl@latest/dist/maplibre-gl.css';
-                document.head.appendChild(styleLink);
-
                 // Create a container for the map
                 const mapContainer = document.createElement('div');
                 mapContainer.style.height = height;

--- a/assets/styles/map.scss
+++ b/assets/styles/map.scss
@@ -1,0 +1,1 @@
+@import url('maplibre-gl/dist/maplibre-gl.css');

--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -32,9 +32,13 @@ nelmio_security:
             default-src: ['self']
             script-src: ['self']
             style-src: ['self']
-            connect-src: ['self']
+            connect-src: ['self', 'https://data.geopf.fr']
             font-src: ['self']
-            img-src: ['self', 'data:']
+            img-src: ['self', 'data:', 'blob:']
+            # maplibre-gl
+            # https://maplibre.org/maplibre-gl-js/docs/#csp-directives
+            worker-src: ['blob:']
+            child-src: ['blob:']
             block-all-mixed-content: true
 
 when@dev:

--- a/templates/map/map.html.twig
+++ b/templates/map/map.html.twig
@@ -4,6 +4,11 @@
     {{'map.meta.title'|trans}} - {{ parent() }}
 {% endblock %}
 
+{% block stylesheets %}
+    {{ parent() }}
+    {{ encore_entry_link_tags('map') }}
+{% endblock %}
+
 {% block body %}
     <span id="locations_as_geojson" hidden>{{ locationsAsGeoJson }}</span>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,9 @@ Encore
      */
     .addEntry('app', './assets/app.js')
 
+    // Public map
+    .addStyleEntry('map', './assets/styles/map.scss')
+
     // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)
     .enableStimulusBridge('./assets/controllers.json')
 


### PR DESCRIPTION
Suite à #796 

Elles étaient probablement là sur l'app de branche mais pas pensé à vérifier...

Pour les résoudre il faut s'assurer qu'on charge les ressources de notre propre domaine (ici on package le CSS de MapLibre dans un CSS chargé uniquement sur la page de la carto), ou bien qu'on autorise un domaine externe (cas de la ressource chargée depuis data.geopf.fr)