### PR TITLE
Add maplibregl to webpack safelist

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,6 +97,8 @@ Encore
                 /^fr-icon-x-/,
                 /^fr-modal--/,
                 /^fr-alert--/,
+                // Map libre classes
+                /^maplibregl/
             ],
             greedy: [
                 // Source of complex selectors


### PR DESCRIPTION
* Closes #805 

Le CSS de la map était KO (popin, boutons de contrôle etc.).

Avant : 
![image](https://github.com/MTES-MCT/dialog/assets/2683379/49f469c9-581e-4b77-b8c7-6e15f9abc307)

Après : 

![image](https://github.com/MTES-MCT/dialog/assets/2683379/333f99c5-208d-4986-8c16-3ebb92bb5f32)
