### PR TITLE
Fix json encoding

### DIFF
--- a/templates/map/fragments/map_data.stream.html.twig
+++ b/templates/map/fragments/map_data.stream.html.twig
@@ -1,5 +1,5 @@
 <turbo-stream action="update" target="locations_as_geojson">
   <template>
-    {{ locationsAsGeoJson }}
+    {{ locationsAsGeoJson|raw }}
   </template>
 </turbo-stream>


### PR DESCRIPTION
Cette PR permet de formater correctement le JSON qui est utilisé par la map.

Avant : 
```
<turbo-stream action="update" target="locations_as_geojson">
  <template>
    {&quot;type&quot;:&quot;FeatureCollection&quot;,&quot;features&quot;:[{&quot;type&quot;:&quot;Feature&quot;,&quot;geometry&quot;:{&quot;type&quot;:&quot;MultiLineString&quot;,&quot;coordinates&quot;:[[[2.34941313,48.904575394],[2.348095478,48.905107817]],[[2.348095478,48.905107817],[2.347268658,48.905443254]],[[2.345377814,48.906206343],[2.34496091,48.90637943],[2.344158604,48.906714979]],[[2.345416213,48.906190365],[2.345377814,48.906206343]],[[2.347268658,48.905443254],[2.346126485,48.905903767]],[[2.346126485,48.905903767],[2.345416213,48.906190365]]]},&quot;properties&quot;:{&quot;location_uuid&quot;:&quot;018fbf49-7216-7782-ba48-c81c0545c609&quot;,&quot;measure_type&quot;:&quot;noEntry&quot;}}]}
  </template>
</turbo-stream>
```
Après : 

```
<turbo-stream action="update" target="locations_as_geojson">
  <template>
    {"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"MultiLineString","coordinates":[[[2.34941313,48.904575394],[2.348095478,48.905107817]],[[2.348095478,48.905107817],[2.347268658,48.905443254]],[[2.345377814,48.906206343],[2.34496091,48.90637943],[2.344158604,48.906714979]],[[2.345416213,48.906190365],[2.345377814,48.906206343]],[[2.347268658,48.905443254],[2.346126485,48.905903767]],[[2.346126485,48.905903767],[2.345416213,48.906190365]]]},"properties":{"location_uuid":"018fbf49-7216-7782-ba48-c81c0545c609","measure_type":"noEntry"}}]}
  </template>
</turbo-stream>
```