### PR TITLE
Carto : gère les gros payloads découpes en plusieurs textNodes

### DIFF
--- a/assets/customElements/map.js
+++ b/assets/customElements/map.js
@@ -28,7 +28,14 @@ class MapDataSource {
         const observer = new MutationObserver((mutations) => {
             for (const mutation of mutations) {
                 if (mutation.type === "childList" && mutation.addedNodes.length > 0) {
-                    const text = mutation.addedNodes[0].textContent;
+                    const parts = [];
+
+                    mutation.addedNodes.forEach(node => {
+                        parts.push(node.textContent);
+                    });
+
+                    const text = parts.join('');
+
                     if (text) {
                         callback(JSON.parse(text));
                     }


### PR DESCRIPTION
En complément de #808 

On récupérait seulement le premier node, mais certains navigateurs vont découper le contenu du `<span>` en plusieurs text nodes. Par exemple Chromium découpe en morceaux de 2^16 caractères maximum (65336 caractères). Donc pour avoir tout le contenu il faut assembler le texte de tous les noeuds.