### PR TITLE
Ajoute la règle CSP style-src: unsafe-hashes

### DIFF
--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -31,7 +31,7 @@ nelmio_security:
         enforce:
             default-src: ['self']
             script-src: ['self']
-            style-src: ['self']
+            style-src: ['self', 'unsafe-hashes']
             connect-src: ['self', 'https://data.geopf.fr']
             font-src: ['self']
             img-src: ['self', 'data:', 'blob:']


### PR DESCRIPTION
On a des erreurs CSP depuis longtemps, qui n'ont pas d'impact très visible mais sont bien présentes, visiblement liées aux usages de `style="..."` dans le HTML

> Content-Security-Policy : Les paramètres de la page ont empêché l’application d’un style intégré (style-src-elem) car il enfreint la directive suivante : « style-src 'self' 'unsafe-inline' 'nonce-/S4ER3lzsJ7MpvtExBuXIQ==' » [content.js:78:24](moz-extension://ac6881bb-79c4-401f-8dd7-e2103bcf57d8/content.js)

> Content-Security-Policy : Les paramètres de la page ont empêché l’exécution d’un script intégré (script-src-elem) car il enfreint la directive suivante : « script-src 'self' 'unsafe-inline' 'nonce-/S4ER3lzsJ7MpvtExBuXIQ==' » 2 [content.js:60:437](moz-extension://ac6881bb-79c4-401f-8dd7-e2103bcf57d8/content.js)

> Content-Security-Policy : Les paramètres de la page ont empêché l’application d’un style intégré (style-src-attr) car il enfreint la directive suivante : « style-src 'self' 'unsafe-inline' 'nonce-/S4ER3lzsJ7MpvtExBuXIQ==' »
> Source: --stack-spacing: 1rem; [dialog.incubateur.net](https://dialog.incubateur.net/)

> Content-Security-Policy : Les paramètres de la page ont empêché l’application d’un style intégré (style-src-attr) car il enfreint la directive suivante : « style-src 'self' 'unsafe-inline' 'nonce-/S4ER3lzsJ7MpvtExBuXIQ==' »