### PR TITLE
Add regulation order issues admin

### DIFF
--- a/src/Infrastructure/Controller/Admin/DashboardController.php
+++ b/src/Infrastructure/Controller/Admin/DashboardController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Controller\Admin;
 
+use App\Domain\Regulation\RegulationOrderIssue;
 use App\Domain\User\AccessRequest;
 use App\Domain\User\Feedback;
 use App\Domain\User\Organization;
@@ -37,6 +38,9 @@ final class DashboardController extends AbstractDashboardController
         yield MenuItem::linkToCrud('Organisations', 'fa fa-list', Organization::class);
         yield MenuItem::linkToCrud('Création de comptes', 'fa fa-code-pull-request', AccessRequest::class);
         yield MenuItem::linkToCrud('Avis', 'fa fa-comments', Feedback::class);
+
+        yield MenuItem::section('Arrếtés');
+        yield MenuItem::linkToCrud('Alertes qualité', 'fa fa-triangle-exclamation', RegulationOrderIssue::class);
 
         yield MenuItem::section('Application');
         yield MenuItem::linkToRoute('DiaLog', 'fa fa-globe', 'app_regulations_list');

--- a/src/Infrastructure/Controller/Admin/RegulationOrderIssueCrudController.php
+++ b/src/Infrastructure/Controller/Admin/RegulationOrderIssueCrudController.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Controller\Admin;
+
+use App\Domain\Regulation\RegulationOrderIssue;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Action;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Actions;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateTimeField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
+
+final class RegulationOrderIssueCrudController extends AbstractCrudController
+{
+    public static function getEntityFqcn(): string
+    {
+        return RegulationOrderIssue::class;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        return [
+            TextField::new('source')->setLabel('Origine'),
+            TextField::new('identifier')->setLabel('Identifiant'),
+            TextField::new('organization')->setLabel('Organisation'),
+            TextField::new('context')->setLabel('Information'),
+            ChoiceField::new('level')
+                ->setLabel('Niveau')
+                ->setChoices(['warning' => 'warning', 'error' => 'error'])
+                ->renderAsBadges([
+                    'warning' => 'warning',
+                    'error' => 'danger',
+                ]),
+            DateTimeField::new('createdAt')->setLabel('Créé le'),
+        ];
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Alerte qualité')
+            ->setEntityLabelInPlural('Alertes qualité')
+            ->setDefaultSort(['createdAt' => 'DESC'])
+        ;
+    }
+
+    public function configureActions(Actions $actions): Actions
+    {
+        return $actions
+            ->remove(Crud::PAGE_INDEX, Action::NEW)
+            ->remove(Crud::PAGE_INDEX, Action::EDIT)
+            ->remove(Crud::PAGE_DETAIL, Action::EDIT)
+        ;
+    }
+}

--- a/tests/Integration/Infrastructure/Controller/Admin/RegulationOrderIssueCrudControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Admin/RegulationOrderIssueCrudControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Controller\Admin;
+
+use App\Infrastructure\Persistence\Doctrine\Fixtures\UserFixture;
+use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
+
+final class RegulationOrderIssueCrudControllerTest extends AbstractWebTestCase
+{
+    public function testIndex(): void
+    {
+        $client = $this->login(UserFixture::MAIN_ORG_ADMIN_EMAIL);
+        $crawler = $client->request('GET', '/admin?crudAction=index&crudControllerFqcn=App%5CInfrastructure%5CController%5CAdmin%5CRegulationOrderIssueCrudController');
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+        $this->assertSame('Alertes qualité', $crawler->filter('h1')->text());
+    }
+
+    public function testIndexWithoutAuthentication(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/admin?crudAction=index&crudControllerFqcn=App%5CInfrastructure%5CController%5CAdmin%5CRegulationOrderIssueCrudController');
+
+        $this->assertResponseRedirects('http://localhost/login', 302);
+    }
+
+    public function testIndexWithRoleUser(): void
+    {
+        $client = $this->login();
+        $client->request('GET', '/admin?crudAction=index&crudControllerFqcn=App%5CInfrastructure%5CController%5CAdmin%5CRegulationOrderIssueCrudController');
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}


### PR DESCRIPTION
* Closes #813 

![image](https://github.com/MTES-MCT/dialog/assets/2683379/2592b748-12e5-4763-888f-51a39b4e47a2)

Cette PR est une première implémentation de l'espace d'administration des alertes des arrêtés. Dans une première version, elle permet de **lister** et de **supprimer** les alertes remontées.
En fonction des retours de @johanricher et @MathieuFV qui l'utiliseront, des évolutions pourront être apportées.