### PR TITLE
Carte : personnalisation des boutons de fermeture des popups

### DIFF
--- a/assets/customElements/map.js
+++ b/assets/customElements/map.js
@@ -180,7 +180,7 @@ class MapLibreMap {
         locationTurboFrame.id = `location_turbo_frame_${uuid}`;
         locationTurboFrame.setAttribute('src', `${this.#locationPopupUrl}/${uuid}`);
 
-        const locationPopUp = new this.#maplibregl.Popup()
+        const locationPopUp = new this.#maplibregl.Popup({closeButton: false})
             .setLngLat(pos)
             .setDOMContent(locationTurboFrame)
             .addTo(this.#map);
@@ -194,6 +194,15 @@ class MapLibreMap {
             // force an update for dynamic positioning (as the popup is filled after its creation, thanks to an AJAX request)
             // credits : https://stackoverflow.com/questions/60928595/dynamic-anchor-popup-open-outside-of-map-container
             locationPopUp._update();
+
+	    // custom close button of the popup
+	    const customCloseButton = document.getElementById(`close_location_popup_${uuid}`);
+	    if (customCloseButton) {
+		customCloseButton.addEventListener('click', () => {
+		    locationPopUp.remove();
+		});
+	    }
+
         });
     }
 }

--- a/templates/map/fragments/location_popup.html.twig
+++ b/templates/map/fragments/location_popup.html.twig
@@ -1,4 +1,11 @@
 <turbo-frame id="location_turbo_frame_{{ location.uuid }}">
+    <div class="fr-container--fluid">
+	<div class="fr-grid-row fr-grid-row--right">
+	    <button id="close_location_popup_{{ location.uuid }}" class="fr-btn fr-btn--sm fr-btn--tertiary-no-outline fr-btn--icon-right fr-icon-close-line">
+		{{ 'common.close'|trans }}
+	    </button>
+	</div>
+    </div>
     <ul class="fr-raw-list d-stack" style="--stack-gap: var(--1w)">
         <li class="fr-grid-row">
             <span class="fr-icon-x-restriction fr-x-icon--primary fr-x-icon--sm fr-pr-1w" aria-hidden="true"></span>


### PR DESCRIPTION
Personnalisation des boutons de fermeture des popups sur la carte : 
- suppression de l'affichage du bouton par défaut
- affichage du nouveau bouton

<img width="1228" alt="Capture d’écran 2024-06-11 à 16 49 33" src="https://github.com/MTES-MCT/dialog/assets/101107163/ecc8317f-a2e8-405e-8cb9-dcbfc7244e85">

(le bouton est grisé car le curseur - invisible sur la capture d'écran - est dessus)