### PR TITLE
Carte : avec la couche BD TOPO

### DIFF
--- a/assets/customElements/map.js
+++ b/assets/customElements/map.js
@@ -93,7 +93,8 @@ class MapLibreMap {
                 // Create and configure the map
                 const map = new maplibregl.Map({
                     container: mapContainer,
-                    style: 'https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/standard.json',
+                    //style: 'https://data.geopf.fr/annexes/ressources/vectorTiles/styles/PLAN.IGN/standard.json',
+		    style: 'point_de_repere.json',
                     center,
                     zoom,
                     hash: "mapZoomAndPosition",
@@ -135,7 +136,7 @@ class MapLibreMap {
                                 'line-width': ["step", ["zoom"], 4, lineWidthFirstStep, 8, lineWidthSecondStep, 16], // line-width = 4 when zoom < 15, line-width = 8 when zoom bewteen 15 and 18, and line-width = 16 for zoom > 18 ; https://maplibre.org/maplibre-style-spec/expressions/#step
                             },
                         },
-                        "toponyme numéro de route - départementale" // insert this layer below the main label layers like road labels
+                        //"toponyme numéro de route - départementale" // insert this layer below the main label layers like road labels
                     );
 
                     map.addLayer(

--- a/public/point_de_repere.json
+++ b/public/point_de_repere.json
@@ -1,0 +1,45 @@
+{
+    "version": 8,
+    "name": "BDTOPO",
+    "glyphs": "https://data.geopf.fr/annexes/ressources/vectorTiles/fonts/{fontstack}/{range}.pbf",
+    "sprite": "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/BDTOPO/sprite/sprite_bdtopo",
+    "sources": {
+        "bdtopo": {
+            "type": "vector",
+            "tiles": [
+		"https://data.geopf.fr/tms/1.0.0/BDTOPO/{z}/{x}/{y}.pbf"
+            ],
+	    "url":"https://data.geopf.fr/tms/1.0.0/BDTOPO/metadata.json"
+        }
+    },
+    "transition": {
+        "duration": 300,
+        "delay": 0
+    },
+    "layers": [
+        {
+            "id": "type_autoroutier",
+            "type": "line",
+            "source": "bdtopo",
+            "source-layer": "troncon_de_route",
+            "minzoom": 13,
+            "paint": {
+		"line-color": "#5068d2",
+		"line-width": 3
+            }
+        },
+	{
+	    "id": "point_de_repere",
+	    "type": "circle",
+	    "source": "bdtopo",
+	    "source-layer": "point_de_repere",
+	    "paint": {
+		"circle-color": "#549d2c",
+		"circle-stroke-color": "#000000",
+		"circle-opacity": 1,
+		"circle-stroke-width": 1,
+		"circle-radius": 50
+	    }
+	}
+    ]
+}

--- a/public/style_autoroutes.json
+++ b/public/style_autoroutes.json
@@ -1,0 +1,46 @@
+{
+    "version": 8,
+    "name": "BDTOPO",
+    "glyphs": "https://data.geopf.fr/annexes/ressources/vectorTiles/fonts/{fontstack}/{range}.pbf",
+    "sprite": "https://data.geopf.fr/annexes/ressources/vectorTiles/styles/BDTOPO/sprite/sprite_bdtopo",
+    "metadata": {"maputnik:renderer": "ol"},
+    "sources": {
+        "bdtopo": {
+            "type": "vector",
+            "tiles": [
+		"https://data.geopf.fr/tms/1.0.0/BDTOPO/{z}/{x}/{y}.pbf"
+            ],
+            "url":"https://data.geopf.fr/tms/1.0.0/BDTOPO/metadata.json"
+        }
+    },
+    "transition": {
+        "duration": 300,
+        "delay": 0
+    },
+    "layers": [
+        {
+            "id": "type_autoroutier",
+            "type": "line",
+            "source": "bdtopo",
+            "source-layer": "troncon_de_route",
+            "minzoom": 13,
+            "paint": {
+		"line-color": "#5068d2",
+		"line-width": 3
+            }
+        },
+	{
+	    "id": "point_de_repere",
+	    "type": "circle",
+	    "source": "bdtopo",
+	    "source-layer": "point_de_repere",
+	    "paint": {
+		"circle-color": "#549d2c",
+		"circle-stroke-color": "#000000",
+		"circle-opacity": 1,
+		"circle-stroke-width": 1,
+		"circle-radius": 5
+	    }
+	}
+    ]
+}


### PR DESCRIPTION
Suite à une discussion par mail avec l'IGN, je crée cette PR pour leur montrer que l'affichage des Points de Repère de la BD TOPO ne marche pas avec leur feuille de style. C'est censé s'afficher à zoom >=14. 