### PR TITLE
Gère certains formats de dates Eudonet

### DIFF
--- a/src/Infrastructure/EudonetParis/EudonetParisExtractor.php
+++ b/src/Infrastructure/EudonetParis/EudonetParisExtractor.php
@@ -24,6 +24,7 @@ final class EudonetParisExtractor
     public const MESURE_TAB_ID = 1200;
     public const MESURE_ID = 1201;
     public const MESURE_NOM = 1202;
+    public const MESURE_ALINEA = 1254;
     public const MEASURE_NOM_CIRCULATION_INTERDITE_DB_VALUE = '103';
 
     // LOCALISATION fields
@@ -109,6 +110,7 @@ final class EudonetParisExtractor
                 listCols: [
                     $this::MESURE_ID,
                     $this::MESURE_NOM,
+                    $this::MESURE_ALINEA,
                 ],
                 whereCustom: [
                     'WhereCustoms' => [

--- a/tests/Unit/Infrastructure/EudonetParis/EudonetParisTransformerTest.php
+++ b/tests/Unit/Infrastructure/EudonetParis/EudonetParisTransformerTest.php
@@ -109,6 +109,7 @@ final class EudonetParisTransformerTest extends TestCase
         $measureCommand->type = MeasureTypeEnum::NO_ENTRY->value;
         $measureCommand->locations = [$locationCommand1, $locationCommand2];
         $measureCommand->vehicleSet = $vehicleSet;
+        $measureCommand->periods = [];
 
         $importCommand = new ImportEudonetParisRegulationCommand($generalInfoCommand, [$measureCommand]);
         $result = new EudonetParisTransformerResult($importCommand, []);


### PR DESCRIPTION
Refs #812 

J'ouvre cette PR tôt pour avoir quelques avis...

J'ai traité un premier cas (le seul présent à date dans les données récupérées sur Eudonet), format "du 16 au 20 janvier 2023"

Ça fonctionne bien hormis une histoire de fuseaux horaires

![Screenshot 2024-06-17 at 11-42-29 Arrêté temporaire 2022T110159 - DiaLog](https://github.com/MTES-MCT/dialog/assets/15911462/d7a0d4cb-e9fd-4baf-8041-91c35753142c)

Mais je me dis aussi qu'avec cette approche basée sur des regex il y a beaucoup de possibilités de mal-interprétation... Car dès qu'une date ou une heure sera présente dans un format qu'on ne vérifie pas, la signification pourrait complètement changer.

Par ex j'ai pensé qu'il fallait vérifier l'absence de jours de la semaine (par ex "sauf les vendredis"), sinon on tombe faux

Et plein d'autres cas comme ça... C'est un gros travail de parsing.