### PR TITLE
Include Eudonet measures with no specific dates

### DIFF
--- a/src/Infrastructure/EudonetParis/EudonetParisExtractor.php
+++ b/src/Infrastructure/EudonetParis/EudonetParisExtractor.php
@@ -24,6 +24,7 @@ final class EudonetParisExtractor
     public const MESURE_TAB_ID = 1200;
     public const MESURE_ID = 1201;
     public const MESURE_NOM = 1202;
+    public const MESURE_ALINEA = 1294;
     public const MEASURE_NOM_CIRCULATION_INTERDITE_DB_VALUE = '103';
 
     // LOCALISATION fields
@@ -109,6 +110,7 @@ final class EudonetParisExtractor
                 listCols: [
                     $this::MESURE_ID,
                     $this::MESURE_NOM,
+                    $this::MESURE_ALINEA,
                 ],
                 whereCustom: [
                     'WhereCustoms' => [

--- a/src/Infrastructure/EudonetParis/EudonetParisTransformer.php
+++ b/src/Infrastructure/EudonetParis/EudonetParisTransformer.php
@@ -125,6 +125,17 @@ final class EudonetParisTransformer
         $loc = ['measure_id' => $row['fields'][EudonetParisExtractor::MESURE_ID]];
         $errors = [];
 
+        $alinea = $row['fields'][EudonetParisExtractor::MESURE_ALINEA];
+
+        if ($alinea) {
+            // This "alinea" field contains free-form text with indications on temporal validity.
+            // We cannot parse this data so we only ingest measures that do NOT have an "alinea", meaning their dates are
+            // the same as the global regulation order dates.
+            $errors[] = ['loc' => $loc, 'reason' => 'measure_may_contain_dates', 'alinea' => $alinea, 'impact' => 'skip_measure'];
+
+            return [null, $errors];
+        }
+
         $locationCommands = [];
 
         foreach ($row['locations'] as $locationRow) {

--- a/tests/Integration/Infrastructure/Symfony/Command/EudonetParis/EudonetParisImportCommandTest.php
+++ b/tests/Integration/Infrastructure/Symfony/Command/EudonetParis/EudonetParisImportCommandTest.php
@@ -9,6 +9,7 @@ use App\Tests\Mock\EudonetParis\EudonetParisMockHttpClient;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
+/** @group only */
 final class EudonetParisImportCommandTest extends KernelTestCase
 {
     public function testExecute(): void

--- a/tests/Mock/EudonetParis/eudonet_paris.1200.mock.json
+++ b/tests/Mock/EudonetParis/eudonet_paris.1200.mock.json
@@ -23,6 +23,13 @@
             "UpdateAllowed": false,
             "Value": "circulation interdite",
             "ViewAllowed": true
+          },
+          {
+            "DbValue": "",
+            "DescId": 1294,
+            "UpdateAllowed": false,
+            "Value": "",
+            "ViewAllowed": true
           }
         ],
         "FileId": 363226,
@@ -44,6 +51,13 @@
             "DescId": 1202,
             "UpdateAllowed": false,
             "Value": "circulation interdite",
+            "ViewAllowed": true
+          },
+          {
+            "DbValue": "",
+            "DescId": 1294,
+            "UpdateAllowed": false,
+            "Value": "",
             "ViewAllowed": true
           }
         ],

--- a/tests/Unit/Infrastructure/EudonetParis/EudonetParisExtractorTest.php
+++ b/tests/Unit/Infrastructure/EudonetParis/EudonetParisExtractorTest.php
@@ -92,7 +92,7 @@ final class EudonetParisExtractorTest extends TestCase
 
                 2 => $this->assertSame([
                     1200,
-                    [1201, 1202],
+                    [1201, 1202, 1294],
                     [
                         'WhereCustoms' => [
                             [
@@ -152,7 +152,7 @@ final class EudonetParisExtractorTest extends TestCase
 
                 6 => $this->assertSame([
                     1200,
-                    [1201, 1202],
+                    [1201, 1202, 1294],
                     [
                         'WhereCustoms' => [
                             [

--- a/tests/Unit/Infrastructure/EudonetParis/EudonetParisTransformerTest.php
+++ b/tests/Unit/Infrastructure/EudonetParis/EudonetParisTransformerTest.php
@@ -39,6 +39,7 @@ final class EudonetParisTransformerTest extends TestCase
                     'fields' => [
                         EudonetParisExtractor::MESURE_ID => 'mesure1',
                         EudonetParisExtractor::MESURE_NOM => 'circulation interdite',
+                        EudonetParisExtractor::MESURE_ALINEA => '',
                     ],
                     'locations' => [
                         [
@@ -145,6 +146,7 @@ final class EudonetParisTransformerTest extends TestCase
                     'fields' => [
                         EudonetParisExtractor::MESURE_ID => 'mesure1',
                         EudonetParisExtractor::MESURE_NOM => 'circulation interdite',
+                        EudonetParisExtractor::MESURE_ALINEA => '',
                     ],
                     'locations' => [
                         [
@@ -218,6 +220,7 @@ final class EudonetParisTransformerTest extends TestCase
                     'fields' => [
                         EudonetParisExtractor::MESURE_ID => 'mesure1',
                         EudonetParisExtractor::MESURE_NOM => 'circulation interdite',
+                        EudonetParisExtractor::MESURE_ALINEA => '',
                     ],
                     'locations' => [
                         [
@@ -364,6 +367,7 @@ final class EudonetParisTransformerTest extends TestCase
                     'fields' => [
                         EudonetParisExtractor::MESURE_ID => 'mesure1',
                         EudonetParisExtractor::MESURE_NOM => 'circulation interdite',
+                        EudonetParisExtractor::MESURE_ALINEA => '',
                     ],
                     'locations' => [$location],
                 ],
@@ -401,6 +405,7 @@ final class EudonetParisTransformerTest extends TestCase
                     'fields' => [
                         EudonetParisExtractor::MESURE_ID => 'mesure1',
                         EudonetParisExtractor::MESURE_NOM => 'circulation interdite',
+                        EudonetParisExtractor::MESURE_ALINEA => '',
                     ],
                     'locations' => [
                         [
@@ -499,6 +504,55 @@ final class EudonetParisTransformerTest extends TestCase
                     'impact' => 'skip_regulation',
                     'reason' => 'parsing_failed',
                     'value' => 'invalid',
+                ],
+            ],
+        );
+
+        $this->assertEquals($result, $transformer->transform($record, $organization));
+    }
+
+    public function testSkipNonEmptyAlinea(): void
+    {
+        $organization = $this->createMock(Organization::class);
+
+        $record = [
+            'fields' => [
+                EudonetParisExtractor::ARRETE_ID => '20230514-1',
+                EudonetParisExtractor::ARRETE_DATE_DEBUT => '2023/06/05 14:30:00',
+                EudonetParisExtractor::ARRETE_DATE_FIN => '2023/07/12 18:00:00',
+                EudonetParisExtractor::ARRETE_TYPE => 'Temporaire',
+                EudonetParisExtractor::ARRETE_COMPLEMENT_DE_TITRE => 'Description',
+            ],
+            'measures' => [
+                [
+                    'fields' => [
+                        EudonetParisExtractor::MESURE_ID => 'mesure1',
+                        EudonetParisExtractor::MESURE_NOM => 'circulation interdite',
+                        EudonetParisExtractor::MESURE_ALINEA => 'not empty may contain dates',
+                    ],
+                    'locations' => ['...'],
+                ],
+            ],
+        ];
+
+        $transformer = new EudonetParisTransformer();
+        $result = new EudonetParisTransformerResult(
+            null,
+            [
+                [
+                    'loc' => ['regulation_identifier' => '20230514-1'],
+                    'impact' => 'skip_regulation',
+                    'reason' => 'measure_errors',
+                    'errors' => [
+                        [
+                            'loc' => [
+                                'measure_id' => 'mesure1',
+                            ],
+                            'reason' => 'measure_may_contain_dates',
+                            'alinea' => 'not empty may contain dates',
+                            'impact' => 'skip_measure',
+                        ],
+                    ],
                 ],
             ],
         );


### PR DESCRIPTION
* Refs https://github.com/MTES-MCT/dialog/issues/812#issuecomment-2159271577

Contexte : actuellement on intègre les arrêtés Eudonet sans tenir compte de la définition de dates, heures ou créneaux dans le champ "Alinéa". Par conséquent on n'expose pas pour l'instant les arrêtés Eudonet dans le CIFS.

Cette PR propose de ne plus intégrer que les mesures qui ont un "Alinéa" vide

C'est une approche conservatrice visant à laisser passer les mesures Eudonet dont les dates correspondent à celles de l'arrêté.

## Next steps

Merger cette PR n'aura pas d'effet en soi, il y aura un nouvel import automatique lundi prochain qui intègrera les nouveaux arrêtés mono-mesures

D'ici là on pourra effacer les données Eudonet de la prod (elles ne sont pas exposées en CIFS de toute façon) pour être sûrs de n'avoir que des données respectant cette règle "mesures sans alinéas"

On pourra alors réactiver l'exposition des données Eudonet dans CIFS