### PR TITLE
Filtre des données de la carte : restrictions temporaires et/ou permanentes : remplacer les boutons radio par des checkboxes

### DIFF
--- a/src/Domain/Regulation/Repository/LocationRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/LocationRepositoryInterface.php
@@ -15,8 +15,8 @@ interface LocationRepositoryInterface
     public function findOneByUuid(string $uuid): ?Location;
 
     public function findAllForMapAsGeoJSON(
-        bool $includePermanentRegulations = true,
-        bool $includeTemporaryRegulations = true,
+        bool $includePermanentRegulations = false,
+        bool $includeTemporaryRegulations = false,
         bool $includeUpcomingRegulations = false,
         bool $includePastRegulations = false,
     ): string;

--- a/src/Infrastructure/Controller/DTO/MapFilterDTO.php
+++ b/src/Infrastructure/Controller/DTO/MapFilterDTO.php
@@ -6,7 +6,8 @@ namespace App\Infrastructure\Controller\DTO;
 
 final class MapFilterDTO
 {
-    public ?string $category = null;
-    public ?string $displayFutureRegulations = null;
-    public ?string $displayPastRegulations = null;
+    public bool $displayPermanentRegulations = true;
+    public bool $displayTemporaryRegulations = true;
+    public bool $displayFutureRegulations = false;
+    public bool $displayPastRegulations = false;
 }

--- a/src/Infrastructure/Controller/Map/MapController.php
+++ b/src/Infrastructure/Controller/Map/MapController.php
@@ -46,10 +46,10 @@ final class MapController
         $form->handleRequest($request);
 
         $locationsAsGeoJson = $this->locationRepository->findAllForMapAsGeoJSON(
-            $dto->category === 'permanents_only',
-            $dto->category === 'temporaries_only',
-            $dto->displayFutureRegulations === '1',
-            $dto->displayPastRegulations === '1',
+            $dto->displayPermanentRegulations,
+            $dto->displayTemporaryRegulations,
+            $dto->displayFutureRegulations,
+            $dto->displayPastRegulations,
         );
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Infrastructure/Form/Map/MapFilterFormType.php
+++ b/src/Infrastructure/Form/Map/MapFilterFormType.php
@@ -6,7 +6,6 @@ namespace App\Infrastructure\Form\Map;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
-use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\FormBuilderInterface;
 
@@ -16,9 +15,22 @@ final class MapFilterFormType extends AbstractType
     {
         $builder
             ->add(
-                'category',
-                ChoiceType::class,
-                options: $this->getCategoryOptions(),
+                'displayPermanentRegulations',
+                CheckboxType::class,
+                options: [
+                    'label' => 'map.filter.permanents',
+                    'value' => 'yes',
+                    'required' => false,
+                ],
+            )
+            ->add(
+                'displayTemporaryRegulations',
+                CheckboxType::class,
+                options: [
+                    'label' => 'map.filter.temporaries',
+                    'value' => 'yes',
+                    'required' => false,
+                ],
             )
             ->add(
                 'displayFutureRegulations',
@@ -40,23 +52,5 @@ final class MapFilterFormType extends AbstractType
             )
             ->add('save', SubmitType::class)
         ;
-    }
-
-    private function getCategoryOptions(): array
-    {
-        $choices = [
-            'map.filter.permanents' => 'permanents_only',
-            'map.filter.temporaries' => 'temporaries_only',
-            'map.filter.all' => 'permanents_and_temporaries',
-        ];
-
-        return [
-            'choices' => $choices,
-            'label' => false,
-            'expanded' => true,
-            'multiple' => false,
-            'required' => true,
-            'data' => 'permanents_and_temporaries', // default value for the radio buttons
-        ];
     }
 }

--- a/templates/map/map.html.twig
+++ b/templates/map/map.html.twig
@@ -25,7 +25,9 @@
                             style: '--stack-gap: var(--1w)',
                         },
                     }) }}
-                        {{ form_row(form.category, {group_class: 'fr-radio-group'}) }}
+                        {{ form_row(form.displayPermanentRegulations, {group_class: 'fr-checkbox-group'}) }}
+                        {{ form_row(form.displayTemporaryRegulations, {group_class: 'fr-checkbox-group'}) }}
+                        <hr />
                         {{ form_row(form.displayFutureRegulations, {group_class: 'fr-checkbox-group'}) }}
                         {{ form_row(form.displayPastRegulations, {group_class: 'fr-checkbox-group'}) }}
                         <noscript>

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -1944,15 +1944,11 @@
             </trans-unit>
             <trans-unit id="map.filter.permanents">
                 <source>map.filter.permanents</source>
-                <target>Arrêtés permanents</target>
+                <target>Restrictions permanentes</target>
             </trans-unit>
             <trans-unit id="map.filter.temporaries">
                 <source>map.filter.temporaries</source>
-                <target>Arrêtés temporaires</target>
-            </trans-unit>
-            <trans-unit id="map.filter.all">
-                <source>map.filter.all</source>
-                <target>Tous les arrêtés</target>
+                <target>Restrictions temporaires</target>
             </trans-unit>
             <trans-unit id="map.location.popup.details">
                 <source>map.location.popup.details</source>


### PR DESCRIPTION
Amélioration pour #659 "Explorateur carto public" : 

>  - Filtre : remplacer les boutons radio par des checkboxes
>  - Les 2 checkboxes restrictions permanentes et temporaires sont cochées par défaut
>  - Utiliser le terme de "restriction", c'est le terme le plus compréhensible du point de vue utilisateur, et systématiquement par souci de cohérence

<img width="1086" alt="Capture d’écran 2024-06-19 à 15 03 38" src="https://github.com/MTES-MCT/dialog/assets/101107163/84ad7754-0657-49ee-95c8-ea078e9889ab">


À noter que l'utilisation du terme "restriction" a été traitée partiellement ici. 