### PR TITLE
Filtre des données de la carte : meilleur affichage

### DIFF
--- a/templates/map/map.html.twig
+++ b/templates/map/map.html.twig
@@ -15,8 +15,8 @@
     <div class="fr-x-container--fluid" style="--container-width: 75rem">
         <div class="fr-grid-row">
             <div class="fr-col-12 fr-col-sm-4 fr-col-md-3 fr-container fr-pt-2w fr-pb-6w">
-                <h1 class="fr-h3">{{ 'map.title'|trans }} </h1>
-                <h2 class="fr-h4">{{ 'map.filters.title'|trans }}</h2>
+                <h1 class="fr-h4">{{ 'map.title'|trans }} </h1>
+                <h2 class="fr-h6">{{ 'map.filters.title'|trans }}</h2>
 
                 <d-auto-form>
                     {{ form_start(form, {

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -1924,11 +1924,11 @@
             </trans-unit>
             <trans-unit id="map.form.displayFutureRegulations">
                 <source>map.form.displayFutureRegulations</source>
-                <target>Arrêtés à venir</target>
+                <target>Restrictions à venir</target>
             </trans-unit>
             <trans-unit id="map.form.displayPastRegulations">
                 <source>map.form.displayPastRegulations</source>
-                <target>Arrêtés passés</target>
+                <target>Restrictions passées</target>
             </trans-unit>
             <trans-unit id="map.title">
                 <source>map.title</source>


### PR DESCRIPTION
Améliorations pour [#659 "Explorateur carto public"](https://github.com/MTES-MCT/dialog/issues/659) : 

> - Utiliser le terme de "restriction", c'est le terme le plus compréhensible du point de vue utilisateur, et systématiquement par souci de cohérence
> - "Visualiser les restrictions" mettre en h4
> - "Filtres" mettre en h6

À noter que : 

- pour être compatible avec l'accessibilité (la page doit avoir un et un seul `<h1>`), le type de balise HTML et la classe DSFR diffèrent
- l'utilisation du terme "restriction" est partiellement traitée ici, l'autre partie a été traité dans https://github.com/MTES-MCT/dialog/pull/845