### PR TITLE
Active la compression gzip en local

### DIFF
--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -24,6 +24,9 @@ server {
         fastcgi_buffers 4 256k;
         fastcgi_busy_buffers_size 256k;
 
+        gzip on;
+        gzip_types text/html text/xml;
+
         internal;
     }
 

--- a/paas/server.locations
+++ b/paas/server.locations
@@ -9,3 +9,6 @@ location ~* \.(css|js|jpg|jpeg|png|svg|webp|ico|woff2|woff|eot|ttf) {
 location /blog {
     try_files $uri $uri.html $uri/index.html =404;
 }
+
+gzip on;
+gzip_types text/html text/xml;

--- a/paas/server.locations
+++ b/paas/server.locations
@@ -9,6 +9,3 @@ location ~* \.(css|js|jpg|jpeg|png|svg|webp|ico|woff2|woff|eot|ttf) {
 location /blog {
     try_files $uri $uri.html $uri/index.html =404;
 }
-
-gzip on;
-gzip_types text/html text/xml;


### PR DESCRIPTION
Scalingo applique bien une compression gzip en production https://github.com/MTES-MCT/dialog/pull/850#issuecomment-2191302851

Mais on ne l'avait pas encore en local

Cette PR l'active sur le Nginx local pour être iso avec la prod.

Le gzip réduit l'utilisation du réseau pour le transfert du HTML (pages) ou du XML (DATEX, CIFS...) d'un facteur 5 à 10. Par exemple en local l'arrêté JOP (#847) passe de 325 Ko de HTML transférés à 30 Ko !