### PR TITLE
Affiche les autres types de véhicules dans le DATEX

### DIFF
--- a/docs/spec/datex2/DATEXII_3_Common.xsd
+++ b/docs/spec/datex2/DATEXII_3_Common.xsd
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
-<xs:schema elementFormDefault="qualified" attributeFormDefault="unqualified" xmlns:com="http://datex2.eu/schema/3/common" version="3.3" targetNamespace="http://datex2.eu/schema/3/common" xmlns:comx="http://datex2.eu/schema/3/commonExtension" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<xs:schema
+  elementFormDefault="qualified"
+  attributeFormDefault="unqualified"
+  xmlns:com="http://datex2.eu/schema/3/common"
+  version="3.3"
+  targetNamespace="http://datex2.eu/schema/3/common"
+  xmlns:comx="http://datex2.eu/schema/3/commonExtension"
+  xmlns:dx="https://raw.githubusercontent.com/MTES-MCT/dialog/main/docs/spec/datex2"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+>
   <xs:import namespace="http://datex2.eu/schema/3/commonExtension" schemaLocation="DATEXII_3_CommonExtension.xsd" />
+  <xs:import namespace="https://raw.githubusercontent.com/MTES-MCT/dialog/main/docs/spec/datex2" schemaLocation="DATEXII_3_DiaLogExtension.xsd" />
   <xs:complexType name="_CalendarWeekWithinMonthEnum">
     <xs:simpleContent>
       <xs:extension base="com:CalendarWeekWithinMonthEnum">
@@ -137,7 +147,7 @@
   </xs:complexType>
   <xs:complexType name="_VehicleCharacteristicsExtensionType">
     <xs:sequence>
-      <xs:element name="vehicleCharacteristicsExtended" type="comx:VehicleCharacteristicsExtended" minOccurs="0" />
+      <xs:element name="vehicleCharacteristicsExtended" type="dx:VehicleCharacteristicsExtended" minOccurs="0" />
       <xs:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" />
     </xs:sequence>
   </xs:complexType>

--- a/docs/spec/datex2/DATEXII_3_DiaLogExtension.xsd
+++ b/docs/spec/datex2/DATEXII_3_DiaLogExtension.xsd
@@ -32,4 +32,17 @@
       </xs:element>
     </xs:sequence>
   </xs:complexType>
+
+  <xs:complexType name="VehicleCharacteristicsExtended">
+    <xs:annotation>
+      <xs:documentation>Extension of class VehicleCharacteristics.</xs:documentation>
+    </xs:annotation>
+    <xs:sequence>
+      <xs:element name="otherVehicleType" type="xs:string" minOccurs="0" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Other type of vehicle.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
+    </xs:sequence>
+  </xs:complexType>
 </xs:schema>

--- a/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
@@ -60,6 +60,11 @@ final class GetRegulationOrdersToDatexFormatQueryHandler
                                 vehicleType: $restrictedVehicleType,
                                 maxWeight: $vehicleSet->getHeavyweightMaxWeight(),
                             );
+                        } elseif (VehicleTypeEnum::OTHER->value === $restrictedVehicleType) {
+                            $vehicleConditions[] = new DatexVehicleConditionView(
+                                vehicleType: $restrictedVehicleType,
+                                otherTypeText: $vehicleSet->getOtherRestrictedTypeText(),
+                            );
                         } else {
                             $vehicleConditions[] = new DatexVehicleConditionView(
                                 vehicleType: $restrictedVehicleType,
@@ -68,7 +73,15 @@ final class GetRegulationOrdersToDatexFormatQueryHandler
                     }
 
                     foreach ($vehicleSet->getExemptedTypes() as $exemptedVehicleType) {
-                        $vehicleConditions[] = new DatexVehicleConditionView($exemptedVehicleType, isExempted: true);
+                        if (VehicleTypeEnum::OTHER->value === $exemptedVehicleType) {
+                            $vehicleConditions[] = new DatexVehicleConditionView(
+                                vehicleType: $exemptedVehicleType,
+                                otherTypeText: $vehicleSet->getOtherExemptedTypeText(),
+                                isExempted: true,
+                            );
+                        } else {
+                            $vehicleConditions[] = new DatexVehicleConditionView($exemptedVehicleType, isExempted: true);
+                        }
                     }
                 }
 

--- a/src/Application/Regulation/View/DatexVehicleConditionView.php
+++ b/src/Application/Regulation/View/DatexVehicleConditionView.php
@@ -23,6 +23,7 @@ final class DatexVehicleConditionView
         public readonly ?float $maxLength = null,
         public readonly ?float $maxHeight = null,
         public readonly bool $isExempted = false,
+        public readonly ?string $otherTypeText = null,
     ) {
         switch ($vehicleType) {
             case VehicleTypeEnum::PEDESTRIANS->value:

--- a/templates/api/regulations.xml.twig
+++ b/templates/api/regulations.xml.twig
@@ -139,7 +139,7 @@
                                 {% endfor %}
                             </conditions>
 
-                            {% set vehicles = trafficRegulation.vehicleConditions|filter(v => not v.isOther) %}
+                            {% set vehicles = trafficRegulation.vehicleConditions %}
 
                             {% if vehicles|length > 0 %}
                                 <conditions xsi:type="ConditionSet">
@@ -182,7 +182,7 @@
                                                                     <com:vehicleWidth>{{ vehicle.maxWidth }}</com:vehicleWidth>
                                                                 </com:widthCharacteristic>
                                                             {% endif %}
-                                                        {% else %}
+                                                        {% elseif not vehicle.isOther %}
                                                             <com:vehicleType>{{ vehicle.type }}</com:vehicleType>
                                                         {% endif %}
                                                         {% if vehicle.type == 'heavyGoodsVehicle' %}
@@ -193,6 +193,13 @@
                                                                     <com:typeOfWeight>maximumPermitted</com:typeOfWeight>
                                                                 </com:grossWeightCharacteristic>
                                                             {% endif %}
+                                                        {% endif %}
+                                                        {% if vehicle.isOther %}
+                                                            <com:_vehicleCharacteristicsExtension>
+                                                                <com:vehicleCharacteristicsExtended>
+                                                                    <dx:otherVehicleType>{{ vehicle.otherTypeText }}</dx:otherVehicleType>
+                                                                </com:vehicleCharacteristicsExtended>
+                                                            </com:_vehicleCharacteristicsExtension>
                                                         {% endif %}
                                                     {% endif %}
                                                 </vehicleCharacteristics>

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -712,6 +712,16 @@
                                 <com:vehicleUsage>emergencyServices</com:vehicleUsage>
                             </vehicleCharacteristics>
                         </conditions>
+                        <conditions xsi:type="VehicleCondition">
+                            <negate>true</negate>
+                            <vehicleCharacteristics>
+                                <com:_vehicleCharacteristicsExtension>
+                                    <com:vehicleCharacteristicsExtended>
+                                        <dx:otherVehicleType>Convois exceptionnels</dx:otherVehicleType>
+                                    </com:vehicleCharacteristicsExtended>
+                                </com:_vehicleCharacteristicsExtension>
+                            </vehicleCharacteristics>
+                        </conditions>
                     </conditions>
                 </condition>
             </trafficRegulation>

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
@@ -122,11 +122,15 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
         $vehicleSet1
             ->expects(self::once())
             ->method('getRestrictedTypes')
-            ->willReturn([VehicleTypeEnum::CRITAIR->value]);
+            ->willReturn([VehicleTypeEnum::CRITAIR->value, VehicleTypeEnum::OTHER->value]);
         $vehicleSet1
             ->expects(self::once())
             ->method('getCritairTypes')
             ->willReturn([CritairEnum::CRITAIR_3->value, CritairEnum::CRITAIR_4->value]);
+        $vehicleSet1
+            ->expects(self::once())
+            ->method('getOtherRestrictedtypeText')
+            ->willReturn('Trottinettes');
         $vehicleSet1
             ->expects(self::never())
             ->method('getMaxHeight');
@@ -402,7 +406,11 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
         $vehicleSet3
             ->expects(self::once())
             ->method('getExemptedTypes')
-            ->willReturn([VehicleTypeEnum::COMMERCIAL->value]);
+            ->willReturn([VehicleTypeEnum::COMMERCIAL->value, VehicleTypeEnum::OTHER->value]);
+        $vehicleSet3
+            ->expects(self::once())
+            ->method('getOtherExemptedTypeText')
+            ->willReturn('Véhicules de service');
 
         $locationView3 = new DatexLocationView(
             roadType: RoadTypeEnum::LANE->value,
@@ -586,6 +594,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
                             vehicleConditions: [
                                 new DatexVehicleConditionView('critair3'),
                                 new DatexVehicleConditionView('critair4'),
+                                new DatexVehicleConditionView(VehicleTypeEnum::OTHER->value, otherTypeText: 'Trottinettes'),
                             ],
                         ),
                         new DatexTrafficRegulationView(
@@ -621,6 +630,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
                                     maxHeight: 2.4,
                                 ),
                                 new DatexVehicleConditionView(VehicleTypeEnum::COMMERCIAL->value, isExempted: true),
+                                new DatexVehicleConditionView(VehicleTypeEnum::OTHER->value, isExempted: true, otherTypeText: 'Véhicules de service'),
                             ],
                         ),
                     ],


### PR DESCRIPTION
* Nécessaire pour #847 

Jusqu'ici on n'affichait pas les véhicules de type "autre" (concernés ou exemptés) dans le DATEX

C'est un problème en soi car tout ce qui est dans DiaLog doit être reflété dans le DATEX

Mais c'est un problème spécifiquement pour #847 car les zones JOP sont indiquées sous forme de "sauf véhicules zone rouge" etc.