### PR TITLE
Restreint l'accès aux brouillons aux utilisateurs connectés

### DIFF
--- a/src/Domain/Regulation/Specification/CanViewRegulationDetail.php
+++ b/src/Domain/Regulation/Specification/CanViewRegulationDetail.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Regulation\Specification;
+
+use App\Domain\Regulation\Enum\RegulationOrderRecordStatusEnum;
+
+final class CanViewRegulationDetail
+{
+    public function isSatisfiedBy(?string $userId, string $status): bool
+    {
+        return $userId || $status === RegulationOrderRecordStatusEnum::PUBLISHED;
+    }
+}

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -167,10 +167,10 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testWithoutAuthenticatedUser(): void
+    public function testPublishedWithoutAuthenticatedUser(): void
     {
         $client = static::createClient();
-        $crawler = $client->request('GET', '/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL);
+        $crawler = $client->request('GET', '/regulations/' . RegulationOrderRecordFixture::UUID_PUBLISHED);
 
         $this->assertResponseStatusCodeSame(200);
 
@@ -178,5 +178,13 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertSame(0, $crawler->selectButton('Supprimer')->count());
         $this->assertSame(0, $crawler->selectButton('Dupliquer')->count());
         $this->assertSame(0, $crawler->selectButton('Modifier')->count());
+    }
+
+    public function testDraftWithoutAuthenticatedUser(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL);
+
+        $this->assertResponseStatusCodeSame(403);
     }
 }

--- a/tests/Unit/Domain/Regulation/Specification/CanViewRegulationDetailTest.php
+++ b/tests/Unit/Domain/Regulation/Specification/CanViewRegulationDetailTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\Regulation\Specification;
+
+use App\Domain\Regulation\Enum\RegulationOrderRecordStatusEnum;
+use App\Domain\Regulation\Specification\CanViewRegulationDetail;
+use PHPUnit\Framework\TestCase;
+
+final class CanViewRegulationDetailTest extends TestCase
+{
+    private $spec;
+
+    public function setUp(): void
+    {
+        $this->spec = new CanViewRegulationDetail();
+    }
+
+    public function testGranted(): void
+    {
+        $this->assertTrue($this->spec->isSatisfiedBy(
+            userId: null,
+            status: RegulationOrderRecordStatusEnum::PUBLISHED,
+        ));
+
+        $this->assertTrue($this->spec->isSatisfiedBy(
+            userId: '066868b3-accf-7f18-8000-7daddb86cc7a',
+            status: RegulationOrderRecordStatusEnum::PUBLISHED,
+        ));
+
+        $this->assertTrue($this->spec->isSatisfiedBy(
+            userId: '066868b3-accf-7f18-8000-7daddb86cc7a',
+            status: RegulationOrderRecordStatusEnum::DRAFT,
+        ));
+    }
+
+    public function testDenied(): void
+    {
+        $this->assertFalse($this->spec->isSatisfiedBy(
+            userId: null,
+            status: RegulationOrderRecordStatusEnum::DRAFT,
+        ));
+    }
+}


### PR DESCRIPTION
* Closes #861 

Il y avait un test mais il était faux : il vérifiait qu'un arrêté brouillon était accessible à un utilisateur non-connecté, ce qui est précisément le bug...