### PR TITLE
Gestion des rôles utilisateurs (partie 1)

### DIFF
--- a/.env
+++ b/.env
@@ -25,7 +25,6 @@ DATABASE_URL="postgresql://dialog:dialog@database:5432/dialog"
 REDIS_URL="redis://redis:6379"
 API_ADRESSE_BASE_URL=https://api-adresse.data.gouv.fr
 MATOMO_ENABLED=false
-ADMIN_EMAILS='["mathieu.fernandez@beta.gouv.fr", "johan.richer@multi.coop"]'
 ###> BD TOPO ###
 BDTOPO_DATABASE_URL=
 # BDTOPO_DATABASE_URL=postgres://dialog_app:...

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -20,14 +20,14 @@ security:
             logout:
                 path: app_logout
     access_control:
-        - { path: ^/admin, roles: ROLE_ADMIN }
+        - { path: ^/admin, roles: ROLE_SUPER_ADMIN }
         - { path: '^/regulations/([0-9a-f]{8}-[0-9a-f]{4}-[13-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$', methods: [GET], roles: PUBLIC_ACCESS }
         - { path: '^/regulations$', methods: [GET], roles: PUBLIC_ACCESS }
         - { path: '^/(_fragment|regulations|feedback)', roles: ROLE_USER }
         - { path: ^/, roles: PUBLIC_ACCESS }
 
     role_hierarchy:
-        ROLE_ADMIN: ROLE_USER
+        ROLE_SUPER_ADMIN: ROLE_USER
 
 when@test:
     security:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -6,7 +6,6 @@
 parameters:
     server_timezone: '%env(APP_SERVER_TIMEZONE)%'
     client_timezone: '%env(APP_CLIENT_TIMEZONE)%'
-    admin_emails: '%env(json:ADMIN_EMAILS)%'
     features: []
 
 services:
@@ -17,7 +16,6 @@ services:
         bind:
             $clientTimezone: '%client_timezone%'
             $projectDir: '%kernel.project_dir%'
-            $adminEmails: '%admin_emails%'
             $eudonetParisOrgId: '%env(APP_EUDONET_PARIS_ORG_ID)%'
             $dialogOrgId: '%env(DIALOG_ORG_ID)%'
             $bacIdfDecreesFile: '%env(APP_BAC_IDF_DECREES_FILE)%'

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -103,7 +103,6 @@ Chaque application peut être configurée avec les variables d'environnement sui
 | `REDIS_URL` | URL vers le serveur Redis | _(Obligatoire)_ `$SCALINGO_REDIS_URL` | La variable `$SCALINGO_REDIS_URL` est configurée automatiquement par Scalingo |
 | `SENTRY_DSN` | URL de collecte Sentry | | À récupérer sur l'instance Sentry. Voir : [Monitoring](../tools/monitoring.md) |
 | `WEB_CONCURRENCY` | Nombre de processus enfants créés par PHP-FPM (`pm.max_children`). | Dépend de la `memory_limit` et de la RAM de la machine. | Utiliser `2`. Peut être ajusté pour optimiser le fonctionnement du serveur. Voir : [PHP-FPM Concurrency (Scalingo docs)](https://www.php.net/manual/fr/install.fpm.configuration.php) |
-| `ADMIN_EMAILS` | Adresses email des administrateurs | _(Obligatoire)_ ["mathieu.fernandez@beta.gouv.fr"] | |
 
 ## Retirer un environnement
 

--- a/docs/tools/admin.md
+++ b/docs/tools/admin.md
@@ -6,6 +6,4 @@ L'implémentation utilise [EasyAdmin](https://github.com/EasyCorp/EasyAdminBundl
 
 ## Accès à l'admin
 
-L'admin n'est accessible qu'aux comptes administrateurs déterminés par la variable d'environnement `ADMIN_EMAILS`.
-
-En local, mettez l'email de votre compte dans `ADMIN_EMAILS` dans `.env.local` pour pouvoir accéder à l'admin.
+L'admin n'est accessible qu'aux comptes administrateurs déterminés par le super administrateur Mathieu Fernandez (mathieu.fernandez@beta.gouv.fr).

--- a/src/Application/User/Command/ConvertAccessRequestToUserCommandHandler.php
+++ b/src/Application/User/Command/ConvertAccessRequestToUserCommandHandler.php
@@ -7,12 +7,16 @@ namespace App\Application\User\Command;
 use App\Application\DateUtilsInterface;
 use App\Application\IdFactoryInterface;
 use App\Domain\User\AccessRequest;
+use App\Domain\User\Enum\OrganizationRolesEnum;
+use App\Domain\User\Enum\UserRolesEnum;
 use App\Domain\User\Exception\AccessRequestNotFoundException;
 use App\Domain\User\Exception\SiretMissingException;
 use App\Domain\User\Exception\UserAlreadyRegisteredException;
 use App\Domain\User\Organization;
+use App\Domain\User\OrganizationUser;
 use App\Domain\User\Repository\AccessRequestRepositoryInterface;
 use App\Domain\User\Repository\OrganizationRepositoryInterface;
+use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
 use App\Domain\User\Repository\UserRepositoryInterface;
 use App\Domain\User\User;
 
@@ -22,6 +26,7 @@ final class ConvertAccessRequestToUserCommandHandler
         private IdFactoryInterface $idFactory,
         private AccessRequestRepositoryInterface $accessRequestRepository,
         private UserRepositoryInterface $userRepository,
+        private OrganizationUserRepositoryInterface $organizationUserRepository,
         private OrganizationRepositoryInterface $organizationRepository,
         private DateUtilsInterface $dateUtils,
     ) {
@@ -44,7 +49,10 @@ final class ConvertAccessRequestToUserCommandHandler
         }
 
         $organization = $this->organizationRepository->findOneBySiret($accessRequest->getSiret());
+        $organizationRole = OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value; // Default organization role
+
         if (!$organization) {
+            $organizationRole = OrganizationRolesEnum::ROLE_ORGA_ADMIN->value; // The first user in an organization becomes an admin
             $organization = (new Organization($this->idFactory->make()))
                 ->setSiret($accessRequest->getSiret())
                 ->setName($accessRequest->getOrganization());
@@ -55,10 +63,16 @@ final class ConvertAccessRequestToUserCommandHandler
             ->setFullName($accessRequest->getFullName())
             ->setPassword($accessRequest->getPassword())
             ->setEmail($accessRequest->getEmail())
+            ->setRoles([UserRolesEnum::ROLE_USER->value])
             ->setRegistrationDate($this->dateUtils->getNow());
-        $user->addOrganization($organization);
+
+        $organizationUser = (new OrganizationUser($this->idFactory->make()))
+            ->setUser($user)
+            ->setOrganization($organization)
+            ->setRoles([$organizationRole]);
 
         $this->userRepository->add($user);
+        $this->organizationUserRepository->add($organizationUser);
         $this->accessRequestRepository->remove($accessRequest);
     }
 }

--- a/src/Domain/Regulation/Specification/CanUseRawGeoJSON.php
+++ b/src/Domain/Regulation/Specification/CanUseRawGeoJSON.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Regulation\Specification;
 
-use App\Domain\User\User;
+use App\Domain\User\Enum\UserRolesEnum;
 
 final class CanUseRawGeoJSON
 {
@@ -12,6 +12,6 @@ final class CanUseRawGeoJSON
 
     public function isSatisfiedBy(?array $roles): bool
     {
-        return \in_array(User::ROLE_ADMIN, $roles ?? []);
+        return \in_array(UserRolesEnum::ROLE_SUPER_ADMIN->value, $roles ?? []);
     }
 }

--- a/src/Domain/User/Enum/OrganizationRolesEnum.php
+++ b/src/Domain/User/Enum/OrganizationRolesEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Enum;
+
+enum OrganizationRolesEnum: string
+{
+    case ROLE_ORGA_ADMIN = 'ROLE_ORGA_ADMIN';
+    case ROLE_ORGA_CONTRIBUTOR = 'ROLE_ORGA_CONTRIBUTOR';
+    case ROLE_ORGA_PUBLISHER = 'ROLE_ORGA_PUBLISHER';
+}

--- a/src/Domain/User/Enum/UserRolesEnum.php
+++ b/src/Domain/User/Enum/UserRolesEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Enum;
+
+enum UserRolesEnum: string
+{
+    case ROLE_SUPER_ADMIN = 'ROLE_SUPER_ADMIN';
+    case ROLE_USER = 'ROLE_USER';
+}

--- a/src/Domain/User/Organization.php
+++ b/src/Domain/User/Organization.php
@@ -4,19 +4,14 @@ declare(strict_types=1);
 
 namespace App\Domain\User;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
-
 class Organization
 {
-    private Collection $users;
     private string $name;
     private ?string $siret;
 
     public function __construct(
         private string $uuid,
     ) {
-        $this->users = new ArrayCollection();
     }
 
     public function getUuid(): string
@@ -46,25 +41,6 @@ class Organization
         $this->siret = $siret;
 
         return $this;
-    }
-
-    public function getUsers(): Collection
-    {
-        return $this->users;
-    }
-
-    public function addUser(User $user): void
-    {
-        if (!$this->users->contains($user)) {
-            $this->users->add($user);
-        }
-    }
-
-    public function removeUser(User $user): void
-    {
-        if ($this->users->contains($user)) {
-            $this->users->removeElement($user);
-        }
     }
 
     public function __toString(): string

--- a/src/Domain/User/OrganizationUser.php
+++ b/src/Domain/User/OrganizationUser.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User;
+
+class OrganizationUser
+{
+    private Organization $organization;
+    private User $user;
+    private array $roles = [];
+
+    public function __construct(
+        private string $uuid,
+    ) {
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function getOrganization(): Organization
+    {
+        return $this->organization;
+    }
+
+    public function setOrganization(Organization $organization): self
+    {
+        $this->organization = $organization;
+
+        return $this;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function setUser(User $user): self
+    {
+        $this->user = $user;
+
+        return $this;
+    }
+
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+}

--- a/src/Domain/User/Repository/OrganizationUserRepositoryInterface.php
+++ b/src/Domain/User/Repository/OrganizationUserRepositoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Repository;
+
+use App\Domain\User\OrganizationUser;
+use App\Domain\User\User;
+
+interface OrganizationUserRepositoryInterface
+{
+    public function add(OrganizationUser $organizationUser): void;
+
+    public function findOrganizationsByUser(User $user): array;
+}

--- a/src/Domain/User/User.php
+++ b/src/Domain/User/User.php
@@ -4,24 +4,17 @@ declare(strict_types=1);
 
 namespace App\Domain\User;
 
-use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Collections\Collection;
-
 class User
 {
-    public const ROLE_ADMIN = 'ROLE_ADMIN';
-    public const ROLE_USER = 'ROLE_USER';
-
     private string $fullName;
     private string $email;
     private string $password;
-    private Collection $organizations;
+    private array $roles = [];
     private \DateTimeInterface $registrationDate;
 
     public function __construct(
         private string $uuid,
     ) {
-        $this->organizations = new ArrayCollection();
     }
 
     public function getUuid(): string
@@ -65,6 +58,18 @@ class User
         return $this;
     }
 
+    public function getRoles(): array
+    {
+        return $this->roles;
+    }
+
+    public function setRoles(array $roles): self
+    {
+        $this->roles = $roles;
+
+        return $this;
+    }
+
     public function getRegistrationDate(): \DateTimeInterface
     {
         return $this->registrationDate;
@@ -75,26 +80,5 @@ class User
         $this->registrationDate = $date;
 
         return $this;
-    }
-
-    public function getOrganizations(): Collection
-    {
-        return $this->organizations;
-    }
-
-    public function addOrganization(Organization $organization): void
-    {
-        if (!$this->organizations->contains($organization)) {
-            $this->organizations->add($organization);
-            $organization->addUser($this);
-        }
-    }
-
-    public function removeOrganization(Organization $organization): void
-    {
-        if ($this->organizations->contains($organization)) {
-            $this->organizations->removeElement($organization);
-            $organization->removeUser($this);
-        }
     }
 }

--- a/src/Infrastructure/Controller/Admin/UserCrudController.php
+++ b/src/Infrastructure/Controller/Admin/UserCrudController.php
@@ -11,7 +11,6 @@ use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
-use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
@@ -56,13 +55,6 @@ final class UserCrudController extends AbstractCrudController
             DateField::new('registrationDate')
                 ->setLabel('Date d\'inscription')
                 ->setDisabled($pageName === Crud::PAGE_EDIT),
-            AssociationField::new('organizations')
-                ->setFormTypeOption('by_reference', false)
-                ->setFormTypeOption('choice_label', 'name')
-                ->setLabel('Organisation(s)')
-                ->formatValue(function ($value, $entity) {
-                    return implode(', ', $entity->getOrganizations()->toArray());
-                }),
         ];
 
         $password = TextField::new('password')

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/OrganizationFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/OrganizationFixture.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Persistence\Doctrine\Fixtures;
 
+use App\Domain\User\Enum\OrganizationRolesEnum;
 use App\Domain\User\Organization;
+use App\Domain\User\OrganizationUser;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
@@ -19,15 +21,30 @@ final class OrganizationFixture extends Fixture implements DependentFixtureInter
     {
         $mainOrg = (new Organization(self::MAIN_ORG_ID))
             ->setName(self::MAIN_ORG_NAME);
-        $mainOrg->addUser($this->getReference('mainOrgUser'));
-        $mainOrg->addUser($this->getReference('mainOrgAdmin'));
 
         $otherOrg = (new Organization(self::OTHER_ORG_ID))
             ->setName('Mairie de Savenay');
-        $otherOrg->addUser($this->getReference('otherOrgUser'));
+
+        $organizationUser1 = new OrganizationUser('53aede0c-1ff3-4873-9e3d-132950dfb893');
+        $organizationUser1->setUser($this->getReference('mainOrgUser'));
+        $organizationUser1->setOrganization($mainOrg);
+        $organizationUser1->setRoles([OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR]);
+
+        $organizationUser2 = new OrganizationUser('cf72ca91-3446-410f-b563-74085516180d');
+        $organizationUser2->setUser($this->getReference('mainOrgAdmin'));
+        $organizationUser2->setOrganization($mainOrg);
+        $organizationUser2->setRoles([OrganizationRolesEnum::ROLE_ORGA_ADMIN]);
+
+        $organizationUser3 = new OrganizationUser('890615e1-bcb0-4623-a2fa-362435109030');
+        $organizationUser3->setUser($this->getReference('otherOrgUser'));
+        $organizationUser3->setOrganization($otherOrg);
+        $organizationUser3->setRoles([OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR]);
 
         $manager->persist($mainOrg);
         $manager->persist($otherOrg);
+        $manager->persist($organizationUser1);
+        $manager->persist($organizationUser2);
+        $manager->persist($organizationUser3);
         $manager->flush();
 
         $this->addReference('mainOrg', $mainOrg);

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/UserFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/UserFixture.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Persistence\Doctrine\Fixtures;
 
+use App\Domain\User\Enum\UserRolesEnum;
 use App\Domain\User\User;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
@@ -21,18 +22,21 @@ final class UserFixture extends Fixture
             ->setFullName('Mathieu MARCHOIS')
             ->setEmail(self::MAIN_ORG_USER_EMAIL)
             ->setPassword(self::PASSWORD)
+            ->setRoles([UserRolesEnum::ROLE_USER->value])
             ->setRegistrationDate(new \DateTimeImmutable('2024-03-01'));
 
         $mainOtherAdmin = (new User('5bc831a3-7a09-44e9-aefa-5ce3588dac33'))
             ->setFullName('Mathieu FERNANDEZ')
             ->setEmail(self::MAIN_ORG_ADMIN_EMAIL)
             ->setPassword(self::PASSWORD)
+            ->setRoles([UserRolesEnum::ROLE_SUPER_ADMIN->value])
             ->setRegistrationDate(new \DateTimeImmutable('2024-04-02'));
 
         $otherOrgUser = (new User('d47badd9-989e-472b-a80e-9df642e93880'))
             ->setFullName('Florimond MANCA')
             ->setEmail(self::OTHER_ORG_USER_EMAIL)
             ->setPassword(self::PASSWORD)
+            ->setRoles([UserRolesEnum::ROLE_USER->value])
             ->setRegistrationDate(new \DateTimeImmutable('2024-05-07'));
 
         $manager->persist($mainOrgUser);

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/User.Organization.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/User.Organization.orm.xml
@@ -9,15 +9,5 @@
     <unique-constraints>
         <unique-constraint columns="siret" name="organization_siret" />
     </unique-constraints>
-    <many-to-many field="users" inversed-by="organizations" target-entity="App\Domain\User\User">
-        <join-table name="organizations_users">
-            <join-columns>
-                <join-column name="organization_uuid" referenced-column-name="uuid" />
-            </join-columns>
-            <inverse-join-columns>
-                <join-column name="user_uuid" referenced-column-name="uuid" />
-            </inverse-join-columns>
-        </join-table>
-    </many-to-many>
   </entity>
 </doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/User.OrganizationUser.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/User.OrganizationUser.orm.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity
+    name="App\Domain\User\OrganizationUser"
+    table="organizations_users">
+    <id name="uuid" type="guid" column="uuid"/>
+    <field name="roles" type="array" column="roles" nullable="false"/>
+    <many-to-one field="user" target-entity="App\Domain\User\User">
+        <join-columns>
+            <join-column name="user_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE"/>
+        </join-columns>
+    </many-to-one>
+    <many-to-one field="organization" target-entity="App\Domain\User\Organization">
+      <join-columns>
+          <join-column name="organization_uuid" referenced-column-name="uuid" nullable="false" on-delete="CASCADE"/>
+      </join-columns>
+  </many-to-one>
+  </entity>
+</doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/User.User.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/User.User.orm.xml
@@ -7,12 +7,12 @@
     <field name="fullName" type="string" column="full_name" nullable="false"/>
     <field name="email" type="string" column="email" nullable="false"/>
     <field name="password" type="string" column="password" nullable="false"/>
+    <field name="roles" type="array" column="roles" nullable="false"/>
     <field name="registrationDate" type="datetimetz" nullable="false">
         <options>
           <option name="default">CURRENT_TIMESTAMP</option>
         </options>
     </field>
-    <many-to-many field="organizations" mapped-by="users" target-entity="App\Domain\User\Organization"/>
     <unique-constraints>
         <unique-constraint columns="email" name="user_email" />
     </unique-constraints>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240709115447.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240709115447.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240709115447 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" ADD roles TEXT DEFAULT NULL');
+        $this->addSql('COMMENT ON COLUMN "user".roles IS \'(DC2Type:array)\'');
+        $this->addSql('UPDATE "user" SET roles = \'a:1:{i:0;s:9:"ROLE_USER";}\';');
+        $this->addSql('UPDATE "user" SET roles = \'a:1:{i:0;s:16:"ROLE_SUPER_ADMIN";}\' WHERE email = \'mathieu.fernandez@beta.gouv.fr\';');
+        $this->addSql('ALTER TABLE "user" ALTER roles SET NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE "user" DROP roles');
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240709154626.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240709154626.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20240709154626 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE organizations_users DROP CONSTRAINT FK_9328CA68E8766E3B');
+        $this->addSql('ALTER TABLE organizations_users DROP CONSTRAINT FK_9328CA68ABFE1C6F');
+        $this->addSql('ALTER TABLE organizations_users DROP CONSTRAINT organizations_users_pkey');
+        $this->addSql('ALTER TABLE organizations_users ADD uuid UUID DEFAULT NULL');
+        $this->addSql('ALTER TABLE organizations_users ADD roles TEXT DEFAULT NULL');
+        $this->addSql('COMMENT ON COLUMN organizations_users.roles IS \'(DC2Type:array)\'');
+
+        $this->addSql('UPDATE "organizations_users" SET uuid = public.uuid_generate_v4();');
+        $this->addSql('UPDATE "organizations_users" SET roles = \'a:1:{i:0;s:21:"ROLE_ORGA_CONTRIBUTOR";}\';');
+
+        $this->addSql('ALTER TABLE organizations_users ALTER uuid SET NOT NULL');
+        $this->addSql('ALTER TABLE organizations_users ALTER roles SET NOT NULL');
+        $this->addSql('ALTER TABLE organizations_users ADD CONSTRAINT FK_9328CA68E8766E3B FOREIGN KEY (organization_uuid) REFERENCES organization (uuid) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE organizations_users ADD CONSTRAINT FK_9328CA68ABFE1C6F FOREIGN KEY (user_uuid) REFERENCES "user" (uuid) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE organizations_users ADD PRIMARY KEY (uuid)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE organizations_users DROP CONSTRAINT fk_9328ca68abfe1c6f');
+        $this->addSql('ALTER TABLE organizations_users DROP CONSTRAINT fk_9328ca68e8766e3b');
+        $this->addSql('DROP INDEX organizations_users_pkey');
+        $this->addSql('ALTER TABLE organizations_users DROP uuid');
+        $this->addSql('ALTER TABLE organizations_users DROP roles');
+        $this->addSql('ALTER TABLE organizations_users ADD CONSTRAINT fk_9328ca68abfe1c6f FOREIGN KEY (user_uuid) REFERENCES "user" (uuid) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE organizations_users ADD CONSTRAINT fk_9328ca68e8766e3b FOREIGN KEY (organization_uuid) REFERENCES organization (uuid) NOT DEFERRABLE INITIALLY IMMEDIATE');
+        $this->addSql('ALTER TABLE organizations_users ADD PRIMARY KEY (organization_uuid, user_uuid)');
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Repository/User/OrganizationUserRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/User/OrganizationUserRepository.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Repository\User;
+
+use App\Domain\User\OrganizationUser;
+use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
+use App\Domain\User\User;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+final class OrganizationUserRepository extends ServiceEntityRepository implements OrganizationUserRepositoryInterface
+{
+    public function __construct(
+        ManagerRegistry $registry,
+    ) {
+        parent::__construct($registry, OrganizationUser::class);
+    }
+
+    public function add(OrganizationUser $organizationUser): void
+    {
+        $this->getEntityManager()->persist($organizationUser);
+    }
+
+    public function findOrganizationsByUser(User $user): array
+    {
+        return $this->createQueryBuilder('ou')
+            ->where('ou.user = :user')
+            ->innerJoin('ou.organization', 'o')
+            ->setParameter('user', $user)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Repository/User/UserRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/User/UserRepository.php
@@ -14,7 +14,6 @@ final class UserRepository extends ServiceEntityRepository implements UserReposi
 {
     public function __construct(
         ManagerRegistry $registry,
-        private string $dialogOrgId,
         private readonly StringUtilsInterface $stringUtils,
     ) {
         parent::__construct($registry, User::class);
@@ -30,7 +29,6 @@ final class UserRepository extends ServiceEntityRepository implements UserReposi
         return $this->createQueryBuilder('u')
             ->where('u.email = :email')
             ->setParameter('email', $this->stringUtils->normalizeEmail($email))
-            ->innerJoin('u.organizations', 'o')
             ->setMaxResults(1)
             ->getQuery()
             ->getOneOrNullResult()
@@ -41,9 +39,6 @@ final class UserRepository extends ServiceEntityRepository implements UserReposi
     {
         return $this->createQueryBuilder('u')
             ->select('count(DISTINCT(u.uuid))')
-            ->innerJoin('u.organizations', 'o')
-            ->where('o.uuid <> :uuid')
-            ->setParameter('uuid', $this->dialogOrgId)
             ->getQuery()
             ->getSingleScalarResult()
         ;

--- a/templates/common/header.html.twig
+++ b/templates/common/header.html.twig
@@ -37,7 +37,7 @@
                                         {{ 'common.feedback'|trans }}
                                     </a>
                                 </li>
-                                {% if is_granted('ROLE_ADMIN') %}
+                                {% if is_granted('ROLE_SUPER_ADMIN') %}
                                     <li>
                                         <a class="fr-btn fr-icon-settings-5-line" href="{{ path('app_admin') }}">
                                             Administration

--- a/tests/Integration/Infrastructure/Controller/StatisticsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/StatisticsControllerTest.php
@@ -19,7 +19,7 @@ final class StatisticsControllerTest extends AbstractWebTestCase
         $stats = $crawler->filter('div.fr-card');
         $this->assertSame(6, $stats->count());
 
-        $this->assertSame("Nombre total d'utilisateurs 1", $stats->eq(0)->text());
+        $this->assertSame("Nombre total d'utilisateurs 3", $stats->eq(0)->text());
         $this->assertSame("Nombre total d'organisations 1", $stats->eq(1)->text());
         $this->assertSame("Nombre total d'arrếtés 2", $stats->eq(2)->text());
         $this->assertSame("Nombre total d'arrếtés publiés 1", $stats->eq(3)->text());

--- a/tests/Unit/Domain/User/OrganizationTest.php
+++ b/tests/Unit/Domain/User/OrganizationTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Domain\User;
 
 use App\Domain\User\Organization;
-use App\Domain\User\User;
 use PHPUnit\Framework\TestCase;
 
 final class OrganizationTest extends TestCase
@@ -20,16 +19,5 @@ final class OrganizationTest extends TestCase
         $this->assertSame('Mairie de Savenay', $organization->getName());
         $this->assertSame('21440195200129', $organization->getSiret());
         $this->assertSame('Mairie de Savenay', (string) $organization);
-        $this->assertEmpty($organization->getUsers());
-
-        $user = $this->createMock(User::class);
-        $organization->addUser($user);
-        $organization->addUser($user); // Test deduplication of users
-
-        $this->assertSame([$user], $organization->getUsers()->toArray());
-
-        $organization->removeUser($user);
-        $organization->removeUser($user); // Test removal of non existing user
-        $this->assertEmpty($organization->getUsers()->toArray());
     }
 }

--- a/tests/Unit/Domain/User/OrganizationUserTest.php
+++ b/tests/Unit/Domain/User/OrganizationUserTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\User;
+
+use App\Domain\User\Enum\OrganizationRolesEnum;
+use App\Domain\User\Organization;
+use App\Domain\User\OrganizationUser;
+use App\Domain\User\User;
+use PHPUnit\Framework\TestCase;
+
+final class OrganizationUserTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $organization = $this->createMock(Organization::class);
+        $user = $this->createMock(User::class);
+
+        $organizationUser = (new OrganizationUser('9cebe00d-04d8-48da-89b1-059f6b7bfe44'))
+            ->setOrganization($organization)
+            ->setUser($user)
+            ->setRoles([OrganizationRolesEnum::ROLE_ORGA_ADMIN->value]);
+
+        $this->assertSame('9cebe00d-04d8-48da-89b1-059f6b7bfe44', $organizationUser->getUuid());
+        $this->assertSame($user, $organizationUser->getUser());
+        $this->assertSame($organization, $organizationUser->getOrganization());
+        $this->assertSame([OrganizationRolesEnum::ROLE_ORGA_ADMIN->value], $organizationUser->getRoles());
+    }
+}

--- a/tests/Unit/Domain/User/UserTest.php
+++ b/tests/Unit/Domain/User/UserTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Domain\User;
 
-use App\Domain\User\Organization;
+use App\Domain\User\Enum\UserRolesEnum;
 use App\Domain\User\User;
 use PHPUnit\Framework\TestCase;
 
@@ -12,39 +12,21 @@ final class UserTest extends TestCase
 {
     public function testGetters(): void
     {
-        $organization1 = $this->createMock(Organization::class);
-        $organization2 = $this->createMock(Organization::class);
         $date = new \DateTime('2024-05-07');
 
         $user = (new User('9cebe00d-04d8-48da-89b1-059f6b7bfe44'))
             ->setFullName('Mathieu Marchois')
             ->setEmail('mathieu@fairness.coop')
-            ->setPassword('password');
+            ->setPassword('password')
+            ->setRoles([UserRolesEnum::ROLE_SUPER_ADMIN->value]);
 
         $user->setRegistrationDate($date);
-        $user->addOrganization($organization1);
-        $user->addOrganization($organization2);
-        $user->addOrganization($organization1); // Test deduplication
 
         $this->assertSame('9cebe00d-04d8-48da-89b1-059f6b7bfe44', $user->getUuid());
         $this->assertSame('Mathieu Marchois', $user->getFullName());
         $this->assertSame('mathieu@fairness.coop', $user->getEmail());
         $this->assertSame('password', $user->getPassword());
+        $this->assertSame([UserRolesEnum::ROLE_SUPER_ADMIN->value], $user->getRoles());
         $this->assertSame($date, $user->getRegistrationDate());
-        $this->assertSame([$organization1, $organization2], $user->getOrganizations()->toArray());
-
-        $user->removeOrganization($organization1);
-        $user->removeOrganization($organization1); // Test removal of non existing organization
-        $this->assertSame([1 => $organization2], $user->getOrganizations()->toArray());
-    }
-
-    public function testWithoutOrganization(): void
-    {
-        $user = (new User('9cebe00d-04d8-48da-89b1-059f6b7bfe44'))
-            ->setFullName('Mathieu Marchois')
-            ->setEmail('mathieu@fairness.coop')
-            ->setPassword('password');
-
-        $this->assertSame([], $user->getOrganizations()->toArray());
     }
 }

--- a/tests/Unit/Infrastructure/Security/SymfonyUserTest.php
+++ b/tests/Unit/Infrastructure/Security/SymfonyUserTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Infrastructure\Security;
 
+use App\Domain\User\Enum\UserRolesEnum;
 use App\Domain\User\Organization;
-use App\Domain\User\User;
 use App\Infrastructure\Security\SymfonyUser;
 use PHPUnit\Framework\TestCase;
 
@@ -24,11 +24,11 @@ class SymfonyUserTest extends TestCase
             'Mathieu MARCHOIS',
             'password',
             $organizations,
-            [User::ROLE_USER],
+            [UserRolesEnum::ROLE_USER->value],
         );
 
         $this->assertSame('2d3724f1-2910-48b4-ba56-81796f6e100b', $user->getUuid());
-        $this->assertSame([User::ROLE_USER], $user->getRoles());
+        $this->assertSame([UserRolesEnum::ROLE_USER->value], $user->getRoles());
         $this->assertSame('Mathieu MARCHOIS', $user->getFullName());
         $this->assertSame(null, $user->getSalt());
         $this->assertSame('mathieu.marchois@beta.gouv.fr', $user->getUsername());


### PR DESCRIPTION
* Refs #871 

Cette PR est une première implémentation de la nouvelle gestion des rôles. Elle permet, lors de la création d'un compte utilisateur, de lui attribuer le rôle "sécurité" `ROLE_USER`.
Si c'est le premier inscrit dans l'organisation, l'utilisateur se voit assigner le rôle "applicatif" `ROLE_ORGA_ADMIN` ; sinon, il reçoit le rôle de contributeur `ROLE_ORGA_CONTRIBUTOR`.

Il y a donc maintenant 2 niveaux de rôles : 
- Authentification (stockés dans `user`) :
  - ROLE_SUPER_ADMIN : peut se connecter à l'administration
  - ROLE_USER : peut se connecter à l'application
- Applicatif (stockés dans `organizations_users`) :
  - ROLE_ORGA_ADMIN : administrateur de l'organisation. Il pourra, à terme, administrer l'ensemble de son organisation (cf détail dans #871). À noter qu'il hérite des deux autres rôles de l'organisation.
  - ROLE_ORGA_CONTRIBUTOR : personne qui pourra intégrer les arrêtés.
  - ROLE_ORGA_PUBLISHER : personne qui pourra publier un arrêté.

Remarques : 
- Un utilisateur peut avoir des rôles applicatifs différents par organisation.
- Il n'y a pas encore de restrictions par rapport aux rôles applicatifs

Pour tester : 
- Lancer la commande `make dbmigrate`
- Constater qu'il n'y a aucune régression