### PR TITLE
Gestion des rôles utilisateurs (partie 2)

### DIFF
--- a/config/validator/Domain/User/OrganizationUser.xml
+++ b/config/validator/Domain/User/OrganizationUser.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<constraint-mapping xmlns="http://symfony.com/schema/dic/constraint-mapping"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
+    <class name="App\Domain\User\OrganizationUser">
+        <constraint name="Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity">
+            <option name="fields">
+                <value>organization</value>
+                <value>user</value>
+            </option>
+        </constraint>
+        <property name="roles">
+            <constraint name="NotBlank"/>
+        </property>
+    </class>
+</constraint-mapping>

--- a/src/Domain/User/User.php
+++ b/src/Domain/User/User.php
@@ -81,4 +81,9 @@ class User
 
         return $this;
     }
+
+    public function __toString(): string
+    {
+        return sprintf('%s (%s)', $this->fullName, $this->email);
+    }
 }

--- a/src/Infrastructure/Controller/Admin/DashboardController.php
+++ b/src/Infrastructure/Controller/Admin/DashboardController.php
@@ -7,6 +7,7 @@ namespace App\Infrastructure\Controller\Admin;
 use App\Domain\User\AccessRequest;
 use App\Domain\User\Feedback;
 use App\Domain\User\Organization;
+use App\Domain\User\OrganizationUser;
 use App\Domain\User\User;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Dashboard;
 use EasyCorp\Bundle\EasyAdminBundle\Config\MenuItem;
@@ -34,11 +35,13 @@ final class DashboardController extends AbstractDashboardController
 
         yield MenuItem::section('Gestion des utilisateurs');
         yield MenuItem::linkToCrud('Utilisateurs', 'fa fa-users', User::class);
-        yield MenuItem::linkToCrud('Organisations', 'fa fa-list', Organization::class);
+        yield MenuItem::linkToCrud('Membres d\'organisations', 'fa fa-user-gear', OrganizationUser::class);
         yield MenuItem::linkToCrud('Création de comptes', 'fa fa-code-pull-request', AccessRequest::class);
-        yield MenuItem::linkToCrud('Avis', 'fa fa-comments', Feedback::class);
 
-        yield MenuItem::section('Application');
-        yield MenuItem::linkToRoute('DiaLog', 'fa fa-globe', 'app_regulations_list');
+        yield MenuItem::section('Gestion des organisations');
+        yield MenuItem::linkToCrud('Organisations', 'fa fa-list', Organization::class);
+
+        yield MenuItem::section('Autres');
+        yield MenuItem::linkToCrud('Avis', 'fa fa-comments', Feedback::class);
     }
 }

--- a/src/Infrastructure/Controller/Admin/OrganizationUserCrudController.php
+++ b/src/Infrastructure/Controller/Admin/OrganizationUserCrudController.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Controller\Admin;
+
+use App\Application\IdFactoryInterface;
+use App\Domain\User\Enum\OrganizationRolesEnum;
+use App\Domain\User\OrganizationUser;
+use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
+use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\AssociationField;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
+
+final class OrganizationUserCrudController extends AbstractCrudController
+{
+    public function __construct(
+        private readonly IdFactoryInterface $idFactory,
+    ) {
+    }
+
+    public static function getEntityFqcn(): string
+    {
+        return OrganizationUser::class;
+    }
+
+    public function createEntity(string $entityFqcn): OrganizationUser
+    {
+        return new OrganizationUser($this->idFactory->make());
+    }
+
+    public function configureCrud(Crud $crud): Crud
+    {
+        return $crud
+            ->setEntityLabelInSingular('Membre d\'organisation')
+            ->setEntityLabelInPlural('Membres d\'organisations')
+            ->setDefaultSort(['organization' => 'ASC'])
+        ;
+    }
+
+    public function configureFields(string $pageName): iterable
+    {
+        $roles = array_column(OrganizationRolesEnum::cases(), 'value');
+
+        return [
+            AssociationField::new('organization')->setLabel('Organisation')->setSortProperty('name'),
+            AssociationField::new('user')->setLabel('Utilisateur')->setSortProperty('fullName'),
+            ChoiceField::new('roles')
+                ->setLabel('Rôles')
+                ->setChoices(array_combine($roles, $roles))
+                ->allowMultipleChoices()
+                ->renderAsBadges(),
+        ];
+    }
+}

--- a/tests/Integration/Infrastructure/Controller/Admin/OrganizationUserCrudControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Admin/OrganizationUserCrudControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Controller\Admin;
+
+use App\Infrastructure\Persistence\Doctrine\Fixtures\UserFixture;
+use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
+
+final class OrganizationUserCrudControllerTest extends AbstractWebTestCase
+{
+    public function testIndex(): void
+    {
+        $client = $this->login(UserFixture::MAIN_ORG_ADMIN_EMAIL);
+        $crawler = $client->request('GET', '/admin?crudAction=index&crudControllerFqcn=App%5CInfrastructure%5CController%5CAdmin%5COrganizationUserCrudController');
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+        $this->assertSame('Membres d\'organisations', $crawler->filter('h1')->text());
+    }
+
+    public function testIndexWithoutAuthentication(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/admin?crudAction=index&crudControllerFqcn=App%5CInfrastructure%5CController%5CAdmin%5COrganizationUserCrudController');
+
+        $this->assertResponseRedirects('http://localhost/login', 302);
+    }
+
+    public function testIndexWithRoleUser(): void
+    {
+        $client = $this->login();
+        $client->request('GET', '/admin?crudAction=index&crudControllerFqcn=App%5CInfrastructure%5CController%5CAdmin%5COrganizationUserCrudController');
+
+        $this->assertResponseStatusCodeSame(403);
+    }
+}

--- a/tests/Unit/Domain/User/UserTest.php
+++ b/tests/Unit/Domain/User/UserTest.php
@@ -28,5 +28,6 @@ final class UserTest extends TestCase
         $this->assertSame('password', $user->getPassword());
         $this->assertSame([UserRolesEnum::ROLE_SUPER_ADMIN->value], $user->getRoles());
         $this->assertSame($date, $user->getRegistrationDate());
+        $this->assertSame('Mathieu Marchois (mathieu@fairness.coop)', (string) $user);
     }
 }


### PR DESCRIPTION
* Refs #871 

Cette PR a pour objectif de permettre à l'administrateur d'associer des utilisateurs à des organisations avec des rôles spécifiques.

![image](https://github.com/user-attachments/assets/001e97a5-f1ad-4d53-aa09-8e0689d68bc7)
![image](https://github.com/user-attachments/assets/f1d36d24-51f6-4815-8259-113befc679f1)

Note : cela n'a pas encore d'incidence sur les utilisateurs, l'application de la distinction des rôles se fera dans un second temps après travail UX avec @aureliebaton. 
