### PR TITLE
Gestion des rôles (partie 3)

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -23,7 +23,7 @@ security:
         - { path: ^/admin, roles: ROLE_SUPER_ADMIN }
         - { path: '^/regulations/([0-9a-f]{8}-[0-9a-f]{4}-[13-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})$', methods: [GET], roles: PUBLIC_ACCESS }
         - { path: '^/regulations$', methods: [GET], roles: PUBLIC_ACCESS }
-        - { path: '^/(_fragment|regulations|feedback)', roles: ROLE_USER }
+        - { path: '^/(_fragment|regulations|feedback|organizations)', roles: ROLE_USER }
         - { path: ^/, roles: PUBLIC_ACCESS }
 
     role_hierarchy:

--- a/src/Application/User/View/UserOrganizationView.php
+++ b/src/Application/User/View/UserOrganizationView.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\View;
+
+final class UserOrganizationView
+{
+    public function __construct(
+        public readonly string $uuid,
+        public readonly string $name,
+        public readonly array $roles = [],
+    ) {
+    }
+}

--- a/src/Infrastructure/Controller/Organization/ListOrganizationsController.php
+++ b/src/Infrastructure/Controller/Organization/ListOrganizationsController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Controller\Organization;
+
+use App\Infrastructure\Security\SymfonyUser;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+
+final class ListOrganizationsController
+{
+    public function __construct(
+        private \Twig\Environment $twig,
+        private Security $security,
+    ) {
+    }
+
+    #[Route(
+        '/organizations',
+        name: 'app_organizations_list',
+        methods: ['GET'],
+    )]
+    public function __invoke(Request $request): Response
+    {
+        /** @var SymfonyUser|null */
+        $user = $this->security->getUser();
+
+        return new Response($this->twig->render(
+            name: 'organization/index.html.twig',
+            context: [
+                'organizations' => $user->getUserOrganizations(),
+            ],
+        ));
+    }
+}

--- a/src/Infrastructure/Controller/Regulation/AddRegulationController.php
+++ b/src/Infrastructure/Controller/Regulation/AddRegulationController.php
@@ -44,7 +44,7 @@ final class AddRegulationController
             type: GeneralInfoFormType::class,
             data: $command,
             options: [
-                'organizations' => $user->getOrganizations(),
+                'organizations' => $user->getUserOrganizations(),
                 'action' => $this->router->generate('app_regulation_add'),
                 'save_options' => [
                     'label' => 'common.form.continue',

--- a/src/Infrastructure/Controller/Regulation/Fragments/SaveGeneralInfoController.php
+++ b/src/Infrastructure/Controller/Regulation/Fragments/SaveGeneralInfoController.php
@@ -50,7 +50,7 @@ final class SaveGeneralInfoController extends AbstractRegulationController
             type: GeneralInfoFormType::class,
             data: $command,
             options: [
-                'organizations' => $user->getOrganizations(),
+                'organizations' => $user->getUserOrganizations(),
                 'action' => $this->router->generate('fragment_regulations_general_info_form', ['uuid' => $uuid]),
                 'save_options' => [
                     'label' => 'common.form.validate',

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/OrganizationFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/OrganizationFixture.php
@@ -28,17 +28,17 @@ final class OrganizationFixture extends Fixture implements DependentFixtureInter
         $organizationUser1 = new OrganizationUser('53aede0c-1ff3-4873-9e3d-132950dfb893');
         $organizationUser1->setUser($this->getReference('mainOrgUser'));
         $organizationUser1->setOrganization($mainOrg);
-        $organizationUser1->setRoles([OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR]);
+        $organizationUser1->setRoles([OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value]);
 
         $organizationUser2 = new OrganizationUser('cf72ca91-3446-410f-b563-74085516180d');
         $organizationUser2->setUser($this->getReference('mainOrgAdmin'));
         $organizationUser2->setOrganization($mainOrg);
-        $organizationUser2->setRoles([OrganizationRolesEnum::ROLE_ORGA_ADMIN]);
+        $organizationUser2->setRoles([OrganizationRolesEnum::ROLE_ORGA_ADMIN->value]);
 
         $organizationUser3 = new OrganizationUser('890615e1-bcb0-4623-a2fa-362435109030');
         $organizationUser3->setUser($this->getReference('otherOrgUser'));
         $organizationUser3->setOrganization($otherOrg);
-        $organizationUser3->setRoles([OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR]);
+        $organizationUser3->setRoles([OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value]);
 
         $manager->persist($mainOrg);
         $manager->persist($otherOrg);

--- a/src/Infrastructure/Persistence/Doctrine/Repository/User/OrganizationUserRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/User/OrganizationUserRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Persistence\Doctrine\Repository\User;
 
+use App\Application\User\View\UserOrganizationView;
 use App\Domain\User\OrganizationUser;
 use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
 use App\Domain\User\User;
@@ -26,11 +27,15 @@ final class OrganizationUserRepository extends ServiceEntityRepository implement
     public function findOrganizationsByUser(User $user): array
     {
         return $this->createQueryBuilder('ou')
+            ->select(
+                sprintf('NEW %s(o.uuid, o.name, ou.roles)',
+                    UserOrganizationView::class,
+                ),
+            )
             ->where('ou.user = :user')
             ->innerJoin('ou.organization', 'o')
             ->setParameter('user', $user)
             ->getQuery()
-            ->getResult()
-        ;
+            ->getResult();
     }
 }

--- a/src/Infrastructure/Security/Provider/UserProvider.php
+++ b/src/Infrastructure/Security/Provider/UserProvider.php
@@ -29,18 +29,13 @@ final class UserProvider implements UserProviderInterface
         }
 
         $userOrganizations = $this->organizationUserRepositoryInterface->findOrganizationsByUser($user);
-        $organizations = [];
-
-        foreach ($userOrganizations as $userOrganization) {
-            $organizations[] = $userOrganization->getOrganization();
-        }
 
         return new SymfonyUser(
             $user->getUuid(),
             $user->getEmail(),
             $user->getFullName(),
             $user->getPassword(),
-            $organizations,
+            $userOrganizations,
             $user->getRoles(),
         );
     }

--- a/src/Infrastructure/Security/SymfonyUser.php
+++ b/src/Infrastructure/Security/SymfonyUser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Security;
 
-use App\Domain\User\Organization;
+use App\Application\User\View\UserOrganizationView;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -15,7 +15,7 @@ class SymfonyUser implements UserInterface, PasswordAuthenticatedUserInterface
         private string $email,
         private string $fullName,
         private string $password,
-        private array $organizations,
+        private array $userOrganizations,
         private array $roles,
     ) {
     }
@@ -55,16 +55,16 @@ class SymfonyUser implements UserInterface, PasswordAuthenticatedUserInterface
         return $this->password;
     }
 
-    public function getOrganizations(): array
+    public function getUserOrganizations(): array
     {
-        return $this->organizations;
+        return $this->userOrganizations;
     }
 
     public function getOrganizationUuids(): array
     {
         return array_map(
-            function (Organization $organization) { return $organization->getUuid(); },
-            $this->organizations,
+            function (UserOrganizationView $userOrganization) { return $userOrganization->uuid; },
+            $this->userOrganizations,
         );
     }
 

--- a/templates/organization/index.html.twig
+++ b/templates/organization/index.html.twig
@@ -1,0 +1,42 @@
+{% extends 'layouts/app.html.twig' %}
+
+{% block title %}
+    {{'organization.list.title'|trans}} - {{ parent() }}
+{% endblock %}
+
+{% block body %}
+    <section class="fr-container fr-py-5w" aria-labelledby="organization-list">
+        <div class="fr-grid-row">
+            <h3 id="organization-list" class="fr-col fr-mb-0">{{ 'organization.list.title'|trans }}</h3>
+        </div>
+        <div class="fr-table fr-table--layout-fixed fr-table--no-caption">
+            <table>
+                <caption>{{ 'organization.list.title'|trans }}</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">{{ 'organization.list.organizationName'|trans }}</th>
+                        <th scope="col">{{ 'organization.list.roles'|trans }}</th>
+                        <th scope="col">{{ 'common.actions'|trans }}</th>
+                    </tr>
+                </thead>
+                <tbody data-testid="organization-list">
+                    {% for organization in organizations %}
+                        <tr>
+                            <td>
+                                {{ organization.name }}
+                            </td>
+
+                            <td>
+                                {% for role in organization.roles %}
+                                    {{ ('roles.' ~ role)|trans }}
+                                    {% if not loop.last %}, {% endif %}
+                                {% endfor %}
+                            </td>
+                            <td></td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+{% endblock %}

--- a/tests/Integration/Infrastructure/Controller/AbstractWebTestCase.php
+++ b/tests/Integration/Infrastructure/Controller/AbstractWebTestCase.php
@@ -23,17 +23,13 @@ abstract class AbstractWebTestCase extends WebTestCase
         $roles = $testUser->getRoles();
         $userOrganizations = $organizationUserRepository->findOrganizationsByUser($testUser);
 
-        foreach ($userOrganizations as $userOrganization) {
-            $organizations[] = $userOrganization->getOrganization();
-        }
-
         $client->loginUser(
             new SymfonyUser(
                 $testUser->getUuid(),
                 $testUser->getEmail(),
                 $testUser->getFullName(),
                 $testUser->getPassword(),
-                $organizations,
+                $userOrganizations,
                 $roles,
             ),
         );

--- a/tests/Integration/Infrastructure/Controller/Organization/ListOrganizationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Organization/ListOrganizationsControllerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Controller\Organization;
+
+use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
+
+final class ListOrganizationsControllerTest extends AbstractWebTestCase
+{
+    public function testPageAndTabs(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/organizations');
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+        $this->assertSame('Mes organisations', $crawler->filter('h3')->text());
+        $this->assertMetaTitle('Mes organisations - DiaLog', $crawler);
+
+        $organizations = $crawler->filter('[data-testid="organization-list"]');
+        $this->assertCount(1, $organizations->filter('tr'));
+        $this->assertSame('Main Org Contributeur', $organizations->filter('tr')->eq(0)->text());
+    }
+
+    public function testWithoutAuthenticatedUser(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/organizations');
+        $this->assertResponseRedirects('http://localhost/login', 302);
+    }
+}

--- a/tests/Unit/Infrastructure/Security/SymfonyUserTest.php
+++ b/tests/Unit/Infrastructure/Security/SymfonyUserTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Infrastructure\Security;
 
+use App\Application\User\View\UserOrganizationView;
 use App\Domain\User\Enum\UserRolesEnum;
-use App\Domain\User\Organization;
 use App\Infrastructure\Security\SymfonyUser;
 use PHPUnit\Framework\TestCase;
 
@@ -13,17 +13,14 @@ class SymfonyUserTest extends TestCase
 {
     public function testUser()
     {
-        $organization = (new Organization('133fb411-7754-4749-9590-ce05a2abe108'))
-            ->setName('Mairie de Saint-Ouen Sur Seine');
-
-        $organizations = [$organization];
+        $organizationUser = new UserOrganizationView('133fb411-7754-4749-9590-ce05a2abe108', 'Mairie de Savenay', []);
 
         $user = new SymfonyUser(
             '2d3724f1-2910-48b4-ba56-81796f6e100b',
             'mathieu.marchois@beta.gouv.fr',
             'Mathieu MARCHOIS',
             'password',
-            $organizations,
+            [$organizationUser],
             [UserRolesEnum::ROLE_USER->value],
         );
 
@@ -34,7 +31,7 @@ class SymfonyUserTest extends TestCase
         $this->assertSame('mathieu.marchois@beta.gouv.fr', $user->getUsername());
         $this->assertSame('mathieu.marchois@beta.gouv.fr', $user->getUserIdentifier());
         $this->assertSame('password', $user->getPassword());
-        $this->assertSame($organizations, $user->getOrganizations());
+        $this->assertSame([$organizationUser], $user->getUserOrganizations());
         $this->assertSame(['133fb411-7754-4749-9590-ce05a2abe108'], $user->getOrganizationUuids());
         $this->assertEmpty($user->eraseCredentials());
     }

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -2002,6 +2002,30 @@
                 <source>jop.regulation_order.description</source>
                 <target>Zones réglementées dans le cadre des Jeux Olympiques et Paralympiques de Paris 2024 (JOP 2024)</target>
             </trans-unit>
+            <trans-unit id="organization.list.title">
+                <source>organization.list.title</source>
+                <target>Mes organisations</target>
+            </trans-unit>
+            <trans-unit id="organization.list.organizationName">
+                <source>organization.list.organizationName</source>
+                <target>Organisation</target>
+            </trans-unit>
+            <trans-unit id="organization.list.roles">
+                <source>organization.list.roles</source>
+                <target>Rôles</target>
+            </trans-unit>
+            <trans-unit id="roles.ROLE_ORGA_CONTRIBUTOR">
+                <source>roles.ROLE_ORGA_CONTRIBUTOR</source>
+                <target>Contributeur</target>
+            </trans-unit>
+            <trans-unit id="roles.ROLE_ORGA_PUBLISHER">
+                <source>roles.ROLE_ORGA_PUBLISHER</source>
+                <target>Editeur</target>
+            </trans-unit>
+            <trans-unit id="roles.ROLE_ORGA_ADMIN">
+                <source>roles.ROLE_ORGA_ADMIN</source>
+                <target>Administrateur</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
* Refs #871 

Cette PR permet de lister les organisations de l'utilisateur connecté.

![image](https://github.com/user-attachments/assets/1a072993-a225-4a90-aba3-404af0d4ea03)

@aureliebaton Voici une proposition pour être le point d'entrée. Je liste ici les organisations dont je fais partie pour ensuite pouvoir les administrer. 
Pour le moment, il s'agit d'une page "caché", il n'y a pas de lien accessible dans le menu.

Pour tester :
- Accéder à l'url `/organizations`
- Constater que je vois bien les organisations dont je fais partie avec le ou les rôles associés. 
