### PR TITLE
Gestion des rôles utilisateurs (partie 4)

### DIFF
--- a/src/Application/User/Query/GetOrganizationUsersQuery.php
+++ b/src/Application/User/Query/GetOrganizationUsersQuery.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Query;
+
+use App\Application\QueryInterface;
+
+final class GetOrganizationUsersQuery implements QueryInterface
+{
+    public function __construct(
+        public readonly string $organizationUuid,
+    ) {
+    }
+}

--- a/src/Application/User/Query/GetOrganizationUsersQueryHandler.php
+++ b/src/Application/User/Query/GetOrganizationUsersQueryHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Query;
+
+use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
+
+final class GetOrganizationUsersQueryHandler
+{
+    public function __construct(
+        private OrganizationUserRepositoryInterface $organizationUserRepository,
+    ) {
+    }
+
+    public function __invoke(GetOrganizationUsersQuery $query): array
+    {
+        return $this->organizationUserRepository->findUsersByOrganizationUuid($query->organizationUuid);
+    }
+}

--- a/src/Application/User/View/OrganizationView.php
+++ b/src/Application/User/View/OrganizationView.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\View;
+
+final readonly class OrganizationView
+{
+    public function __construct(
+        public string $uuid,
+        public string $name,
+        public array $roles = [],
+    ) {
+    }
+}

--- a/src/Application/User/View/UserView.php
+++ b/src/Application/User/View/UserView.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\View;
+
+final readonly class UserView
+{
+    public function __construct(
+        public string $uuid,
+        public string $fullName,
+        public string $email,
+        public array $roles = [],
+    ) {
+    }
+}

--- a/src/Domain/User/Repository/OrganizationUserRepositoryInterface.php
+++ b/src/Domain/User/Repository/OrganizationUserRepositoryInterface.php
@@ -12,4 +12,6 @@ interface OrganizationUserRepositoryInterface
     public function add(OrganizationUser $organizationUser): void;
 
     public function findOrganizationsByUser(User $user): array;
+
+    public function findUsersByOrganizationUuid(string $uuid): array;
 }

--- a/src/Infrastructure/Controller/Organization/ListOrganizationsController.php
+++ b/src/Infrastructure/Controller/Organization/ListOrganizationsController.php
@@ -6,7 +6,6 @@ namespace App\Infrastructure\Controller\Organization;
 
 use App\Infrastructure\Security\SymfonyUser;
 use Symfony\Bundle\SecurityBundle\Security;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -23,7 +22,7 @@ final class ListOrganizationsController
         name: 'app_organizations_list',
         methods: ['GET'],
     )]
-    public function __invoke(Request $request): Response
+    public function __invoke(): Response
     {
         /** @var SymfonyUser|null */
         $user = $this->security->getUser();

--- a/src/Infrastructure/Controller/Organization/User/ListUsersController.php
+++ b/src/Infrastructure/Controller/Organization/User/ListUsersController.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Controller\Organization\User;
+
+use App\Application\QueryBusInterface;
+use App\Application\User\Query\GetOrganizationByUuidQuery;
+use App\Application\User\Query\GetOrganizationUsersQuery;
+use App\Domain\User\Exception\OrganizationNotFoundException;
+use App\Infrastructure\Security\Voter\OrganizationVoter;
+use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\Requirement\Requirement;
+
+final class ListUsersController
+{
+    public function __construct(
+        private \Twig\Environment $twig,
+        private QueryBusInterface $queryBus,
+        private Security $security,
+    ) {
+    }
+
+    #[Route(
+        '/organizations/{uuid}/users',
+        name: 'app_users_list',
+        requirements: ['uuid' => Requirement::UUID],
+        methods: ['GET'],
+    )]
+    public function __invoke(string $uuid): Response
+    {
+        try {
+            $organization = $this->queryBus->handle(new GetOrganizationByUuidQuery($uuid));
+        } catch (OrganizationNotFoundException) {
+            throw new NotFoundHttpException();
+        }
+
+        if (!$this->security->isGranted(OrganizationVoter::VIEW, $organization)) {
+            throw new AccessDeniedHttpException();
+        }
+
+        $users = $this->queryBus->handle(new GetOrganizationUsersQuery($uuid));
+
+        return new Response($this->twig->render(
+            name: 'user/index.html.twig',
+            context: [
+                'users' => $users,
+                'organization' => $organization,
+            ],
+        ));
+    }
+}

--- a/src/Infrastructure/Form/Regulation/GeneralInfoFormType.php
+++ b/src/Infrastructure/Form/Regulation/GeneralInfoFormType.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Form\Regulation;
 
-use App\Application\User\View\UserOrganizationView;
+use App\Application\User\View\OrganizationView;
 use App\Domain\Regulation\Enum\RegulationOrderCategoryEnum;
 use App\Domain\User\Organization;
 use Doctrine\ORM\EntityManagerInterface;
@@ -102,13 +102,13 @@ final class GeneralInfoFormType extends AbstractType
 
         $builder->get('organization')
             ->addModelTransformer(new CallbackTransformer(
-                function (?Organization $organization = null): ?UserOrganizationView {
+                function (?Organization $organization = null): ?OrganizationView {
                     return $organization
-                        ? new UserOrganizationView($organization->getUuid(), $organization->getName())
+                        ? new OrganizationView($organization->getUuid(), $organization->getName())
                         : null;
                 },
-                function (UserOrganizationView $userOrganizationView): Organization {
-                    return $this->entityManager->getReference(Organization::class, $userOrganizationView->uuid);
+                function (OrganizationView $organizationView): Organization {
+                    return $this->entityManager->getReference(Organization::class, $organizationView->uuid);
                 },
             ))
         ;

--- a/src/Infrastructure/Persistence/Doctrine/Repository/User/OrganizationUserRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/User/OrganizationUserRepository.php
@@ -4,7 +4,8 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Persistence\Doctrine\Repository\User;
 
-use App\Application\User\View\UserOrganizationView;
+use App\Application\User\View\OrganizationView;
+use App\Application\User\View\UserView;
 use App\Domain\User\OrganizationUser;
 use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
 use App\Domain\User\User;
@@ -28,13 +29,24 @@ final class OrganizationUserRepository extends ServiceEntityRepository implement
     {
         return $this->createQueryBuilder('ou')
             ->select(
-                sprintf('NEW %s(o.uuid, o.name, ou.roles)',
-                    UserOrganizationView::class,
-                ),
+                sprintf('NEW %s(o.uuid, o.name, ou.roles)', OrganizationView::class),
             )
             ->where('ou.user = :user')
             ->innerJoin('ou.organization', 'o')
             ->setParameter('user', $user)
+            ->getQuery()
+            ->getResult();
+    }
+
+    public function findUsersByOrganizationUuid(string $uuid): array
+    {
+        return $this->createQueryBuilder('ou')
+            ->select(
+                sprintf('NEW %s(u.uuid, u.fullName, u.email, ou.roles)', UserView::class),
+            )
+            ->where('ou.organization = :organization')
+            ->innerJoin('ou.user', 'u')
+            ->setParameter('organization', $uuid)
             ->getQuery()
             ->getResult();
     }

--- a/src/Infrastructure/Security/SymfonyUser.php
+++ b/src/Infrastructure/Security/SymfonyUser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Security;
 
-use App\Application\User\View\UserOrganizationView;
+use App\Application\User\View\OrganizationView;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
@@ -63,7 +63,7 @@ class SymfonyUser implements UserInterface, PasswordAuthenticatedUserInterface
     public function getOrganizationUuids(): array
     {
         return array_map(
-            function (UserOrganizationView $userOrganization) { return $userOrganization->uuid; },
+            function (OrganizationView $userOrganization) { return $userOrganization->uuid; },
             $this->userOrganizations,
         );
     }

--- a/src/Infrastructure/Security/Voter/OrganizationVoter.php
+++ b/src/Infrastructure/Security/Voter/OrganizationVoter.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security\Voter;
+
+use App\Domain\User\Organization;
+use App\Infrastructure\Security\SymfonyUser;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+final class OrganizationVoter extends Voter
+{
+    public const VIEW = 'view';
+    public const EDIT = 'edit';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        if (!\in_array($attribute, [self::VIEW, self::EDIT])) {
+            return false;
+        }
+
+        if (!$subject instanceof Organization) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof SymfonyUser) {
+            return false;
+        }
+
+        /** @var Organization $organization */
+        $organization = $subject;
+
+        return match ($attribute) {
+            self::VIEW => $this->canView($organization, $user),
+            self::EDIT => $this->canEdit($organization, $user),
+            default => throw new \LogicException('This code should not be reached!')
+        };
+    }
+
+    private function canView(Organization $organization, SymfonyUser $user): bool
+    {
+        return \in_array($organization->getUuid(), $user->getOrganizationUuids());
+    }
+
+    private function canEdit(Organization $organization, SymfonyUser $user): bool
+    {
+        return $this->canView($organization, $user);
+    }
+}

--- a/templates/organization/index.html.twig
+++ b/templates/organization/index.html.twig
@@ -32,7 +32,11 @@
                                     {% if not loop.last %}, {% endif %}
                                 {% endfor %}
                             </td>
-                            <td></td>
+                            <td>
+                                <a title="{{ 'common.see'|trans }}" href="{{ path('app_users_list', { uuid: organization.uuid }) }}" class="fr-btn fr-icon-eye-line fr-btn--tertiary-no-outline">
+                                    {{ 'common.see'|trans }}
+                                </a>
+                            </td>
                         </tr>
                     {% endfor %}
                 </tbody>

--- a/templates/user/index.html.twig
+++ b/templates/user/index.html.twig
@@ -1,0 +1,45 @@
+{% extends 'layouts/app.html.twig' %}
+
+{% block title %}
+    {{'user.list.title'|trans({'%organizationName%': organization.name }) }} - {{ parent() }}
+{% endblock %}
+
+{% block body %}
+    <section class="fr-container fr-py-5w" aria-labelledby="user-list">
+        <div class="fr-grid-row">
+            <h3 id="user-list" class="fr-col fr-mb-0">{{ 'user.list.title'|trans({'%organizationName%': organization.name }) }}</h3>
+        </div>
+        <div class="fr-table fr-table--layout-fixed fr-table--no-caption">
+            <table>
+                <caption>{{ 'user.list.title'|trans }}</caption>
+                <thead>
+                    <tr>
+                        <th scope="col">{{ 'user.list.fullName'|trans }}</th>
+                        <th scope="col">{{ 'user.list.email'|trans }}</th>
+                        <th scope="col">{{ 'user.list.roles'|trans }}</th>
+                        <th scope="col">{{ 'common.actions'|trans }}</th>
+                    </tr>
+                </thead>
+                <tbody data-testid="user-list">
+                    {% for user in users %}
+                        <tr>
+                            <td>
+                                {{ user.fullName }}
+                            </td>
+                            <td>
+                                {{ user.email }}
+                            </td>
+                            <td>
+                                {% for role in user.roles %}
+                                    {{ ('roles.' ~ role)|trans }}
+                                    {% if not loop.last %}, {% endif %}
+                                {% endfor %}
+                            </td>
+                            <td></td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+{% endblock %}

--- a/tests/Integration/Infrastructure/Controller/Organization/ListOrganizationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Organization/ListOrganizationsControllerTest.php
@@ -8,7 +8,7 @@ use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
 
 final class ListOrganizationsControllerTest extends AbstractWebTestCase
 {
-    public function testPageAndTabs(): void
+    public function testIndex(): void
     {
         $client = $this->login();
         $crawler = $client->request('GET', '/organizations');
@@ -19,8 +19,11 @@ final class ListOrganizationsControllerTest extends AbstractWebTestCase
         $this->assertMetaTitle('Mes organisations - DiaLog', $crawler);
 
         $organizations = $crawler->filter('[data-testid="organization-list"]');
+        $td = $organizations->filter('tr')->eq(0)->filter('td');
         $this->assertCount(1, $organizations->filter('tr'));
-        $this->assertSame('Main Org Contributeur', $organizations->filter('tr')->eq(0)->text());
+        $this->assertSame('Main Org', $td->eq(0)->text());
+        $this->assertSame('Contributeur', $td->eq(1)->text());
+        $this->assertSame('Voir le détail', $td->eq(2)->text());
     }
 
     public function testWithoutAuthenticatedUser(): void

--- a/tests/Integration/Infrastructure/Controller/Organization/User/ListUsersControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Organization/User/ListUsersControllerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Controller\Organization\User;
+
+use App\Infrastructure\Persistence\Doctrine\Fixtures\OrganizationFixture;
+use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
+
+final class ListUsersControllerTest extends AbstractWebTestCase
+{
+    public function testIndex(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/organizations/' . OrganizationFixture::MAIN_ORG_ID . '/users');
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+        $this->assertSame('Utilisateurs Main Org', $crawler->filter('h3')->text());
+        $this->assertMetaTitle('Utilisateurs Main Org - DiaLog', $crawler);
+
+        $users = $crawler->filter('[data-testid="user-list"]');
+        $tr0 = $users->filter('tr')->eq(0)->filter('td');
+        $tr1 = $users->filter('tr')->eq(1)->filter('td');
+        $this->assertCount(2, $users->filter('tr'));
+        $this->assertSame('Mathieu MARCHOIS', $tr0->eq(0)->text());
+        $this->assertSame('mathieu.marchois@beta.gouv.fr', $tr0->eq(1)->text());
+        $this->assertSame('Contributeur', $tr0->eq(2)->text());
+
+        $this->assertSame('Mathieu FERNANDEZ', $tr1->eq(0)->text());
+        $this->assertSame('mathieu.fernandez@beta.gouv.fr', $tr1->eq(1)->text());
+        $this->assertSame('Administrateur', $tr1->eq(2)->text());
+    }
+
+    public function testOrganizationNotOwned(): void
+    {
+        $client = $this->login();
+        $client->request('GET', '/organizations/' . OrganizationFixture::OTHER_ORG_ID . '/users');
+        $this->assertResponseStatusCodeSame(403);
+    }
+
+    public function testOrganizationNotFound(): void
+    {
+        $client = $this->login();
+        $client->request('GET', '/organizations/f5c1cea8-a61d-43a7-9b5d-4b8c9557c673/users');
+        $this->assertResponseStatusCodeSame(404);
+    }
+
+    public function testWithoutAuthenticatedUser(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/organizations/' . OrganizationFixture::MAIN_ORG_ID . '/users');
+        $this->assertResponseRedirects('http://localhost/login', 302);
+    }
+}

--- a/tests/Unit/Application/User/Query/GetOrganizationUsersQueryHandlerTest.php
+++ b/tests/Unit/Application/User/Query/GetOrganizationUsersQueryHandlerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Application\User\Query;
+
+use App\Application\User\Query\GetOrganizationUsersQuery;
+use App\Application\User\Query\GetOrganizationUsersQueryHandler;
+use App\Application\User\View\UserView;
+use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
+use PHPUnit\Framework\TestCase;
+
+final class GetOrganizationUsersQueryHandlerTest extends TestCase
+{
+    public function testGetUsers(): void
+    {
+        $expectedResults = [
+            new UserView('42a1888f-29cb-4e32-a02f-49d278b6d128', 'Mathieu MARCHOIS', 'mathieu.marchois@beta.gouv.fr'),
+            new UserView('d732584b-810f-4932-bd83-41b60c24c414', 'Mathieu FERNANDEZ', 'mathieu.fernandez@beta.gouv.fr'),
+        ];
+
+        $organizationUserRepository = $this->createMock(OrganizationUserRepositoryInterface::class);
+        $organizationUserRepository
+            ->expects(self::once())
+            ->method('findUsersByOrganizationUuid')
+            ->with('3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf')
+            ->willReturn($expectedResults);
+
+        $handler = new GetOrganizationUsersQueryHandler($organizationUserRepository);
+        $result = $handler(new GetOrganizationUsersQuery('3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf'));
+
+        $this->assertEquals($expectedResults, $result);
+    }
+}

--- a/tests/Unit/Infrastructure/Security/SymfonyUserTest.php
+++ b/tests/Unit/Infrastructure/Security/SymfonyUserTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Infrastructure\Security;
 
-use App\Application\User\View\UserOrganizationView;
+use App\Application\User\View\OrganizationView;
 use App\Domain\User\Enum\UserRolesEnum;
 use App\Infrastructure\Security\SymfonyUser;
 use PHPUnit\Framework\TestCase;
@@ -13,7 +13,7 @@ class SymfonyUserTest extends TestCase
 {
     public function testUser()
     {
-        $organizationUser = new UserOrganizationView('133fb411-7754-4749-9590-ce05a2abe108', 'Mairie de Savenay', []);
+        $organizationUser = new OrganizationView('133fb411-7754-4749-9590-ce05a2abe108', 'Mairie de Savenay', []);
 
         $user = new SymfonyUser(
             '2d3724f1-2910-48b4-ba56-81796f6e100b',

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -2026,6 +2026,22 @@
                 <source>roles.ROLE_ORGA_ADMIN</source>
                 <target>Administrateur</target>
             </trans-unit>
+            <trans-unit id="user.list.title">
+                <source>user.list.title</source>
+                <target>Utilisateurs %organizationName%</target>
+            </trans-unit>
+            <trans-unit id="user.list.fullName">
+                <source>user.list.fullName</source>
+                <target>Prénom / Nom</target>
+            </trans-unit>
+            <trans-unit id="user.list.email">
+                <source>user.list.email</source>
+                <target>Email</target>
+            </trans-unit>
+            <trans-unit id="user.list.roles">
+                <source>user.list.roles</source>
+                <target>Rôles</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
* Refs #871 

Cette PR permet de lister les utilisateurs d'une organisation. À noter que si un utilisateur ne fait pas partie d'une organisation, il ne pourra pas y accéder.

![image](https://github.com/user-attachments/assets/afe15ef8-a054-4f99-aa8d-4a431c57a5e9)
![image](https://github.com/user-attachments/assets/005647fd-df1b-4425-a63a-7dffce1f6358)
![image](https://github.com/user-attachments/assets/f49caded-2c81-442a-9b2e-097952f57edd)

La prochaine étape sera de pouvoir les modifier / supprimer / créer.

@aureliebaton Voici la proposition pour la liste des utilisateurs. La navigation sera améliorée pour fluidifier les transitions de pages.
Outre le rajout d'un breadcrumb, je pensais rajouter une navigation en onglet comme celle qu'on a sur la page d'accueil. Qu'en penses-tu ?