### PR TITLE
[Eudonet] Ajout d'un "enum" pour les erreurs d'import Eudonet Paris

### DIFF
--- a/src/Infrastructure/EudonetParis/Enum/EudonetParisErrorEnum.php
+++ b/src/Infrastructure/EudonetParis/Enum/EudonetParisErrorEnum.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\EudonetParis\Enum;
 
-
-enum RoadSideEnum: string
+enum EudonetParisErrorEnum: string
 {
     case NO_MEASURES_FOUND = 'no_measures_found';
     case MEASURE_ERRORS = 'measure_errors';
     case PARSING_FAILED = 'parsing_failed';
-    case MEASURE_MAY_CONTAINS_DATES = 'measure_may_contain_dates';
-    case VALUES_DOES_NOT_MATCH_PATTERN = 'value_does_not_match_pattern';
+    case MEASURE_MAY_CONTAIN_DATES = 'measure_may_contain_dates';
+    case VALUE_DOES_NOT_MATCH_PATTERN = 'value_does_not_match_pattern';
     case UNSUPPORTED_LOCATION_FIELDSET = 'unsupported_location_fieldset';
     case NO_LOCATIONS_GATHERED = 'no_locations_gathered';
 }

--- a/src/Infrastructure/EudonetParis/Enum/EudonetParisErrorEnum.php
+++ b/src/Infrastructure/EudonetParis/Enum/EudonetParisErrorEnum.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\EudonetParis\Enum;
+
+
+enum RoadSideEnum: string
+{
+    case NO_MEASURES_FOUND = 'no_measures_found';
+    case MEASURE_ERRORS = 'measure_errors';
+    case PARSING_FAILED = 'parsing_failed';
+    case MEASURE_MAY_CONTAINS_DATES = 'measure_may_contain_dates';
+    case VALUES_DOES_NOT_MATCH_PATTERN = 'value_does_not_match_pattern';
+    case UNSUPPORTED_LOCATION_FIELDSET = 'unsupported_location_fieldset';
+    case NO_LOCATIONS_GATHERED = 'no_locations_gathered';
+}

--- a/src/Infrastructure/EudonetParis/EudonetParisTransformer.php
+++ b/src/Infrastructure/EudonetParis/EudonetParisTransformer.php
@@ -14,6 +14,7 @@ use App\Domain\Regulation\Enum\MeasureTypeEnum;
 use App\Domain\Regulation\Enum\RegulationOrderCategoryEnum;
 use App\Domain\Regulation\Enum\RoadTypeEnum;
 use App\Domain\User\Organization;
+use App\Infrastructure\EudonetParis\Enum\EudonetParisErrorEnum;
 
 final class EudonetParisTransformer
 {
@@ -27,7 +28,7 @@ final class EudonetParisTransformer
         $loc = ['regulation_identifier' => $row['fields'][EudonetParisExtractor::ARRETE_ID]];
 
         if (\count($row['measures']) === 0) {
-            $errors[] = ['loc' => $loc, 'impact' => 'skip_regulation', 'reason' => 'no_measures_found'];
+            $errors[] = ['loc' => $loc, 'impact' => 'skip_regulation', 'reason' => EudonetParisErrorEnum::NO_MEASURES_FOUND->value];
 
             return new EudonetParisTransformerResult(null, $errors);
         }
@@ -46,7 +47,7 @@ final class EudonetParisTransformer
             [$measureCommand, $measureErrors] = $this->buildMeasureCommand($measureRow);
 
             if (empty($measureCommand)) {
-                $errors[] = ['loc' => $loc, 'impact' => 'skip_regulation', 'reason' => 'measure_errors', 'errors' => $measureErrors];
+                $errors[] = ['loc' => $loc, 'impact' => 'skip_regulation', 'reason' => EudonetParisErrorEnum::MEASURE_ERRORS->value, 'errors' => $measureErrors];
 
                 return new EudonetParisTransformerResult(null, $errors);
             }
@@ -100,7 +101,7 @@ final class EudonetParisTransformer
         $startDate = $this->parseDate($row['fields'][EudonetParisExtractor::ARRETE_DATE_DEBUT]);
 
         if (!$startDate) {
-            $error = ['loc' => ['fieldname' => 'ARRETE_DATE_DEBUT'], 'reason' => 'parsing_failed', 'value' => $row['fields'][EudonetParisExtractor::ARRETE_DATE_DEBUT]];
+            $error = ['loc' => ['fieldname' => 'ARRETE_DATE_DEBUT'], 'reason' => EudonetParisErrorEnum::PARSING_FAILED->value, 'value' => $row['fields'][EudonetParisExtractor::ARRETE_DATE_DEBUT]];
 
             return [null, $error];
         }
@@ -110,7 +111,7 @@ final class EudonetParisTransformer
         $endDate = $this->parseDate($row['fields'][EudonetParisExtractor::ARRETE_DATE_FIN]);
 
         if (!$endDate) {
-            $error = ['loc' => ['fieldname' => 'ARRETE_DATE_FIN'], 'reason' => 'parsing_failed', 'value' => $row['fields'][EudonetParisExtractor::ARRETE_DATE_FIN]];
+            $error = ['loc' => ['fieldname' => 'ARRETE_DATE_FIN'], 'reason' => EudonetParisErrorEnum::PARSING_FAILED->value, 'value' => $row['fields'][EudonetParisExtractor::ARRETE_DATE_FIN]];
 
             return [null, $error];
         }
@@ -131,7 +132,7 @@ final class EudonetParisTransformer
             // This "alinea" field contains free-form text with indications on temporal validity.
             // We cannot parse this data so we only ingest measures that do NOT have an "alinea", meaning their dates are
             // the same as the global regulation order dates.
-            $errors[] = ['loc' => $loc, 'reason' => 'measure_may_contain_dates', 'alinea' => $alinea, 'impact' => 'skip_measure'];
+            $errors[] = ['loc' => $loc, 'reason' => EudonetParisErrorEnum::MEASURE_MAY_CONTAIN_DATES->value, 'alinea' => $alinea, 'impact' => 'skip_measure'];
 
             return [null, $errors];
         }
@@ -170,7 +171,7 @@ final class EudonetParisTransformer
         if (!preg_match(self::ARRONDISSEMENT_REGEX, $arrondissement, $matches)) {
             $error = [
                 'loc' => [...$loc, 'fieldname' => 'ARRONDISSEMENT'],
-                'reason' => 'value_does_not_match_pattern',
+                'reason' => EudonetParisErrorEnum::VALUE_DOES_NOT_MATCH_PATTERN->value,
                 'value' => $arrondissement,
                 'pattern' => self::ARRONDISSEMENT_REGEX,
             ];
@@ -205,7 +206,7 @@ final class EudonetParisTransformer
         } else {
             $error = [
                 'loc' => $loc,
-                'reason' => 'unsupported_location_fieldset',
+                'reason' => EudonetParisErrorEnum::UNSUPPORTED_LOCATION_FIELDSET->value,
                 'location_raw' => json_encode($row),
             ];
 

--- a/tests/Unit/Infrastructure/EudonetParis/EudonetParisTransformerTest.php
+++ b/tests/Unit/Infrastructure/EudonetParis/EudonetParisTransformerTest.php
@@ -14,6 +14,7 @@ use App\Domain\Geography\Coordinates;
 use App\Domain\Regulation\Enum\MeasureTypeEnum;
 use App\Domain\Regulation\Enum\RegulationOrderCategoryEnum;
 use App\Domain\User\Organization;
+use App\Infrastructure\EudonetParis\Enum\EudonetParisErrorEnum;
 use App\Infrastructure\EudonetParis\EudonetParisExtractor;
 use App\Infrastructure\EudonetParis\EudonetParisTransformer;
 use App\Infrastructure\EudonetParis\EudonetParisTransformerResult;
@@ -193,7 +194,7 @@ final class EudonetParisTransformerTest extends TestCase
         $result = new EudonetParisTransformerResult(null, [
             [
                 'loc' => ['regulation_identifier' => '20230514-1'],
-                'reason' => 'no_measures_found',
+                'reason' => EudonetParisErrorEnum::NO_MEASURES_FOUND->value,
                 'impact' => 'skip_regulation',
             ],
         ]);
@@ -244,12 +245,12 @@ final class EudonetParisTransformerTest extends TestCase
             [
                 'loc' => ['regulation_identifier' => '20230514-1'],
                 'impact' => 'skip_regulation',
-                'reason' => 'measure_errors',
+                'reason' => EudonetParisErrorEnum::MEASURE_ERRORS->value,
                 'errors' => [
                     [
                         'loc' => ['measure_id' => 'mesure1', 'location_id' => 'localisation1'],
                         'impact' => 'skip_measure',
-                        'reason' => 'unsupported_location_fieldset',
+                        'reason' => EudonetParisErrorEnum::UNSUPPORTED_LOCATION_FIELDSET->value,
                         'location_raw' => '{"fields":{"2701":"localisation1","2705":"Autre chose","2708":"18\u00e8me Arrondissement","2710":"...","2730":null,"2740":null,"2720":null,"2737":null}}',
                     ],
                 ],
@@ -280,7 +281,7 @@ final class EudonetParisTransformerTest extends TestCase
                 'error' => [
                     'loc' => ['measure_id' => 'mesure1', 'location_id' => 'localisation1'],
                     'impact' => 'skip_measure',
-                    'reason' => 'unsupported_location_fieldset',
+                    'reason' => EudonetParisErrorEnum::UNSUPPORTED_LOCATION_FIELDSET->value,
                     'location_raw' => '{"fields":{"2701":"localisation1","2705":"Une section","2708":"18\u00e8me Arrondissement","2710":"...","2730":"Start road","2740":null,"2720":null,"2737":null}}',
                 ],
             ],
@@ -300,7 +301,7 @@ final class EudonetParisTransformerTest extends TestCase
                 'error' => [
                     'loc' => ['measure_id' => 'mesure1', 'location_id' => 'localisation1'],
                     'impact' => 'skip_measure',
-                    'reason' => 'unsupported_location_fieldset',
+                    'reason' => EudonetParisErrorEnum::UNSUPPORTED_LOCATION_FIELDSET->value,
                     'location_raw' => '{"fields":{"2701":"localisation1","2705":"Une section","2708":"18\u00e8me Arrondissement","2710":"...","2730":null,"2740":"End road","2720":null,"2737":null}}',
                 ],
             ],
@@ -320,7 +321,7 @@ final class EudonetParisTransformerTest extends TestCase
                 'error' => [
                     'loc' => ['measure_id' => 'mesure1', 'location_id' => 'localisation1'],
                     'impact' => 'skip_measure',
-                    'reason' => 'unsupported_location_fieldset',
+                    'reason' => EudonetParisErrorEnum::UNSUPPORTED_LOCATION_FIELDSET->value,
                     'location_raw' => '{"fields":{"2701":"localisation1","2705":"Une section","2708":"18\u00e8me Arrondissement","2710":"...","2730":null,"2740":null,"2720":"Start house number","2737":null}}',
                 ],
             ],
@@ -340,7 +341,7 @@ final class EudonetParisTransformerTest extends TestCase
                 'error' => [
                     'loc' => ['measure_id' => 'mesure1', 'location_id' => 'localisation1'],
                     'impact' => 'skip_measure',
-                    'reason' => 'unsupported_location_fieldset',
+                    'reason' => EudonetParisErrorEnum::UNSUPPORTED_LOCATION_FIELDSET->value,
                     'location_raw' => '{"fields":{"2701":"localisation1","2705":"Une section","2708":"18\u00e8me Arrondissement","2710":"...","2730":null,"2740":null,"2720":null,"2737":"End house number"}}',
                 ],
             ],
@@ -378,7 +379,7 @@ final class EudonetParisTransformerTest extends TestCase
             [
                 'loc' => ['regulation_identifier' => '20230514-1'],
                 'impact' => 'skip_regulation',
-                'reason' => 'measure_errors',
+                'reason' => EudonetParisErrorEnum::MEASURE_ERRORS->value,
                 'errors' => [$error],
             ],
         ]);
@@ -429,11 +430,11 @@ final class EudonetParisTransformerTest extends TestCase
             [
                 'loc' => ['regulation_identifier' => '20230514-1'],
                 'impact' => 'skip_regulation',
-                'reason' => 'measure_errors',
+                'reason' => EudonetParisErrorEnum::MEASURE_ERRORS->value,
                 'errors' => [
                     [
                         'loc' => ['measure_id' => 'mesure1', 'location_id' => 'localisation1', 'fieldname' => 'ARRONDISSEMENT'],
-                        'reason' => 'value_does_not_match_pattern',
+                        'reason' => EudonetParisErrorEnum::VALUE_DOES_NOT_MATCH_PATTERN->value,
                         'impact' => 'skip_measure',
                         'value' => 'invalid',
                         'pattern' => '/^(?<arrondissement>\d+)(er|e|ème|eme)\s+arrondissement$/i',
@@ -471,7 +472,7 @@ final class EudonetParisTransformerTest extends TestCase
                 [
                     'loc' => ['fieldname' => 'ARRETE_DATE_DEBUT'],
                     'impact' => 'skip_regulation',
-                    'reason' => 'parsing_failed',
+                    'reason' => EudonetParisErrorEnum::PARSING_FAILED->value,
                     'value' => 'invalid',
                 ],
             ],
@@ -502,7 +503,7 @@ final class EudonetParisTransformerTest extends TestCase
                 [
                     'loc' => ['fieldname' => 'ARRETE_DATE_FIN'],
                     'impact' => 'skip_regulation',
-                    'reason' => 'parsing_failed',
+                    'reason' => EudonetParisErrorEnum::PARSING_FAILED->value,
                     'value' => 'invalid',
                 ],
             ],
@@ -542,13 +543,13 @@ final class EudonetParisTransformerTest extends TestCase
                 [
                     'loc' => ['regulation_identifier' => '20230514-1'],
                     'impact' => 'skip_regulation',
-                    'reason' => 'measure_errors',
+                    'reason' => EudonetParisErrorEnum::MEASURE_ERRORS->value,
                     'errors' => [
                         [
                             'loc' => [
                                 'measure_id' => 'mesure1',
                             ],
-                            'reason' => 'measure_may_contain_dates',
+                            'reason' => EudonetParisErrorEnum::MEASURE_MAY_CONTAIN_DATES->value,
                             'alinea' => 'not empty may contain dates',
                             'impact' => 'skip_measure',
                         ],


### PR DESCRIPTION
* Refs #876 

Cette PR est liée au ticket  #876 "Lister les cas d'erreur Eudonet"
Les raisons des erreurs d'import Eudonet Paris étaient codées en dur, maintenant elles sont dans un `Enum`. 

Exemple de raison : `measure_may_contain_dates` : le champ « alinéa » d’une mesure Eudonet n’est pas vide, il se pourrait qu’elle contienne des dates non traitables automatiquement