### PR TITLE
Carto : log les erreurs de Promise dans la console

### DIFF
--- a/assets/customElements/map.js
+++ b/assets/customElements/map.js
@@ -39,9 +39,9 @@ class MapDataSource {
         this.#mapElement.onDataUrlChange(() => {
             this.#data = null;
 
-            this.readValue().then((json) => {
-                callback(json);
-            });
+            this.readValue()
+                .then((json) => callback(json))
+                .catch(err => console.error(err));
         });
     }
 }
@@ -210,9 +210,9 @@ class MapLibreMap {
      * @param {(instance: maplibregl.Map) => void} callback
      */
     onReady(callback) {
-        this.#prom.then(() => {
-            callback(this.#map);
-        });
+        this.#prom
+            .then(() => callback(this.#map))
+            .catch(err => console.error(err));
     }
 
     /**


### PR DESCRIPTION
* Refs https://github.com/MTES-MCT/dialog/issues/881#issuecomment-2255448769

Il manquait des `.catch()` dans l'utilisation des `Promise` ce qui peut expliquer que d'éventuelles erreurs JS en prod ne soient pas affichées dans la console web 