### PR TITLE
Edition d'un utilisateur

### DIFF
--- a/config/validator/Application/User/SaveUserOrganizationCommand.xml
+++ b/config/validator/Application/User/SaveUserOrganizationCommand.xml
@@ -3,8 +3,23 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://symfony.com/schema/dic/constraint-mapping https://symfony.com/schema/dic/constraint-mapping/constraint-mapping-1.0.xsd">
     <class name="App\Application\User\Command\SaveUserOrganizationCommand">
+        <property name="fullName">
+            <constraint name="NotBlank"/>
+        </property>
+        <property name="email">
+            <constraint name="NotBlank"/>
+            <constraint name="Email"/>
+        </property>
         <property name="roles">
             <constraint name="NotBlank"/>
+        </property>
+        <property name="password">
+            <constraint name="When">
+                <option name="expression">!this.organizationUser</option>
+                <option name="constraints">
+                    <constraint name="NotBlank"/>
+                </option>
+            </constraint>
         </property>
     </class>
 </constraint-mapping>

--- a/src/Application/User/Command/SaveUserOrganizationCommand.php
+++ b/src/Application/User/Command/SaveUserOrganizationCommand.php
@@ -7,17 +7,20 @@ namespace App\Application\User\Command;
 use App\Application\CommandInterface;
 use App\Domain\User\Organization;
 use App\Domain\User\OrganizationUser;
-use App\Domain\User\User;
 
 final class SaveUserOrganizationCommand implements CommandInterface
 {
+    public ?string $fullName = null;
+    public ?string $email = null;
+    public ?string $password = null;
     public array $roles = [];
 
     public function __construct(
-        public readonly User $user,
         public readonly Organization $organization,
         public readonly ?OrganizationUser $organizationUser = null,
     ) {
         $this->roles = $organizationUser?->getRoles() ?? [];
+        $this->fullName = $organizationUser?->getUser()?->getFullName();
+        $this->email = $organizationUser?->getUser()?->getEmail();
     }
 }

--- a/src/Application/User/Command/SaveUserOrganizationCommandHandler.php
+++ b/src/Application/User/Command/SaveUserOrganizationCommandHandler.php
@@ -4,31 +4,80 @@ declare(strict_types=1);
 
 namespace App\Application\User\Command;
 
+use App\Application\DateUtilsInterface;
 use App\Application\IdFactoryInterface;
+use App\Application\PasswordHasherInterface;
+use App\Application\StringUtilsInterface;
+use App\Domain\User\Enum\UserRolesEnum;
+use App\Domain\User\Exception\EmailAlreadyExistsException;
+use App\Domain\User\Exception\UserAlreadyRegisteredException;
 use App\Domain\User\OrganizationUser;
 use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
+use App\Domain\User\Repository\UserRepositoryInterface;
+use App\Domain\User\Specification\IsEmailAlreadyExists;
+use App\Domain\User\Specification\IsUserAlreadyRegisteredInOrganization;
+use App\Domain\User\User;
 
 final class SaveUserOrganizationCommandHandler
 {
     public function __construct(
         private IdFactoryInterface $idFactory,
         private OrganizationUserRepositoryInterface $organizationUserRepository,
+        private UserRepositoryInterface $userRepository,
+        private StringUtilsInterface $stringUtils,
+        private DateUtilsInterface $dateUtils,
+        private PasswordHasherInterface $passwordHasher,
+        private IsUserAlreadyRegisteredInOrganization $isUserAlreadyRegisteredInOrganization,
+        private IsEmailAlreadyExists $isEmailAlreadyExists,
     ) {
     }
 
     public function __invoke(SaveUserOrganizationCommand $command): void
     {
-        if (!$command->organizationUser) {
-            $this->organizationUserRepository->add(
-                (new OrganizationUser($this->idFactory->make()))
-                    ->setUser($command->user)
-                    ->setOrganization($command->organization)
-                    ->setRoles($command->roles),
-            );
+        $email = $this->stringUtils->normalizeEmail($command->email);
+        $organizationUser = $command->organizationUser;
+
+        // Update user
+
+        if ($organizationUser) {
+            $user = $organizationUser->getUser();
+
+            if ($email !== $user->getEmail() && true === $this->isEmailAlreadyExists->isSatisfiedBy($email)) {
+                throw new EmailAlreadyExistsException();
+            }
+
+            $user->setEmail($email);
+            $user->setFullName($command->fullName);
+            $organizationUser->setRoles($command->roles);
 
             return;
         }
 
-        $command->organizationUser->setRoles($command->roles);
+        // Create user
+
+        // Check if the user's email address already exists in the organization
+        if (true === $this->isUserAlreadyRegisteredInOrganization->isSatisfiedBy($email, $command->organization)) {
+            throw new UserAlreadyRegisteredException();
+        }
+
+        // Create a new user or add one to the organization if an account already exists
+        $user = $this->userRepository->findOneByEmail($email);
+        if (!$user instanceof User) {
+            $user = (new User($this->idFactory->make()))
+                ->setEmail($email)
+                ->setFullName($command->fullName)
+                ->setPassword($this->passwordHasher->hash($command->password))
+                ->setRoles([UserRolesEnum::ROLE_USER->value])
+                ->setRegistrationDate($this->dateUtils->getNow());
+
+            $this->userRepository->add($user);
+        }
+
+        $this->organizationUserRepository->add(
+            (new OrganizationUser($this->idFactory->make()))
+                ->setUser($user)
+                ->setOrganization($command->organization)
+                ->setRoles($command->roles),
+        );
     }
 }

--- a/src/Domain/User/Exception/EmailAlreadyExistsException.php
+++ b/src/Domain/User/Exception/EmailAlreadyExistsException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Exception;
+
+final class EmailAlreadyExistsException extends \Exception
+{
+}

--- a/src/Domain/User/Repository/OrganizationUserRepositoryInterface.php
+++ b/src/Domain/User/Repository/OrganizationUserRepositoryInterface.php
@@ -18,4 +18,6 @@ interface OrganizationUserRepositoryInterface
     public function findUsersByOrganizationUuid(string $uuid): array;
 
     public function findUserOrganization(string $organizationUuid, string $userUuid): ?OrganizationUser;
+
+    public function findByEmailAndOrganization(string $email, string $organizationUuid): ?OrganizationUser;
 }

--- a/src/Domain/User/Repository/UserRepositoryInterface.php
+++ b/src/Domain/User/Repository/UserRepositoryInterface.php
@@ -12,7 +12,7 @@ interface UserRepositoryInterface
 
     public function countUsers(): int;
 
-    public function add(User $user): void;
+    public function add(User $user): User;
 
     public function remove(User $user): void;
 }

--- a/src/Domain/User/Specification/IsEmailAlreadyExists.php
+++ b/src/Domain/User/Specification/IsEmailAlreadyExists.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Specification;
+
+use App\Domain\User\Repository\UserRepositoryInterface;
+use App\Domain\User\User;
+
+final class IsEmailAlreadyExists
+{
+    public function __construct(
+        private readonly UserRepositoryInterface $userRepository,
+    ) {
+    }
+
+    public function isSatisfiedBy(string $email): bool
+    {
+        return $this->userRepository->findOneByEmail($email) instanceof User;
+    }
+}

--- a/src/Domain/User/Specification/IsUserAlreadyRegisteredInOrganization.php
+++ b/src/Domain/User/Specification/IsUserAlreadyRegisteredInOrganization.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Specification;
+
+use App\Domain\User\Organization;
+use App\Domain\User\OrganizationUser;
+use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
+
+final class IsUserAlreadyRegisteredInOrganization
+{
+    public function __construct(
+        private readonly OrganizationUserRepositoryInterface $organizationUserRepository,
+    ) {
+    }
+
+    public function isSatisfiedBy(string $email, Organization $organization): bool
+    {
+        return $this->organizationUserRepository
+            ->findByEmailAndOrganization($email, $organization->getUuid()) instanceof OrganizationUser;
+    }
+}

--- a/src/Infrastructure/Form/User/UserFormType.php
+++ b/src/Infrastructure/Form/User/UserFormType.php
@@ -7,10 +7,14 @@ namespace App\Infrastructure\Form\User;
 use App\Domain\User\Enum\OrganizationRolesEnum;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 
-final class RolesFormType extends AbstractType
+final class UserFormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
@@ -20,6 +24,21 @@ final class RolesFormType extends AbstractType
 
         $builder
             ->add(
+                'fullName',
+                TextType::class,
+                options: [
+                    'label' => 'user.list.fullName',
+                ],
+            )
+            ->add(
+                'email',
+                EmailType::class,
+                options: [
+                    'label' => 'user.list.email',
+                    'help' => 'login.email_format',
+                ],
+            )
+            ->add(
                 'roles',
                 ChoiceType::class,
                 options: [
@@ -28,7 +47,7 @@ final class RolesFormType extends AbstractType
                         "roles.$rolePublisher" => $rolePublisher,
                         "roles.$roleAdmin" => $roleAdmin,
                     ],
-                    'label' => 'user.list.roles',
+                    'label' => 'user.form.roles',
                     'expanded' => true,
                     'multiple' => true,
                 ],
@@ -40,5 +59,17 @@ final class RolesFormType extends AbstractType
                 ],
             )
         ;
+
+        if (!$options['data']->organizationUser) {
+            $builder->add(
+                'password',
+                RepeatedType::class,
+                options: [
+                    'type' => PasswordType::class,
+                    'first_options' => ['label' => 'user.form.password'],
+                    'second_options' => ['label' => 'user.form.password.repeat'],
+                ],
+            );
+        }
     }
 }

--- a/src/Infrastructure/Persistence/Doctrine/Repository/User/OrganizationUserRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/User/OrganizationUserRepository.php
@@ -61,13 +61,29 @@ final class OrganizationUserRepository extends ServiceEntityRepository implement
     {
         return $this->createQueryBuilder('ou')
             ->addSelect('u', 'o')
-            ->where('ou.organization = :organization')
-            ->andWhere('ou.user = :user')
+            ->where('o.uuid = :organizationUuid')
+            ->andWhere('ou.user = :userUuid')
             ->innerJoin('ou.user', 'u')
             ->innerJoin('ou.organization', 'o')
             ->setParameters([
-                'organization' => $organizationUuid,
-                'user' => $userUuid,
+                'organizationUuid' => $organizationUuid,
+                'userUuid' => $userUuid,
+            ])
+            ->setMaxResults(1)
+            ->getQuery()
+            ->getOneOrNullResult();
+    }
+
+    public function findByEmailAndOrganization(string $email, string $organizationUuid): ?OrganizationUser
+    {
+        return $this->createQueryBuilder('ou')
+            ->where('o.uuid = :organizationUuid')
+            ->andWhere('u.email = :email')
+            ->innerJoin('ou.user', 'u')
+            ->innerJoin('ou.organization', 'o')
+            ->setParameters([
+                'organizationUuid' => $organizationUuid,
+                'email' => $email,
             ])
             ->setMaxResults(1)
             ->getQuery()

--- a/src/Infrastructure/Persistence/Doctrine/Repository/User/UserRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/User/UserRepository.php
@@ -19,9 +19,11 @@ final class UserRepository extends ServiceEntityRepository implements UserReposi
         parent::__construct($registry, User::class);
     }
 
-    public function add(User $user): void
+    public function add(User $user): User
     {
         $this->getEntityManager()->persist($user);
+
+        return $user;
     }
 
     public function remove(User $user): void

--- a/templates/organization/user/edit.html.twig
+++ b/templates/organization/user/edit.html.twig
@@ -1,33 +1,32 @@
 {% extends 'layouts/app.html.twig' %}
-{% set metaTitle = user.fullName ~ ' (' ~ user.email ~ ')' %}
+{% set metaTitle = user.fullName %}
 {% block title %}
     {{ metaTitle }} - {{ parent() }}
 {% endblock %}
 
 {% block body %}
-    <section class="fr-container fr-py-5w" aria-labelledby="user-list">
-            <div class="fr-grid-row fr-grid-row--gutters">
+    <section class="fr-container fr-py-5w">
+        <div class="fr-grid-row fr-grid-row--gutters">
             <div class="fr-col-12 fr-col-md-3">
                 {% include 'organization/_menu.html.twig' with { organization } only %}
             </div>
             <div class="fr-col-12 fr-col-md-9">
-                <div class="app-card app-card--raised">
-                    <div class="app-card__header">
-                        <span class="app-card__img fr-icon-article-fill fr-x-icon-decorative--blue-france fr-x-icon--xl" aria-hidden="true"></span>
-                        <h3 class="app-card__title fr-h4 fr-mb-0">
-                            {{ metaTitle }}
-                        </h3>
-                    </div>
-                    <div class="app-card__content">
-                        {{ form_start(form) }}
-                            {{ form_row(form.roles) }}
-                            <a href="{{ path('app_users_list', {uuid: organization.uuid }) }}" class="fr-btn fr-btn--tertiary fr-mr-3w">
-                                {{ "common.cancel"|trans }}
-                            </a>
-                            {{ form_widget(form.save) }}
-                        {{ form_end(form) }}
-                    </div>
-                </div>
+                <h3 class="fr-h3 fr-mb-2">
+                    {{ metaTitle }}
+                </h3>
+                {{ form_start(form) }}
+                    {{ form_row(form.fullName, { group_class: 'fr-input-group', widget_class: 'fr-input' }) }}
+                    {{ form_row(form.email, { group_class: 'fr-input-group', widget_class: 'fr-input' }) }}
+                    {% if form.password is defined %}
+                        {{ form_row(form.password, { group_class: 'fr-input-group', widget_class: 'fr-input' }) }}
+                    {% endif %}
+                    {{ form_row(form.roles) }}
+
+                    <a href="{{ path('app_users_list', {uuid: organization.uuid }) }}" class="fr-btn fr-btn--tertiary fr-mr-3w">
+                        {{ "common.cancel"|trans }}
+                    </a>
+                    {{ form_widget(form.save) }}
+                {{ form_end(form) }}
             </div>
         </div>
     </section>

--- a/tests/Unit/Application/User/Command/SaveUserOrganizationCommandHandlerTest.php
+++ b/tests/Unit/Application/User/Command/SaveUserOrganizationCommandHandlerTest.php
@@ -4,46 +4,256 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Application\User\Command;
 
+use App\Application\DateUtilsInterface;
 use App\Application\IdFactoryInterface;
+use App\Application\PasswordHasherInterface;
+use App\Application\StringUtilsInterface;
 use App\Application\User\Command\SaveUserOrganizationCommand;
 use App\Application\User\Command\SaveUserOrganizationCommandHandler;
 use App\Domain\User\Enum\OrganizationRolesEnum;
+use App\Domain\User\Enum\UserRolesEnum;
+use App\Domain\User\Exception\EmailAlreadyExistsException;
+use App\Domain\User\Exception\UserAlreadyRegisteredException;
 use App\Domain\User\Organization;
 use App\Domain\User\OrganizationUser;
 use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
+use App\Domain\User\Repository\UserRepositoryInterface;
+use App\Domain\User\Specification\IsEmailAlreadyExists;
+use App\Domain\User\Specification\IsUserAlreadyRegisteredInOrganization;
 use App\Domain\User\User;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 final class SaveUserOrganizationCommandHandlerTest extends TestCase
 {
-    public function testCreate(): void
+    private MockObject $idFactory;
+    private MockObject $organizationUserRepository;
+    private MockObject $userRepository;
+    private MockObject $stringUtils;
+    private MockObject $dateUtils;
+    private MockObject $passwordHasher;
+    private MockObject $isUserAlreadyRegistered;
+    private MockObject $isEmailAlreadyExists;
+    private MockObject $organization;
+
+    public function setUp(): void
+    {
+        $this->idFactory = $this->createMock(IdFactoryInterface::class);
+        $this->organizationUserRepository = $this->createMock(OrganizationUserRepositoryInterface::class);
+        $this->userRepository = $this->createMock(UserRepositoryInterface::class);
+        $this->stringUtils = $this->createMock(StringUtilsInterface::class);
+        $this->dateUtils = $this->createMock(DateUtilsInterface::class);
+        $this->passwordHasher = $this->createMock(PasswordHasherInterface::class);
+        $this->isUserAlreadyRegistered = $this->createMock(IsUserAlreadyRegisteredInOrganization::class);
+        $this->isEmailAlreadyExists = $this->createMock(IsEmailAlreadyExists::class);
+        $this->organization = $this->createMock(Organization::class);
+
+        $this->stringUtils
+            ->expects(self::once())
+            ->method('normalizeEmail')
+            ->willReturn('mathieu.marchois@beta.gouv.fr');
+    }
+
+    public function testCreateNewUserAccount(): void
+    {
+        $registrationDate = new \DateTimeImmutable('2024-08-06');
+
+        $this->dateUtils
+            ->expects(self::once())
+            ->method('getNow')
+            ->willReturn($registrationDate);
+
+        $this->passwordHasher
+            ->expects(self::once())
+            ->method('hash')
+            ->with('password')
+            ->willReturn('encryptedPassword');
+
+        $this->isUserAlreadyRegistered
+            ->expects(self::once())
+            ->method('isSatisfiedBy')
+            ->with('mathieu.marchois@beta.gouv.fr', $this->organization)
+            ->willReturn(false);
+
+        $this->isEmailAlreadyExists
+            ->expects(self::never())
+            ->method('isSatisfiedBy');
+
+        $this->userRepository
+            ->expects(self::once())
+            ->method('findOneByEmail')
+            ->with('mathieu.marchois@beta.gouv.fr')
+            ->willReturn(null);
+
+        $this->idFactory
+            ->expects(self::exactly(2))
+            ->method('make')
+            ->willReturn(
+                '584f12e7-01b1-4981-9bab-cf8dcce535b9',
+                '0de5692b-cab1-494c-804d-765dc14df674',
+            );
+
+        $user = (new User('584f12e7-01b1-4981-9bab-cf8dcce535b9'))
+            ->setEmail('mathieu.marchois@beta.gouv.fr')
+            ->setFullName('Mathieu MARCHOIS')
+            ->setPassword('encryptedPassword')
+            ->setRoles([UserRolesEnum::ROLE_USER->value])
+            ->setRegistrationDate($registrationDate);
+
+        $this->userRepository
+            ->expects(self::once())
+            ->method('add')
+            ->with($this->equalTo($user))
+            ->willReturn($user);
+
+        $this->organizationUserRepository
+            ->expects(self::once())
+            ->method('add')
+            ->with($this->equalTo(
+                (new OrganizationUser('0de5692b-cab1-494c-804d-765dc14df674'))
+                    ->setUser($user)
+                    ->setOrganization($this->organization)
+                    ->setRoles([OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value]),
+            ));
+
+        $handler = new SaveUserOrganizationCommandHandler(
+            $this->idFactory,
+            $this->organizationUserRepository,
+            $this->userRepository,
+            $this->stringUtils,
+            $this->dateUtils,
+            $this->passwordHasher,
+            $this->isUserAlreadyRegistered,
+            $this->isEmailAlreadyExists,
+        );
+        $command = new SaveUserOrganizationCommand($this->organization);
+        $command->roles = [OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value];
+        $command->fullName = 'Mathieu MARCHOIS';
+        $command->email = 'mathieu.marchois@beta.gouv.fr';
+        $command->password = 'password';
+
+        $handler($command);
+    }
+
+    public function testAddExistingUserInOrganization(): void
     {
         $user = $this->createMock(User::class);
-        $organization = $this->createMock(Organization::class);
-        $idFactory = $this->createMock(IdFactoryInterface::class);
-        $organizationUserRepository = $this->createMock(OrganizationUserRepositoryInterface::class);
 
-        $idFactory
+        $this->dateUtils
+            ->expects(self::never())
+            ->method('getNow');
+
+        $this->passwordHasher
+            ->expects(self::never())
+            ->method('hash');
+
+        $this->isEmailAlreadyExists
+            ->expects(self::never())
+            ->method('isSatisfiedBy');
+
+        $this->isUserAlreadyRegistered
+            ->expects(self::once())
+            ->method('isSatisfiedBy')
+            ->with('mathieu.marchois@beta.gouv.fr', $this->organization)
+            ->willReturn(false);
+
+        $this->userRepository
+            ->expects(self::once())
+            ->method('findOneByEmail')
+            ->with('mathieu.marchois@beta.gouv.fr')
+            ->willReturn($user);
+
+        $this->idFactory
             ->expects(self::once())
             ->method('make')
             ->willReturn('0de5692b-cab1-494c-804d-765dc14df674');
 
-        $organizationUser = (new OrganizationUser('0de5692b-cab1-494c-804d-765dc14df674'))
-            ->setUser($user)
-            ->setOrganization($organization)
-            ->setRoles([OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value]);
+        $this->userRepository
+            ->expects(self::never())
+            ->method('add');
 
-        $organizationUserRepository
+        $this->organizationUserRepository
             ->expects(self::once())
             ->method('add')
-            ->with($this->equalTo($organizationUser));
+            ->with($this->equalTo(
+                (new OrganizationUser('0de5692b-cab1-494c-804d-765dc14df674'))
+                    ->setUser($user)
+                    ->setOrganization($this->organization)
+                    ->setRoles([OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value]),
+            ));
 
         $handler = new SaveUserOrganizationCommandHandler(
-            $idFactory,
-            $organizationUserRepository,
+            $this->idFactory,
+            $this->organizationUserRepository,
+            $this->userRepository,
+            $this->stringUtils,
+            $this->dateUtils,
+            $this->passwordHasher,
+            $this->isUserAlreadyRegistered,
+            $this->isEmailAlreadyExists,
         );
-        $command = new SaveUserOrganizationCommand($user, $organization);
+        $command = new SaveUserOrganizationCommand($this->organization);
         $command->roles = [OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value];
+        $command->fullName = 'Mathieu MARCHOIS';
+        $command->email = 'mathieu.marchois@beta.gouv.fr';
+        $command->password = 'password';
+
+        $handler($command);
+    }
+
+    public function testCreateAlreadyExistingAccount(): void
+    {
+        $this->expectException(UserAlreadyRegisteredException::class);
+
+        $this->dateUtils
+            ->expects(self::never())
+            ->method('getNow');
+
+        $this->passwordHasher
+            ->expects(self::never())
+            ->method('hash');
+
+        $this->isEmailAlreadyExists
+            ->expects(self::never())
+            ->method('isSatisfiedBy');
+
+        $this->isUserAlreadyRegistered
+            ->expects(self::once())
+            ->method('isSatisfiedBy')
+            ->with('mathieu.marchois@beta.gouv.fr', $this->organization)
+            ->willReturn(true);
+
+        $this->userRepository
+            ->expects(self::never())
+            ->method('findOneByEmail');
+
+        $this->idFactory
+            ->expects(self::never())
+            ->method('make');
+
+        $this->userRepository
+            ->expects(self::never())
+            ->method('add');
+
+        $this->organizationUserRepository
+            ->expects(self::never())
+            ->method('add');
+
+        $handler = new SaveUserOrganizationCommandHandler(
+            $this->idFactory,
+            $this->organizationUserRepository,
+            $this->userRepository,
+            $this->stringUtils,
+            $this->dateUtils,
+            $this->passwordHasher,
+            $this->isUserAlreadyRegistered,
+            $this->isEmailAlreadyExists,
+        );
+        $command = new SaveUserOrganizationCommand($this->organization);
+        $command->roles = [OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value];
+        $command->fullName = 'Mathieu MARCHOIS';
+        $command->email = 'mathieu.marchois@beta.gouv.fr';
+        $command->password = 'password';
 
         $handler($command);
     }
@@ -51,34 +261,142 @@ final class SaveUserOrganizationCommandHandlerTest extends TestCase
     public function testUpdate(): void
     {
         $user = $this->createMock(User::class);
+        $user
+            ->expects(self::exactly(2))
+            ->method('getEmail')
+            ->willReturn('mathieu.marchois@beta.gouv.com');
+
+        $user
+            ->expects(self::once())
+            ->method('setEmail')
+            ->with('mathieu.marchois@beta.gouv.fr');
+        $user
+            ->expects(self::once())
+            ->method('setFullName')
+            ->with('Mathieu MARCHOIS');
+
         $organizationUser = $this->createMock(OrganizationUser::class);
+        $organizationUser
+            ->expects(self::exactly(3))
+            ->method('getUser')
+            ->willReturn($user);
         $organizationUser
             ->expects(self::once())
             ->method('setRoles')
             ->with([OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value]);
-        $organizationUser
+
+        $this->isEmailAlreadyExists
             ->expects(self::once())
-            ->method('getRoles')
-            ->willReturn([OrganizationRolesEnum::ROLE_ORGA_ADMIN->value]);
+            ->method('isSatisfiedBy')
+            ->with('mathieu.marchois@beta.gouv.fr')
+            ->willReturn(false);
 
-        $organization = $this->createMock(Organization::class);
-        $idFactory = $this->createMock(IdFactoryInterface::class);
-        $organizationUserRepository = $this->createMock(OrganizationUserRepositoryInterface::class);
+        $this->dateUtils
+            ->expects(self::never())
+            ->method('getNow');
 
-        $idFactory
+        $this->passwordHasher
+            ->expects(self::never())
+            ->method('hash');
+
+        $this->isUserAlreadyRegistered
+            ->expects(self::never())
+            ->method('isSatisfiedBy');
+
+        $this->userRepository
+            ->expects(self::never())
+            ->method('findOneByEmail');
+
+        $this->idFactory
             ->expects(self::never())
             ->method('make');
 
-        $organizationUserRepository
+        $handler = new SaveUserOrganizationCommandHandler(
+            $this->idFactory,
+            $this->organizationUserRepository,
+            $this->userRepository,
+            $this->stringUtils,
+            $this->dateUtils,
+            $this->passwordHasher,
+            $this->isUserAlreadyRegistered,
+            $this->isEmailAlreadyExists,
+        );
+        $command = new SaveUserOrganizationCommand($this->organization, $organizationUser);
+        $command->roles = [OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value];
+        $command->fullName = 'Mathieu MARCHOIS';
+        $command->email = 'mathieu.marchois@beta.gouv.fr';
+        $command->password = 'password';
+
+        $handler($command);
+    }
+
+    public function testUpdateEmailAlreadyExist(): void
+    {
+        $this->expectException(EmailAlreadyExistsException::class);
+
+        $user = $this->createMock(User::class);
+        $user
+            ->expects(self::exactly(2))
+            ->method('getEmail')
+            ->willReturn('mathieu.marchois@beta.gouv.com');
+
+        $user
             ->expects(self::never())
-            ->method('add');
+            ->method('setEmail');
+        $user
+            ->expects(self::never())
+            ->method('setFullName');
+
+        $organizationUser = $this->createMock(OrganizationUser::class);
+        $organizationUser
+            ->expects(self::exactly(3))
+            ->method('getUser')
+            ->willReturn($user);
+        $organizationUser
+            ->expects(self::never())
+            ->method('setRoles');
+
+        $this->isEmailAlreadyExists
+            ->expects(self::once())
+            ->method('isSatisfiedBy')
+            ->with('mathieu.marchois@beta.gouv.fr')
+            ->willReturn(true);
+
+        $this->dateUtils
+            ->expects(self::never())
+            ->method('getNow');
+
+        $this->passwordHasher
+            ->expects(self::never())
+            ->method('hash');
+
+        $this->isUserAlreadyRegistered
+            ->expects(self::never())
+            ->method('isSatisfiedBy');
+
+        $this->userRepository
+            ->expects(self::never())
+            ->method('findOneByEmail');
+
+        $this->idFactory
+            ->expects(self::never())
+            ->method('make');
 
         $handler = new SaveUserOrganizationCommandHandler(
-            $idFactory,
-            $organizationUserRepository,
+            $this->idFactory,
+            $this->organizationUserRepository,
+            $this->userRepository,
+            $this->stringUtils,
+            $this->dateUtils,
+            $this->passwordHasher,
+            $this->isUserAlreadyRegistered,
+            $this->isEmailAlreadyExists,
         );
-        $command = new SaveUserOrganizationCommand($user, $organization, $organizationUser);
+        $command = new SaveUserOrganizationCommand($this->organization, $organizationUser);
         $command->roles = [OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value];
+        $command->fullName = 'Mathieu MARCHOIS';
+        $command->email = 'mathieu.marchois@beta.gouv.fr';
+        $command->password = 'password';
 
         $handler($command);
     }

--- a/tests/Unit/Domain/User/Specification/IsAccessAlreadyRequestedTest.php
+++ b/tests/Unit/Domain/User/Specification/IsAccessAlreadyRequestedTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\User\Specification;
+
+use App\Domain\User\AccessRequest;
+use App\Domain\User\Repository\AccessRequestRepositoryInterface;
+use App\Domain\User\Specification\IsAccessAlreadyRequested;
+use PHPUnit\Framework\TestCase;
+
+final class IsAccessAlreadyRequestedTest extends TestCase
+{
+    public function testAccessAlreadyRequested(): void
+    {
+        $accessRequest = $this->createMock(AccessRequest::class);
+        $accessRequestRepository = $this->createMock(AccessRequestRepositoryInterface::class);
+        $accessRequestRepository
+            ->expects(self::once())
+            ->method('findOneByEmail')
+            ->with('mathieu.marchois@beta.gouv.fr')
+            ->willReturn($accessRequest);
+
+        $pattern = new IsAccessAlreadyRequested($accessRequestRepository);
+        $this->assertTrue($pattern->isSatisfiedBy('mathieu.marchois@beta.gouv.fr'));
+    }
+
+    public function testAccessNotRequested(): void
+    {
+        $accessRequestRepository = $this->createMock(AccessRequestRepositoryInterface::class);
+        $accessRequestRepository
+            ->expects(self::once())
+            ->method('findOneByEmail')
+            ->with('mathieu.marchois@beta.gouv.fr')
+            ->willReturn(null);
+
+        $pattern = new IsAccessAlreadyRequested($accessRequestRepository);
+        $this->assertFalse($pattern->isSatisfiedBy('mathieu.marchois@beta.gouv.fr'));
+    }
+}

--- a/tests/Unit/Domain/User/Specification/IsEmailAlreadyExistsTest.php
+++ b/tests/Unit/Domain/User/Specification/IsEmailAlreadyExistsTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\User\Specification;
+
+use App\Domain\User\Repository\UserRepositoryInterface;
+use App\Domain\User\Specification\IsEmailAlreadyExists;
+use App\Domain\User\User;
+use PHPUnit\Framework\TestCase;
+
+final class IsEmailAlreadyExistsTest extends TestCase
+{
+    public function testEmailAlreadyExist(): void
+    {
+        $user = $this->createMock(User::class);
+        $userRepository = $this->createMock(UserRepositoryInterface::class);
+        $userRepository
+            ->expects(self::once())
+            ->method('findOneByEmail')
+            ->with('mathieu.marchois@beta.gouv.fr')
+            ->willReturn($user);
+
+        $pattern = new IsEmailAlreadyExists($userRepository);
+        $this->assertTrue($pattern->isSatisfiedBy('mathieu.marchois@beta.gouv.fr'));
+    }
+
+    public function testEmailDoesntExist(): void
+    {
+        $userRepository = $this->createMock(UserRepositoryInterface::class);
+        $userRepository
+            ->expects(self::once())
+            ->method('findOneByEmail')
+            ->with('mathieu.marchois@beta.gouv.fr')
+            ->willReturn(null);
+
+        $pattern = new IsEmailAlreadyExists($userRepository);
+        $this->assertFalse($pattern->isSatisfiedBy('mathieu.marchois@beta.gouv.fr'));
+    }
+}

--- a/tests/Unit/Domain/User/Specification/IsUserAlreadyRegisteredInOrganizationTest.php
+++ b/tests/Unit/Domain/User/Specification/IsUserAlreadyRegisteredInOrganizationTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\User\Specification;
+
+use App\Domain\User\Organization;
+use App\Domain\User\OrganizationUser;
+use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
+use App\Domain\User\Specification\IsUserAlreadyRegisteredInOrganization;
+use PHPUnit\Framework\TestCase;
+
+final class IsUserAlreadyRegisteredInOrganizationTest extends TestCase
+{
+    public function testUserAlreadyExist(): void
+    {
+        $organization = $this->createMock(Organization::class);
+        $organization
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('97ebfcee-80dc-4bdc-bcde-681e54c4d717');
+
+        $organizationUser = $this->createMock(OrganizationUser::class);
+        $organizationUserRepository = $this->createMock(OrganizationUserRepositoryInterface::class);
+        $organizationUserRepository
+            ->expects(self::once())
+            ->method('findByEmailAndOrganization')
+            ->with('mathieu.marchois@beta.gouv.fr', '97ebfcee-80dc-4bdc-bcde-681e54c4d717')
+            ->willReturn($organizationUser);
+
+        $pattern = new IsUserAlreadyRegisteredInOrganization($organizationUserRepository);
+        $this->assertTrue($pattern->isSatisfiedBy('mathieu.marchois@beta.gouv.fr', $organization));
+    }
+
+    public function testUserDoesntExist(): void
+    {
+        $organization = $this->createMock(Organization::class);
+        $organization
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('97ebfcee-80dc-4bdc-bcde-681e54c4d717');
+
+        $organizationUserRepository = $this->createMock(OrganizationUserRepositoryInterface::class);
+        $organizationUserRepository
+            ->expects(self::once())
+            ->method('findByEmailAndOrganization')
+            ->with('mathieu.marchois@beta.gouv.fr', '97ebfcee-80dc-4bdc-bcde-681e54c4d717')
+            ->willReturn(null);
+
+        $pattern = new IsUserAlreadyRegisteredInOrganization($organizationUserRepository);
+        $this->assertFalse($pattern->isSatisfiedBy('mathieu.marchois@beta.gouv.fr', $organization));
+    }
+}

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -2036,7 +2036,19 @@
             </trans-unit>
             <trans-unit id="user.list.email">
                 <source>user.list.email</source>
-                <target>Email</target>
+                <target>Adresse e-mail</target>
+            </trans-unit>
+            <trans-unit id="user.form.password">
+                <source>user.form.password</source>
+                <target>Mot de passe</target>
+            </trans-unit>
+            <trans-unit id="user.form.password.repeat">
+                <source>user.form.password.repeat</source>
+                <target>Confirmer le mot de passe</target>
+            </trans-unit>
+            <trans-unit id="user.form.roles">
+                <source>user.form.roles</source>
+                <target>Assigner un ou plusieurs rôles à l'utilisateur</target>
             </trans-unit>
             <trans-unit id="user.list.roles">
                 <source>user.list.roles</source>

--- a/translations/validators.fr.xlf
+++ b/translations/validators.fr.xlf
@@ -66,6 +66,14 @@
                 <source>regulation.period.error.end_time</source>
                 <target>L'heure de fin doit être supérieure à l'heure de début.</target>
             </trans-unit>
+            <trans-unit id="user.already.registered">
+                <source>user.already.registered</source>
+                <target>Cette adresse email est déjà associée à l'organisation.</target>
+            </trans-unit>
+            <trans-unit id="email.already.exists">
+                <source>email.already.exists</source>
+                <target>Cette adresse email est déjà associée à un autre compte.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
* Refs #871 

Cette PR permet de modifier un utilisateur.

Règles métiers (valable pour la création & l'édition d'un compte) : 
- Si un compte utilisateur existe déjà, il est récupéré depuis la base de données et ajouté à l'organisation.
- Si un compte n'existe pas, il est créé avec les valeurs saisies dans le formulaire, puis ajouté à l'organisation.
- À l'édition, il est impossible de modifier le mot de passe. Celui-ci sera défini uniquement au moment de la création du compte, s'il n'existe pas déjà.
- Si une adresse email a déjà été configurée dans l'organisation, un message d'erreur indique que le compte est déjà associé à l'organisation.

:eyes: 

![image](https://github.com/user-attachments/assets/a05b3003-41f8-4345-ad6d-ac9e47a43704)
![image](https://github.com/user-attachments/assets/c1d55ea5-3741-4866-86b3-c180a350f005)

Pour tester, c'est par ici : https://dialog-staging-pr907.osc-fr1.scalingo.io/
