### PR TITLE
Autoriser la publication uniquement aux rôles admin et publisher

### DIFF
--- a/src/Domain/User/Specification/CanUserPublishRegulation.php
+++ b/src/Domain/User/Specification/CanUserPublishRegulation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Specification;
+
+use App\Domain\Regulation\RegulationOrderRecord;
+use App\Domain\User\Enum\OrganizationRolesEnum;
+use App\Infrastructure\Security\SymfonyUser;
+
+class CanUserPublishRegulation
+{
+    public function isSatisfiedBy(RegulationOrderRecord $regulationOrderRecord, SymfonyUser $user): bool
+    {
+        $organization = $regulationOrderRecord->getOrganization();
+
+        foreach ($user->getOrganizationUsers() as $userOrganization) {
+            if ($userOrganization->uuid !== $organization->getUuid()) {
+                continue;
+            }
+
+            return \in_array(OrganizationRolesEnum::ROLE_ORGA_ADMIN->value, $userOrganization->roles)
+                || \in_array(OrganizationRolesEnum::ROLE_ORGA_PUBLISHER->value, $userOrganization->roles);
+        }
+
+        return false;
+    }
+}

--- a/src/Infrastructure/Controller/Regulation/Fragments/AddMeasureController.php
+++ b/src/Infrastructure/Controller/Regulation/Fragments/AddMeasureController.php
@@ -86,6 +86,7 @@ final class AddMeasureController extends AbstractRegulationController
                         context: [
                             'measure' => MeasureView::fromEntity($measure),
                             'regulationOrderRecordUuid' => $uuid,
+                            'regulationOrderRecord' => $regulationOrderRecord,
                             'generalInfo' => $generalInfo,
                             'canDelete' => ($regulationOrderRecord->countMeasures() + 1) > 1,
                             'preExistingMeasureUuids' => $preExistingMeasureUuids,

--- a/src/Infrastructure/Controller/Regulation/PublishRegulationController.php
+++ b/src/Infrastructure/Controller/Regulation/PublishRegulationController.php
@@ -9,6 +9,7 @@ use App\Application\QueryBusInterface;
 use App\Application\Regulation\Command\PublishRegulationCommand;
 use App\Domain\Regulation\Exception\RegulationOrderRecordCannotBePublishedException;
 use App\Domain\Regulation\Specification\CanOrganizationAccessToRegulation;
+use App\Infrastructure\Security\Voter\RegulationOrderRecordVoter;
 use Symfony\Bundle\SecurityBundle\Security;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -48,6 +49,10 @@ final class PublishRegulationController extends AbstractRegulationController
         }
 
         $regulationOrderRecord = $this->getRegulationOrderRecord($uuid);
+
+        if (!$this->security->isGranted(RegulationOrderRecordVoter::PUBLISH, $regulationOrderRecord)) {
+            throw new AccessDeniedHttpException();
+        }
 
         try {
             $this->commandBus->handle(new PublishRegulationCommand($regulationOrderRecord));

--- a/src/Infrastructure/Controller/Regulation/RegulationDetailController.php
+++ b/src/Infrastructure/Controller/Regulation/RegulationDetailController.php
@@ -6,7 +6,6 @@ namespace App\Infrastructure\Controller\Regulation;
 
 use App\Application\QueryBusInterface;
 use App\Application\Regulation\Query\GetGeneralInfoQuery;
-use App\Application\Regulation\Query\GetOrganizationUuidByRegulationOrderRecordQuery;
 use App\Application\Regulation\Query\Measure\GetMeasuresQuery;
 use App\Application\Regulation\View\GeneralInfoView;
 use App\Domain\Regulation\ArrayRegulationMeasures;
@@ -55,7 +54,8 @@ final class RegulationDetailController extends AbstractRegulationController
             throw new AccessDeniedHttpException();
         }
 
-        $organizationUuid = $this->queryBus->handle(new GetOrganizationUuidByRegulationOrderRecordQuery($uuid));
+        $regulationOrderRecord = $this->getRegulationOrderRecord($uuid, requireUserSameOrg: false);
+        $organizationUuid = $regulationOrderRecord->getOrganizationUuid();
         $measures = $this->queryBus->handle(new GetMeasuresQuery($uuid));
         $isReadOnly = !($currentUser && $this->canOrganizationAccessToRegulation->isSatisfiedBy($organizationUuid, $currentUser->getOrganizationUuids()));
 
@@ -67,6 +67,7 @@ final class RegulationDetailController extends AbstractRegulationController
             'isReadOnly' => $isReadOnly,
             'generalInfo' => $generalInfo,
             'measures' => $measures,
+            'regulationOrderRecord' => $regulationOrderRecord,
         ];
 
         return new Response(

--- a/src/Infrastructure/Security/Voter/RegulationOrderRecordVoter.php
+++ b/src/Infrastructure/Security/Voter/RegulationOrderRecordVoter.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Security\Voter;
+
+use App\Domain\Regulation\RegulationOrderRecord;
+use App\Domain\User\Specification\CanUserPublishRegulation;
+use App\Infrastructure\Security\SymfonyUser;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Authorization\Voter\Voter;
+
+final class RegulationOrderRecordVoter extends Voter
+{
+    public function __construct(
+        private readonly CanUserPublishRegulation $canUserPublishRegulation,
+    ) {
+    }
+
+    public const PUBLISH = 'publish';
+
+    protected function supports(string $attribute, mixed $subject): bool
+    {
+        if (!\in_array($attribute, [self::PUBLISH])) {
+            return false;
+        }
+
+        if (!$subject instanceof RegulationOrderRecord) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function voteOnAttribute(string $attribute, mixed $subject, TokenInterface $token): bool
+    {
+        $user = $token->getUser();
+
+        if (!$user instanceof SymfonyUser) {
+            return false;
+        }
+
+        /** @var RegulationOrderRecord $regulationOrderRecord */
+        $regulationOrderRecord = $subject;
+
+        return match ($attribute) {
+            self::PUBLISH => $this->canUserPublishRegulation->isSatisfiedBy($regulationOrderRecord, $user),
+            default => throw new \LogicException('This code should not be reached!')
+        };
+    }
+}

--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -68,7 +68,7 @@
                                     {% if isDraft %}
                                         <li>
                                             <div id="block_publication">
-                                                {% include 'regulation/fragments/_publication_button.html.twig' with { canPublish, uuid: generalInfo.uuid } only %}
+                                                {% include 'regulation/fragments/_publication_button.html.twig' with { canPublish, uuid: generalInfo.uuid, regulationOrderRecord } only %}
                                             </div>
                                         </li>
                                     {% endif %}
@@ -127,14 +127,16 @@
     {{ parent() }}
     {% if not isReadOnly %}
         {% if isDraft %}
-            {% include "common/confirmation_modal.html.twig" with {
-                id: 'regulation-publish-modal',
-                title: 'regulation.publish_modal.title'|trans,
-                buttons: [
-                    { label: 'common.publish'|trans, attr: {type: 'submit', class: 'fr-btn'} },
-                    { label: 'common.do_not_publish'|trans, attr: {value: 'close', class: 'fr-btn fr-btn--secondary'} },
-                ],
-            } only %}
+            {% if is_granted(constant('App\\Infrastructure\\Security\\Voter\\RegulationOrderRecordVoter::PUBLISH'), regulationOrderRecord) %}
+                {% include "common/confirmation_modal.html.twig" with {
+                    id: 'regulation-publish-modal',
+                    title: 'regulation.publish_modal.title'|trans,
+                    buttons: [
+                        { label: 'common.publish'|trans, attr: {type: 'submit', class: 'fr-btn'} },
+                        { label: 'common.do_not_publish'|trans, attr: {value: 'close', class: 'fr-btn fr-btn--secondary'} },
+                    ],
+                } only %}
+            {% endif %}
 
             {% include "common/confirmation_modal.html.twig" with {
                 id: 'measure-delete-modal',

--- a/templates/regulation/fragments/_measure.added.stream.html.twig
+++ b/templates/regulation/fragments/_measure.added.stream.html.twig
@@ -33,6 +33,6 @@
 
 <turbo-stream action="update" target="block_publication">
     <template>
-        {% include 'regulation/fragments/_publication_button.html.twig' with { canPublish: true, uuid: regulationOrderRecordUuid } only %}
+        {% include 'regulation/fragments/_publication_button.html.twig' with { canPublish: true, uuid: regulationOrderRecordUuid, regulationOrderRecord } only %}
     </template>
 </turbo-stream>

--- a/templates/regulation/fragments/_publication_button.html.twig
+++ b/templates/regulation/fragments/_publication_button.html.twig
@@ -1,14 +1,16 @@
-{% if canPublish %}
-    {% set publishCsrfToken = csrf_token('publish-regulation') %}
-    <form method="post" action="{{ path('app_regulation_publish', { uuid }) }}" data-controller="form-submit" data-action="modal-trigger:submit->form-submit#submit">
-        <d-modal-trigger modal="regulation-publish-modal" submitValue="publish">
-            <button class="fr-btn fr-btn--secondary" aria-controls="regulation-publish-modal">
-                {{ 'common.publish'|trans }}
-            </button>
+{% if is_granted(constant('App\\Infrastructure\\Security\\Voter\\RegulationOrderRecordVoter::PUBLISH'), regulationOrderRecord) %}
+    {% if canPublish %}
+        {% set publishCsrfToken = csrf_token('publish-regulation') %}
+        <form method="post" action="{{ path('app_regulation_publish', { uuid }) }}" data-controller="form-submit" data-action="modal-trigger:submit->form-submit#submit">
+            <d-modal-trigger modal="regulation-publish-modal" submitValue="publish">
+                <button class="fr-btn fr-btn--secondary" aria-controls="regulation-publish-modal">
+                    {{ 'common.publish'|trans }}
+                </button>
 
-            <input type="hidden" name="token" value="{{ publishCsrfToken }}"/>
-        </d-modal-trigger>
-    </form>
-{% else %}
-    <button class="fr-btn fr-btn--secondary" disabled>{{ 'common.publish'|trans }}</button>
+                <input type="hidden" name="token" value="{{ publishCsrfToken }}"/>
+            </d-modal-trigger>
+        </form>
+    {% else %}
+        <button class="fr-btn fr-btn--secondary" disabled>{{ 'common.publish'|trans }}</button>
+    {% endif %}
 {% endif %}

--- a/tests/Integration/Infrastructure/Controller/Regulation/PublishRegulationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/PublishRegulationControllerTest.php
@@ -15,7 +15,7 @@ final class PublishRegulationControllerTest extends AbstractWebTestCase
 
     public function testPublish(): void
     {
-        $client = $this->login();
+        $client = $this->login(UserFixture::MAIN_ORG_ADMIN_EMAIL);
         $client->request('POST', '/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/publish', [
             'token' => $this->generateCsrfToken($client, 'publish-regulation'),
         ]);
@@ -23,6 +23,16 @@ final class PublishRegulationControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(303);
         $client->followRedirect();
         $this->assertRouteSame('app_regulation_detail', ['uuid' => RegulationOrderRecordFixture::UUID_TYPICAL]);
+    }
+
+    public function testPublishAsContributor(): void
+    {
+        $client = $this->login();
+        $client->request('POST', '/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/publish', [
+            'token' => $this->generateCsrfToken($client, 'publish-regulation'),
+        ]);
+
+        $this->assertResponseStatusCodeSame(403);
     }
 
     public function testCannotBePublishedBecauseNoMeasures(): void

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -12,9 +12,9 @@ use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
 
 final class RegulationDetailControllerTest extends AbstractWebTestCase
 {
-    public function testDraftRegulationDetail(): void
+    public function testDraftRegulationDetailAsAdmin(): void
     {
-        $client = $this->login();
+        $client = $this->login(UserFixture::MAIN_ORG_ADMIN_EMAIL);
         $crawler = $client->request('GET', '/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL);
 
         $this->assertSecurityHeaders();
@@ -80,6 +80,14 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         // Go back link
         $goBackLink = $crawler->selectLink('Revenir aux arrêtés');
         $this->assertSame('/regulations?tab=temporary', $goBackLink->extract(['href'])[0]);
+    }
+
+    public function testDraftRegulationDetailAsContributor(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL);
+
+        $this->assertSame(0, $crawler->selectButton('Publier')->count());
     }
 
     public function testPermanentRegulationDetail(): void

--- a/tests/Unit/Domain/User/Specification/CanUserPublishRegulationTest.php
+++ b/tests/Unit/Domain/User/Specification/CanUserPublishRegulationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\User\Specification;
+
+use App\Application\User\View\OrganizationView;
+use App\Domain\Regulation\RegulationOrderRecord;
+use App\Domain\User\Enum\OrganizationRolesEnum;
+use App\Domain\User\Organization;
+use App\Domain\User\Specification\CanUserPublishRegulation;
+use App\Infrastructure\Security\SymfonyUser;
+use PHPUnit\Framework\TestCase;
+
+final class CanUserPublishRegulationTest extends TestCase
+{
+    public function testCanPublish(): void
+    {
+        $organization = $this->createMock(Organization::class);
+        $organization
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('c1790745-b915-4fb5-96e7-79b104092a55');
+
+        $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
+        $regulationOrderRecord
+            ->expects(self::once())
+            ->method('getOrganization')
+            ->willReturn($organization);
+
+        $symfonyUser = $this->createMock(SymfonyUser::class);
+        $symfonyUser
+            ->expects(self::once())
+            ->method('getOrganizationUsers')
+            ->willReturn([
+                new OrganizationView('c1790745-b915-4fb5-96e7-79b104092a55', 'Dialog', [OrganizationRolesEnum::ROLE_ORGA_PUBLISHER->value]),
+            ]);
+
+        $pattern = new CanUserPublishRegulation();
+        $this->assertTrue($pattern->isSatisfiedBy($regulationOrderRecord, $symfonyUser));
+    }
+
+    public function testCantPublish(): void
+    {
+        $organization = $this->createMock(Organization::class);
+        $organization
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('c1790745-b915-4fb5-96e7-79b104092a55');
+
+        $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
+        $regulationOrderRecord
+            ->expects(self::once())
+            ->method('getOrganization')
+            ->willReturn($organization);
+
+        $symfonyUser = $this->createMock(SymfonyUser::class);
+        $symfonyUser
+            ->expects(self::once())
+            ->method('getOrganizationUsers')
+            ->willReturn([
+                new OrganizationView('c1790745-b915-4fb5-96e7-79b104092a55', 'Dialog', [OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value]),
+            ]);
+
+        $pattern = new CanUserPublishRegulation();
+        $this->assertFalse($pattern->isSatisfiedBy($regulationOrderRecord, $symfonyUser));
+    }
+}


### PR DESCRIPTION
* Refs #871 

Suite au travail de @MathieuFV pour associer les rôles utilisateurs dans chaque organisations, cette PR permet de restreindre la publication d'un arrêté à l'administrateur ou au "publisher" de l'organisation en question.

## :eyes: 

- Organisation dans laquelle **je ne suis pas admin** : 
![image](https://github.com/user-attachments/assets/8dda6c86-85c2-447d-8004-34b7b2e336e6)

- Organisation dans laquelle **je suis admin** : 
![image](https://github.com/user-attachments/assets/3ffd0832-dbed-440b-b7f2-583d36473703)

Pour tester : https://dialog-staging-pr910.osc-fr1.scalingo.io/