### PR TITLE
Improve OrganizationVoter

### DIFF
--- a/src/Domain/User/Specification/CanUserEditOrganization.php
+++ b/src/Domain/User/Specification/CanUserEditOrganization.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Specification;
+
+use App\Domain\User\Enum\OrganizationRolesEnum;
+use App\Domain\User\Organization;
+use App\Infrastructure\Security\SymfonyUser;
+
+class CanUserEditOrganization
+{
+    public function isSatisfiedBy(Organization $organization, SymfonyUser $user): bool
+    {
+        foreach ($user->getOrganizationUsers() as $organizationUser) {
+            if ($organizationUser->uuid !== $organization->getUuid()) {
+                continue;
+            }
+
+            return \in_array(OrganizationRolesEnum::ROLE_ORGA_ADMIN->value, $organizationUser->roles);
+        }
+
+        return false;
+    }
+}

--- a/src/Domain/User/Specification/CanUserViewOrganization.php
+++ b/src/Domain/User/Specification/CanUserViewOrganization.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Specification;
+
+use App\Domain\User\Organization;
+use App\Infrastructure\Security\SymfonyUser;
+
+class CanUserViewOrganization
+{
+    public function isSatisfiedBy(Organization $organization, SymfonyUser $user): bool
+    {
+        return \in_array($organization->getUuid(), $user->getOrganizationUuids());
+    }
+}

--- a/tests/Unit/Domain/User/Specification/CanUserEditOrganizationTest.php
+++ b/tests/Unit/Domain/User/Specification/CanUserEditOrganizationTest.php
@@ -5,54 +5,41 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Domain\User\Specification;
 
 use App\Application\User\View\OrganizationView;
-use App\Domain\Regulation\RegulationOrderRecord;
 use App\Domain\User\Enum\OrganizationRolesEnum;
 use App\Domain\User\Organization;
-use App\Domain\User\Specification\CanUserPublishRegulation;
+use App\Domain\User\Specification\CanUserEditOrganization;
 use App\Infrastructure\Security\SymfonyUser;
 use PHPUnit\Framework\TestCase;
 
-final class CanUserPublishRegulationTest extends TestCase
+final class CanUserEditOrganizationTest extends TestCase
 {
-    public function testCanPublish(): void
+    public function testCanEdit(): void
     {
         $organization = $this->createMock(Organization::class);
         $organization
             ->expects(self::once())
             ->method('getUuid')
             ->willReturn('c1790745-b915-4fb5-96e7-79b104092a55');
-
-        $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
-        $regulationOrderRecord
-            ->expects(self::once())
-            ->method('getOrganization')
-            ->willReturn($organization);
 
         $symfonyUser = $this->createMock(SymfonyUser::class);
         $symfonyUser
             ->expects(self::once())
             ->method('getOrganizationUsers')
             ->willReturn([
-                new OrganizationView('c1790745-b915-4fb5-96e7-79b104092a55', 'Dialog', [OrganizationRolesEnum::ROLE_ORGA_PUBLISHER->value]),
+                new OrganizationView('c1790745-b915-4fb5-96e7-79b104092a55', 'Dialog', [OrganizationRolesEnum::ROLE_ORGA_ADMIN->value]),
             ]);
 
-        $pattern = new CanUserPublishRegulation();
-        $this->assertTrue($pattern->isSatisfiedBy($regulationOrderRecord, $symfonyUser));
+        $pattern = new CanUserEditOrganization();
+        $this->assertTrue($pattern->isSatisfiedBy($organization, $symfonyUser));
     }
 
-    public function testCannotPublish(): void
+    public function testCannotEdit(): void
     {
         $organization = $this->createMock(Organization::class);
         $organization
             ->expects(self::once())
             ->method('getUuid')
             ->willReturn('c1790745-b915-4fb5-96e7-79b104092a55');
-
-        $regulationOrderRecord = $this->createMock(RegulationOrderRecord::class);
-        $regulationOrderRecord
-            ->expects(self::once())
-            ->method('getOrganization')
-            ->willReturn($organization);
 
         $symfonyUser = $this->createMock(SymfonyUser::class);
         $symfonyUser
@@ -62,7 +49,7 @@ final class CanUserPublishRegulationTest extends TestCase
                 new OrganizationView('c1790745-b915-4fb5-96e7-79b104092a55', 'Dialog', [OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value]),
             ]);
 
-        $pattern = new CanUserPublishRegulation();
-        $this->assertFalse($pattern->isSatisfiedBy($regulationOrderRecord, $symfonyUser));
+        $pattern = new CanUserEditOrganization();
+        $this->assertFalse($pattern->isSatisfiedBy($organization, $symfonyUser));
     }
 }

--- a/tests/Unit/Domain/User/Specification/CanUserViewOrganizationTest.php
+++ b/tests/Unit/Domain/User/Specification/CanUserViewOrganizationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\User\Specification;
+
+use App\Domain\User\Organization;
+use App\Domain\User\Specification\CanUserViewOrganization;
+use App\Infrastructure\Security\SymfonyUser;
+use PHPUnit\Framework\TestCase;
+
+final class CanUserViewOrganizationTest extends TestCase
+{
+    public function testCanView(): void
+    {
+        $organization = $this->createMock(Organization::class);
+        $organization
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('c1790745-b915-4fb5-96e7-79b104092a55');
+
+        $symfonyUser = $this->createMock(SymfonyUser::class);
+        $symfonyUser
+            ->expects(self::once())
+            ->method('getOrganizationUuids')
+            ->willReturn(['c1790745-b915-4fb5-96e7-79b104092a55']);
+
+        $pattern = new CanUserViewOrganization();
+        $this->assertTrue($pattern->isSatisfiedBy($organization, $symfonyUser));
+    }
+
+    public function testCannotView(): void
+    {
+        $organization = $this->createMock(Organization::class);
+        $organization
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('28aaef2a-e9d1-4189-9ead-17e866a8726f');
+
+        $symfonyUser = $this->createMock(SymfonyUser::class);
+        $symfonyUser
+            ->expects(self::once())
+            ->method('getOrganizationUuids')
+            ->willReturn(['c1790745-b915-4fb5-96e7-79b104092a55']);
+
+        $pattern = new CanUserViewOrganization();
+        $this->assertFalse($pattern->isSatisfiedBy($organization, $symfonyUser));
+    }
+}


### PR DESCRIPTION
Suite à une recommandation de @florimondmanca sur #910 , cette PR permet d'isoler la logique métier du voter `OrganizationVoter`