### PR TITLE
Simplification de l'affichage des arrếtés

### DIFF
--- a/src/Application/Regulation/Query/GetRegulationsQuery.php
+++ b/src/Application/Regulation/Query/GetRegulationsQuery.php
@@ -11,7 +11,6 @@ final readonly class GetRegulationsQuery implements QueryInterface
     public function __construct(
         public int $pageSize,
         public int $page,
-        public bool $isPermanent,
         public ?array $organizationUuids = null,
     ) {
     }

--- a/src/Application/Regulation/Query/GetRegulationsQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationsQueryHandler.php
@@ -24,7 +24,6 @@ final class GetRegulationsQueryHandler
         $rows = $this->repository->findAllRegulations(
             $query->pageSize,
             $query->page,
-            $query->isPermanent,
             $query->organizationUuids,
         );
 

--- a/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
@@ -18,7 +18,6 @@ interface RegulationOrderRecordRepositoryInterface
     public function findAllRegulations(
         int $maxItemsPerPage,
         int $page,
-        bool $isPermanent,
         ?array $organizationUuids = null,
     ): array;
 

--- a/src/Infrastructure/Controller/Regulation/DeleteRegulationController.php
+++ b/src/Infrastructure/Controller/Regulation/DeleteRegulationController.php
@@ -58,15 +58,10 @@ final class DeleteRegulationController
             // The regulation may have been deleted before.
             // Don't fail, as DELETE is an idempotent method (see RFC 9110, 9.2.2).
             return new RedirectResponse(
-                url: $this->router->generate('app_regulations_list', [
-                    'tab' => 'temporary',
-                ]),
+                url: $this->router->generate('app_regulations_list'),
                 status: Response::HTTP_SEE_OTHER,
             );
         }
-
-        // Get before the entity gets deleted.
-        $endDate = $regulationOrderRecord->getRegulationOrder()->getEndDate();
 
         try {
             $this->commandBus->handle(new DeleteRegulationCommand($user->getOrganizationUuids(), $regulationOrderRecord));
@@ -75,9 +70,7 @@ final class DeleteRegulationController
         }
 
         return new RedirectResponse(
-            url: $this->router->generate('app_regulations_list', [
-                'tab' => $endDate ? 'temporary' : 'permanent',
-            ]),
+            url: $this->router->generate('app_regulations_list'),
             status: Response::HTTP_SEE_OTHER,
         );
     }

--- a/src/Infrastructure/Controller/Regulation/ListRegulationsController.php
+++ b/src/Infrastructure/Controller/Regulation/ListRegulationsController.php
@@ -34,7 +34,6 @@ final class ListRegulationsController
     {
         /** @var SymfonyUser|null */
         $user = $this->security->getUser();
-        $tab = $request->query->get('tab', 'temporary');
         $pageSize = min($request->query->getInt('pageSize', 20), 100);
         $page = $request->query->getInt('page', 1);
 
@@ -46,19 +45,10 @@ final class ListRegulationsController
 
         $organizationUserUuids = $user?->getOrganizationUuids();
 
-        $temporaryRegulations = $this->queryBus->handle(
+        $regulations = $this->queryBus->handle(
             new GetRegulationsQuery(
                 pageSize: $pageSize,
-                page: $tab === 'temporary' ? $page : 1,
-                isPermanent: false,
-                organizationUuids: $organizationUserUuids,
-            ),
-        );
-        $permanentRegulations = $this->queryBus->handle(
-            new GetRegulationsQuery(
-                pageSize: $pageSize,
-                page: $tab === 'permanent' ? $page : 1,
-                isPermanent: true,
+                page: $page,
                 organizationUuids: $organizationUserUuids,
             ),
         );
@@ -66,9 +56,7 @@ final class ListRegulationsController
         return new Response($this->twig->render(
             name: 'regulation/index.html.twig',
             context: [
-                'temporaryRegulations' => $temporaryRegulations,
-                'permanentRegulations' => $permanentRegulations,
-                'tab' => $tab,
+                'regulations' => $regulations,
                 'pageSize' => $pageSize,
                 'page' => $page,
             ],

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
@@ -12,8 +12,6 @@ use Doctrine\Persistence\ObjectManager;
 final class RegulationOrderFixture extends Fixture
 {
     public const TYPICAL_IDENTIFIER = 'FO1/2023';
-    public const NUM_TEMPORARY = 9;
-    public const NUM_PERMANENT = 1;
     public const IDENTIFIER_CIFS = 'F/CIFS/2023';
 
     public function load(ObjectManager $manager): void

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -56,7 +56,6 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
     public function findAllRegulations(
         int $maxItemsPerPage,
         int $page,
-        bool $isPermanent,
         ?array $organizationUuids = null,
     ): array {
         $query = $this->createQueryBuilder('roc')
@@ -83,7 +82,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
 
         $query
             ->innerJoin('roc.organization', 'o')
-            ->innerJoin('roc.regulationOrder', 'ro', 'WITH', $isPermanent ? 'ro.endDate IS NULL' : 'ro.endDate IS NOT NULL')
+            ->innerJoin('roc.regulationOrder', 'ro')
             ->orderBy('ro.startDate', 'DESC')
             ->addOrderBy('ro.identifier', 'ASC')
             ->addGroupBy('ro, roc, o')

--- a/templates/regulation/_items.html.twig
+++ b/templates/regulation/_items.html.twig
@@ -16,7 +16,7 @@
                 <th scope="col" class="app-regulation-table__identifier fr-hidden fr-x-revert-sm">{{ 'regulation.organization'|trans }}</th>
                 <th scope="col">{{ 'regulation.locations'|trans }}</th>
                 <th scope="col" class="fr-hidden fr-x-revert-sm">{{ 'regulation.period'|trans }}</th>
-                <th scope="col" class="fr-hidden fr-x-revert-sm">{{ 'regulation.status'|trans }}</th>
+                <th scope="col" class="fr-hidden fr-x-revert-sm app-table__actions">{{ 'regulation.status'|trans }}</th>
                 <th scope="col" class="app-table__actions">{{ 'common.actions'|trans }}</th>
             </tr>
         </thead>

--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -114,8 +114,7 @@
                 </aside>
             </div>
             <div class="fr-mt-22v">
-                {% set tab = generalInfo.startDate and generalInfo.endDate ? 'temporary' : 'permanent'  %}
-                <a href="{{ path('app_regulations_list', { tab }) }}" class="fr-link fr-fi-arrow-left-line fr-link--icon-left">
+                <a href="{{ path('app_regulations_list') }}" class="fr-link fr-fi-arrow-left-line fr-link--icon-left">
                     {{ 'regulation.back'|trans }}
                 </a>
             </div>

--- a/templates/regulation/index.html.twig
+++ b/templates/regulation/index.html.twig
@@ -6,8 +6,6 @@
 
 {% block body %}
     <section class="fr-container fr-py-5w" aria-labelledby="regulation-list">
-        {% set isTemporaryTab = tab == 'temporary' %}
-        {% set isPermanent = tab == 'permanent' %}
         <div class="fr-grid-row">
             <h3 id="regulation-list" class="fr-col fr-mb-0">{{ 'regulation.list.title'|trans }}</h3>
             {% if app.user %}
@@ -16,47 +14,13 @@
                 </a>
             {% endif %}
         </div>
-        <div class="fr-tabs fr-mt-2w">
-            <ul class="fr-tabs__list" role="tablist" aria-label="{{ 'regulation.list.title'|trans }}">
-                <li role="presentation">
-                    <button id="temporary" class="fr-tabs__tab" tabindex="0" role="tab" aria-selected="{{ isTemporaryTab ? "true" : "false" }}" aria-controls="temporary-panel">
-                        {{ 'regulation.list.total_temporary'|trans({'%count%': temporaryRegulations.totalItems}) }}
-                    </button>
-                </li>
-                <li role="presentation">
-                    <button id="permanent" class="fr-tabs__tab" tabindex="1" role="tab" aria-selected="{{ isPermanent ? "true" : "false" }}" aria-controls="permanent-panel">
-                        {{ 'regulation.list.total_permanent'|trans({'%count%': permanentRegulations.totalItems}) }}
-                    </button>
-                </li>
-            </ul>
-            <div
-                id="temporary-panel"
-                class="fr-tabs__panel {% if isTemporaryTab %}fr-tabs__panel--selected{% else %}fr-tabs__panel--direction-start{% endif %}"
-                role="tabpanel"
-                aria-labelledby="temporary"
-                tabindex="0"
-            >
-                {% include "regulation/_items.html.twig" with { pagination: temporaryRegulations } only %}
-                {% include "common/pagination.html.twig" with {
-                    pagination: temporaryRegulations,
-                    currentPage: isTemporaryTab ? app.request.get('page', 1) : 1,
-                    queryParams: app.request.query.all|merge({ tab: 'temporary' }),
-                } only %}
-            </div>
-            <div
-                id="permanent-panel"
-                class="fr-tabs__panel {% if isPermanent %}fr-tabs__panel--selected{% else %}fr-tabs__panel--direction-end{% endif %}"
-                role="tabpanel"
-                aria-labelledby="permanent"
-                tabindex="1"
-            >
-                {% include "regulation/_items.html.twig" with { pagination: permanentRegulations } only %}
-                {% include "common/pagination.html.twig" with {
-                    pagination: permanentRegulations,
-                    currentPage: isPermanent ? app.request.get('page', 1) : 1,
-                    queryParams: app.request.query.all|merge({ tab: 'permanent' }),
-                } only %}
-            </div>
+        <div class="fr-card fr-mt-2w fr-p-2w">
+            {% include "regulation/_items.html.twig" with { pagination: regulations } only %}
+            {% include "common/pagination.html.twig" with {
+                pagination: regulations,
+                currentPage: app.request.get('page', 1),
+                queryParams: app.request.query.all(),
+            } only %}
         </div>
     </section>
 {% endblock %}

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -79,7 +79,7 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
 
         // Go back link
         $goBackLink = $crawler->selectLink('Revenir aux arrêtés');
-        $this->assertSame('/regulations?tab=temporary', $goBackLink->extract(['href'])[0]);
+        $this->assertSame('/regulations', $goBackLink->extract(['href'])[0]);
     }
 
     public function testDraftRegulationDetailAsContributor(): void
@@ -101,7 +101,7 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $this->assertMetaTitle('Arrêté permanent FO3/2023 - DiaLog', $crawler);
 
         $goBackLink = $crawler->selectLink('Revenir aux arrêtés');
-        $this->assertSame('/regulations?tab=permanent', $goBackLink->extract(['href'])[0]);
+        $this->assertSame('/regulations', $goBackLink->extract(['href'])[0]);
     }
 
     public function testDraftRegulationDetailWithoutLocations(): void
@@ -136,22 +136,6 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
         $formDelete = $crawler->filter('aside')->selectButton('Supprimer')->form();
         $this->assertSame($formDelete->getUri(), 'http://localhost/regulations/' . RegulationOrderRecordFixture::UUID_PUBLISHED);
         $this->assertSame($formDelete->getMethod(), 'DELETE');
-    }
-
-    public function testSeeAll(): void
-    {
-        $client = $this->login();
-        $client->request('GET', '/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL);
-
-        $this->assertSecurityHeaders();
-        $this->assertResponseStatusCodeSame(200);
-
-        $crawler = $client->clickLink('Arrêtés de circulation');
-        $this->assertRouteSame('app_regulations_list');
-
-        // Temporary regulation order list is shown.
-        $temporaryPanel = $crawler->filter('#temporary-panel');
-        $this->assertStringContainsString('fr-tabs__panel--selected', $temporaryPanel->attr('class'));
     }
 
     public function testCannotAccessBecauseDifferentOrganization(): void

--- a/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
@@ -64,7 +64,7 @@ final class GetRegulationsQueryHandlerTest extends TestCase
         $regulationOrderRecordRepository
             ->expects(self::once())
             ->method('findAllRegulations')
-            ->with(20, 1, true, ['dcab837f-4460-4355-99d5-bf4891c35f8f'])
+            ->with(20, 1, ['dcab837f-4460-4355-99d5-bf4891c35f8f'])
             ->willReturn([
                 'count' => 3,
                 'items' => $rows,
@@ -74,7 +74,6 @@ final class GetRegulationsQueryHandlerTest extends TestCase
         $regulationOrders = $handler(new GetRegulationsQuery(
             pageSize: 20,
             page: 1,
-            isPermanent: true,
             organizationUuids: ['dcab837f-4460-4355-99d5-bf4891c35f8f'],
         ));
 


### PR DESCRIPTION
* Refs #902 

Cette PR permet de simplifier l'affichage des arrêtés en supprimant les onglets (voir maquette figma) : ![image](https://github.com/user-attachments/assets/3779666b-f2a1-4398-ab83-546aad453e53)

:eyes: 
![image](https://github.com/user-attachments/assets/11071164-f450-44d2-b80d-12293f89a305)
