### PR TITLE
Retire contrainte de longueur sur RawGeoJSON.label

### DIFF
--- a/config/validator/Application/Regulation/Command/SaveRawGeoJSONCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveRawGeoJSONCommand.xml
@@ -5,7 +5,7 @@
     <class name="App\Application\Regulation\Command\Location\SaveRawGeoJSONCommand">
         <property name="label">
             <constraint name="Length">
-                <option name="max">255</option>
+                <option name="max">5000</option>
             </constraint>
             <constraint name="When">
                 <option name="expression">this.roadType === 'rawGeoJSON'</option>

--- a/src/Infrastructure/JOP/JOPTransformer.php
+++ b/src/Infrastructure/JOP/JOPTransformer.php
@@ -97,12 +97,6 @@ final readonly class JOPTransformer
 
             $label = implode(', ', $eventNames);
 
-            if (\strlen($label) > 255) {
-                // Adhere to DB column length
-                $suffix = ' [...]';
-                $label = substr($label, 0, 255 - \strlen($suffix)) . $suffix;
-            }
-
             // CRS is missing in the data but required by PostGIS
             $areaGeometry['crs'] = ['type' => 'name', 'properties' => ['name' => 'EPSG:4326']];
             $sectionsGeometryCollection = $this->roadGeocoder->findSectionsInArea(

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.RawGeoJSON.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.RawGeoJSON.orm.xml
@@ -6,7 +6,7 @@
     name="App\Domain\Regulation\Location\RawGeoJSON"
     table="raw_geojson">
     <id name="uuid" type="guid" column="uuid" />
-    <field name="label" type="string" column="label" nullable="false" length="255" />
+    <field name="label" type="text" column="label" nullable="false"/>
     <one-to-one field="location" target-entity="App\Domain\Regulation\Location\Location" inversed-by="rawGeoJSON">
         <join-column name="location_uuid" referenced-column-name="uuid" on-delete="CASCADE"/>
     </one-to-one>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240820083209.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240820083209.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240820083209 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE raw_geojson ALTER label TYPE TEXT');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE raw_geojson ALTER label TYPE VARCHAR(255)');
+    }
+}

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
@@ -977,6 +977,28 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $this->assertSame('Cette chaîne est trop longue. Elle doit avoir au maximum 50 caractères.', $crawler->filter('#measure_form_locations_0_numberedRoad_roadNumber_error')->text());
     }
 
+    public function testFieldsTooLongRawGeoJSON(): void
+    {
+        $client = $this->login(UserFixture::MAIN_ORG_ADMIN_EMAIL);
+        $crawler = $client->request('GET', '/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/measure/add');
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $saveButton = $crawler->selectButton('Valider');
+        $form = $saveButton->form();
+
+        // Get the raw values.
+        $values = $form->getPhpValues();
+        $values['measure_form']['locations'][0]['roadType'] = 'rawGeoJSON';
+        $values['measure_form']['locations'][0]['rawGeoJSON']['geometry'] = 'geom';
+        $values['measure_form']['locations'][0]['rawGeoJSON']['label'] = str_repeat('a', 5001);
+
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertSame('Cette chaîne est trop longue. Elle doit avoir au maximum 5000 caractères.', $crawler->filter('#measure_form_locations_0_rawGeoJSON_label_error')->text());
+    }
+
     public function testCannotAccessBecauseDifferentOrganization(): void
     {
         $client = $this->login(UserFixture::OTHER_ORG_USER_EMAIL);

--- a/tests/Unit/Infrastructure/JOP/JOPTransformerTest.php
+++ b/tests/Unit/Infrastructure/JOP/JOPTransformerTest.php
@@ -100,7 +100,7 @@ final class JOPTransformerTest extends TestCase
         $locationCommand1 = new SaveLocationCommand();
         $locationCommand1->roadType = RoadTypeEnum::RAW_GEOJSON->value;
         $locationCommand1->rawGeoJSON = new SaveRawGeoJSONCommand();
-        $locationCommand1->rawGeoJSON->label = 'PARA_Marathon, ' . str_repeat('a', 234) . ' [...]';
+        $locationCommand1->rawGeoJSON->label = 'PARA_Marathon, ' . str_repeat('a', 255);
         $locationCommand1->rawGeoJSON->geometry = '<sectionsGeometry1>';
         $locationCommand1->permissions = $permissions;
 


### PR DESCRIPTION
* Vu https://github.com/MTES-MCT/dialog/pull/874#issuecomment-2298245454

Il y avait une limite de 255 caractères sur `RawGeoJSON.label` ce qui très souvent nécessite de tronquer un label qu'on voudrait avoir en entier

Cette PR la retire en passant la colonne en type `TEXT` comme pour `RegulationOrder.description`