### PR TITLE
Ajoute l'URL publique de l'arrêté dans le DATEX

### DIFF
--- a/docs/spec/datex2/DATEXII_3_DiaLogExtension.xsd
+++ b/docs/spec/datex2/DATEXII_3_DiaLogExtension.xsd
@@ -30,6 +30,11 @@
           <xs:documentation>Source of the data in DiaLog.</xs:documentation>
         </xs:annotation>
       </xs:element>
+      <xs:element name="publicUrl" type="xs:string" minOccurs="1" maxOccurs="1">
+        <xs:annotation>
+          <xs:documentation>Link to the public Web page where the regulation order can be viewed in DiaLog.</xs:documentation>
+        </xs:annotation>
+      </xs:element>
     </xs:sequence>
   </xs:complexType>
 

--- a/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandler.php
@@ -139,6 +139,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandler
 
             $regulationOrderViews[] = new RegulationOrderDatexListItemView(
                 uuid: $regulationOrder->getUuid(),
+                regulationOrderRecordUuid: $regulationOrderRecord->getUuid(),
                 regulationId: $regulationOrder->getIdentifier() . '#' . $regulationOrderRecord->getOrganizationUuid(),
                 organization: $regulationOrderRecord->getOrganizationName(),
                 source: $regulationOrderRecord->getSource(),

--- a/src/Application/Regulation/View/RegulationOrderDatexListItemView.php
+++ b/src/Application/Regulation/View/RegulationOrderDatexListItemView.php
@@ -8,6 +8,7 @@ final readonly class RegulationOrderDatexListItemView
 {
     public function __construct(
         public string $uuid,
+        public string $regulationOrderRecordUuid,
         public string $regulationId,
         public string $organization,
         public string $source,

--- a/templates/api/regulations.xml.twig
+++ b/templates/api/regulations.xml.twig
@@ -215,6 +215,7 @@
                 <_trafficRegulationOrderExtension>
                     <trafficRegulationOrderExtended>
                         <dx:source>{{ regulationOrder.source }}</dx:source>
+                        <dx:publicUrl>{{ url('app_regulation_detail', { uuid: regulationOrder.regulationOrderRecordUuid }) }}</dx:publicUrl>
                     </trafficRegulationOrderExtended>
                 </_trafficRegulationOrderExtension>
             </trafficRegulationOrder>

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -559,6 +559,7 @@
             <_trafficRegulationOrderExtension>
                 <trafficRegulationOrderExtended>
                     <dx:source>dialog</dx:source>
+                    <dx:publicUrl>http://localhost/regulations/0654905d-6771-75d8-8000-d523184d0b55</dx:publicUrl>
                 </trafficRegulationOrderExtended>
             </_trafficRegulationOrderExtension>
         </trafficRegulationOrder>
@@ -729,6 +730,7 @@
             <_trafficRegulationOrderExtension>
                 <trafficRegulationOrderExtended>
                     <dx:source>dialog</dx:source>
+                    <dx:publicUrl>http://localhost/regulations/3ede8b1a-1816-4788-8510-e08f45511cb5</dx:publicUrl>
                 </trafficRegulationOrderExtended>
             </_trafficRegulationOrderExtension>
         </trafficRegulationOrder>
@@ -810,6 +812,7 @@
             <_trafficRegulationOrderExtension>
                 <trafficRegulationOrderExtended>
                     <dx:source>dialog</dx:source>
+                    <dx:publicUrl>http://localhost/regulations/9d408332-d30f-4530-be66-dfb2d98ebae5</dx:publicUrl>
                 </trafficRegulationOrderExtended>
             </_trafficRegulationOrderExtension>
         </trafficRegulationOrder>

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
@@ -75,6 +75,10 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
             ->expects(self::once())
             ->method('getRegulationOrder')
             ->willReturn($regulationOrder1);
+        $regulationOrderRecord1
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('066c603a-ca34-75b9-8000-62c82cc0ed11');
         $regulationOrder1
             ->expects(self::once())
             ->method('getUuid')
@@ -336,6 +340,10 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
             ->expects(self::once())
             ->method('getRegulationOrder')
             ->willReturn($regulationOrder2);
+        $regulationOrderRecord2
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('066c603b-c507-75fd-8000-66acdc0f7ba1');
         $regulationOrder2
             ->expects(self::once())
             ->method('getUuid')
@@ -462,6 +470,10 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
             ->expects(self::once())
             ->method('getRegulationOrder')
             ->willReturn($regulationOrder3);
+        $regulationOrderRecord3
+            ->expects(self::once())
+            ->method('getUuid')
+            ->willReturn('066c6040-ab2d-70d6-8000-1de4ad5ed312');
         $regulationOrder3
             ->expects(self::once())
             ->method('getUuid')
@@ -580,6 +592,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
             [
                 new RegulationOrderDatexListItemView(
                     uuid: '247edaa2-58d1-43de-9d33-9753bf6f4d30',
+                    regulationOrderRecordUuid: '066c603a-ca34-75b9-8000-62c82cc0ed11',
                     regulationId: 'F01/2024#56456ff6-7e1c-4d24-aa09-9c650d7f6115',
                     organization: 'Autorité 1',
                     source: RegulationOrderRecordSourceEnum::DIALOG->value,
@@ -607,6 +620,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
                 ),
                 new RegulationOrderDatexListItemView(
                     uuid: '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
+                    regulationOrderRecordUuid: '066c603b-c507-75fd-8000-66acdc0f7ba1',
                     regulationId: 'F02/2024#df1895bf-17af-4d68-adbd-02a7110d3b29',
                     organization: 'Autorité 2',
                     source: RegulationOrderRecordSourceEnum::DIALOG->value,
@@ -637,6 +651,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
                 ),
                 new RegulationOrderDatexListItemView(
                     uuid: '12410fb8-a2b9-4449-a7d5-a4f409807f99',
+                    regulationOrderRecordUuid: '066c6040-ab2d-70d6-8000-1de4ad5ed312',
                     regulationId: 'F03/2024#fde674d4-9e82-42f5-841d-13f7d20b43e0',
                     organization: 'Autorité 3',
                     source: RegulationOrderRecordSourceEnum::DIALOG->value,


### PR DESCRIPTION
* Closes #884 

Elle sera disponible dans l'élément `<dx:publicUrl>` d'un `<trafficRegulationOrder>`