### PR TITLE
Ajoute un filtre de recherche 'Identifiant de l'arrêté'

### DIFF
--- a/assets/styles/utilities/dsfr-extensions/gap.css
+++ b/assets/styles/utilities/dsfr-extensions/gap.css
@@ -1,0 +1,3 @@
+.fr-x-gap-2w {
+    gap: var(--2w);
+}

--- a/assets/styles/utilities/dsfr-extensions/index.scss
+++ b/assets/styles/utilities/dsfr-extensions/index.scss
@@ -1,4 +1,5 @@
 @import './background';
 @import './display';
+@import './gap';
 @import './sizing';
 @import './text';

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
         "easycorp/easyadmin-bundle": "^4.7",
         "jsor/doctrine-postgis": "^2.1",
         "league/commonmark": "^2.4",
+        "martin-georgiev/postgresql-for-doctrine": "^2.6",
         "nelmio/security-bundle": "^3.0",
         "sentry/sentry-symfony": "^4.5",
         "symfony/asset": "6.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b15d56f5e80e3923491c5cbb95805b9f",
+    "content-hash": "daeefccf4aba866694dc157d3e8b73cb",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -2362,6 +2362,85 @@
                 }
             ],
             "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
+            "name": "martin-georgiev/postgresql-for-doctrine",
+            "version": "v2.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/martin-georgiev/postgresql-for-doctrine.git",
+                "reference": "c3e1766528434984497b0e7fa970afe3592389b2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/martin-georgiev/postgresql-for-doctrine/zipball/c3e1766528434984497b0e7fa970afe3592389b2",
+                "reference": "c3e1766528434984497b0e7fa970afe3592389b2",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/dbal": "~2.10||~3.0||~4.0",
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/orm": "~2.14||~3.0",
+                "ekino/phpstan-banned-code": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.62.0",
+                "php-coveralls/php-coveralls": "^2.7.0",
+                "phpstan/phpstan": "^1.11.10",
+                "phpstan/phpstan-phpunit": "^1.4.0",
+                "phpunit/phpunit": "^10.5.30",
+                "qossmic/deptrac": "^2.0.0-alpha",
+                "rector/rector": "^1.2.3",
+                "symfony/cache": "^6.4||^7.0"
+            },
+            "suggest": {
+                "doctrine/orm": "~2.14||~3.0",
+                "php": "^8.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "MartinGeorgiev\\": "src/MartinGeorgiev/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Martin Georgiev",
+                    "email": "martin.georgiev@gmail.com",
+                    "role": "author"
+                }
+            ],
+            "description": "Adds PostgreSQL enhancements to Doctrine. Provides support for JSON, JSONB and some array data types. Provides functions, operators and common expressions used when working with JSON data, arrays and features related to text search.",
+            "keywords": [
+                "array data types",
+                "dbal",
+                "doctrine",
+                "json",
+                "jsonb",
+                "martin georgiev",
+                "postgres",
+                "postgresql",
+                "text search",
+                "tsvector"
+            ],
+            "support": {
+                "issues": "https://github.com/martin-georgiev/postgresql-for-doctrine/issues",
+                "source": "https://github.com/martin-georgiev/postgresql-for-doctrine/tree/v2.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/martin-georgiev",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-17T20:27:52+00:00"
         },
         {
             "name": "monolog/monolog",

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -19,6 +19,7 @@ doctrine:
                 dql:
                     string_functions:
                         FIRST: App\Infrastructure\Persistence\Doctrine\DBAL\FirstFunction
+                        pg_ILIKE: MartinGeorgiev\Doctrine\ORM\Query\AST\Functions\Ilike
                 mappings:
                     Domain:
                         is_bundle: false

--- a/src/Application/Regulation/Query/GetRegulationsQuery.php
+++ b/src/Application/Regulation/Query/GetRegulationsQuery.php
@@ -12,6 +12,7 @@ final readonly class GetRegulationsQuery implements QueryInterface
         public int $pageSize,
         public int $page,
         public ?array $organizationUuids = null,
+        public ?string $identifier = null,
     ) {
     }
 }

--- a/src/Application/Regulation/Query/GetRegulationsQueryHandler.php
+++ b/src/Application/Regulation/Query/GetRegulationsQueryHandler.php
@@ -25,6 +25,7 @@ final class GetRegulationsQueryHandler
             $query->pageSize,
             $query->page,
             $query->organizationUuids,
+            $query->identifier,
         );
 
         foreach ($rows['items'] as $row) {

--- a/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
+++ b/src/Domain/Regulation/Repository/RegulationOrderRecordRepositoryInterface.php
@@ -19,6 +19,7 @@ interface RegulationOrderRecordRepositoryInterface
         int $maxItemsPerPage,
         int $page,
         ?array $organizationUuids = null,
+        ?string $identifier = null,
     ): array;
 
     public function findGeneralInformation(string $uuid): ?array;

--- a/src/Infrastructure/Controller/DTO/ListRegulationsDTO.php
+++ b/src/Infrastructure/Controller/DTO/ListRegulationsDTO.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Controller\DTO;
+
+final class ListRegulationsDTO
+{
+    public ?string $identifier = null;
+}

--- a/src/Infrastructure/Controller/Regulation/ListRegulationsController.php
+++ b/src/Infrastructure/Controller/Regulation/ListRegulationsController.php
@@ -6,12 +6,16 @@ namespace App\Infrastructure\Controller\Regulation;
 
 use App\Application\QueryBusInterface;
 use App\Application\Regulation\Query\GetRegulationsQuery;
+use App\Infrastructure\Controller\DTO\ListRegulationsDTO;
+use App\Infrastructure\Form\Regulation\ListRegulationsFormType;
 use App\Infrastructure\Security\SymfonyUser;
 use Symfony\Bundle\SecurityBundle\Security;
+use Symfony\Component\Form\FormFactoryInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Routing\RouterInterface;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 final class ListRegulationsController
@@ -20,6 +24,8 @@ final class ListRegulationsController
         private \Twig\Environment $twig,
         private QueryBusInterface $queryBus,
         private TranslatorInterface $translator,
+        private RouterInterface $router,
+        private FormFactoryInterface $formFactory,
         private Security $security,
     ) {
     }
@@ -32,6 +38,21 @@ final class ListRegulationsController
     )]
     public function __invoke(Request $request): Response
     {
+        $dto = new ListRegulationsDTO();
+
+        $form = $this->formFactory->create(
+            type: ListRegulationsFormType::class,
+            data: $dto,
+            options: [
+                'action' => $this->router->generate('app_regulations_list'),
+                'method' => 'GET',
+                // CSRF not useful for GET requests (not data is modified). Makes the URL prettier, too.
+                'csrf_protection' => false,
+            ],
+        );
+
+        $form->handleRequest($request);
+
         /** @var SymfonyUser|null */
         $user = $this->security->getUser();
         $pageSize = min($request->query->getInt('pageSize', 20), 100);
@@ -50,6 +71,7 @@ final class ListRegulationsController
                 pageSize: $pageSize,
                 page: $page,
                 organizationUuids: $organizationUserUuids,
+                identifier: $dto->identifier,
             ),
         );
 
@@ -59,6 +81,7 @@ final class ListRegulationsController
                 'regulations' => $regulations,
                 'pageSize' => $pageSize,
                 'page' => $page,
+                'form' => $form->createView(),
             ],
         ));
     }

--- a/src/Infrastructure/Form/Regulation/ListRegulationsFormType.php
+++ b/src/Infrastructure/Form/Regulation/ListRegulationsFormType.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Form\Regulation;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\SubmitType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class ListRegulationsFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add(
+                'identifier',
+                TextType::class,
+                options: [
+                    'label' => 'regulation.list.filters.identifier',
+                    'required' => false,
+                ],
+            )
+            ->add(
+                'save',
+                SubmitType::class,
+                options: [
+                    'label' => 'common.form.search',
+                    'attr' => [
+                        'class' => 'fr-btn fr-btn-load',
+                    ],
+                ],
+            )
+        ;
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/DBAL/CustomPostgreSQLSchemaManager.php
+++ b/src/Infrastructure/Persistence/Doctrine/DBAL/CustomPostgreSQLSchemaManager.php
@@ -9,7 +9,9 @@ use Doctrine\DBAL\Schema\PostgreSQLSchemaManager;
 class CustomPostgreSQLSchemaManager extends PostgreSQLSchemaManager
 {
     private const INDEXES_TO_IGNORE = [
+        // Add custom index here if it triggers error 'The database schema is not in sync with the current mapping file'
         'idx_fr_city_name_departement',
+        'idx_regulation_order_identifier',
     ];
 
     protected function _getPortableTableIndexesList($tableIndexes, $tableName = null): array

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240822144923.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20240822144923.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20240822144923 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // pg_trgm allows PostgreSQL to use index for queries such as "(I)LIKE '%foo%'"
+        // See: https://www.postgresql.org/docs/current/pgtrgm.html#PGTRGM-INDEX
+        $this->addSql('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+        $this->addSql('CREATE INDEX IF NOT EXISTS idx_regulation_order_identifier ON regulation_order USING gist (identifier gist_trgm_ops)');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_regulation_order_identifier');
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -85,11 +85,12 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
 
         if ($identifier) {
             $query
-                ->andWhere('ro.identifier LIKE :identifier');
+                // Doctrine doesn't have ILIKE support for Postgres, we use https://github.com/martin-georgiev/postgresql-for-doctrine
+                ->andWhere('pg_ILIKE(ro.identifier, :identifierPattern) = TRUE');
 
             $parameters = [
                 ...$parameters,
-                'identifier' => \sprintf('%s%%', $identifier),
+                'identifierPattern' => '%' . $identifier . '%',
             ];
         }
 

--- a/templates/regulation/_list_filters_form.html.twig
+++ b/templates/regulation/_list_filters_form.html.twig
@@ -1,0 +1,6 @@
+{{ form_start(form, { attr: { role: 'search' } }) }}
+    <div class="fr-grid-row fr-grid-row--bottom fr-x-gap-2w">
+        {{ form_row(form.identifier, {group_class: 'fr-input-group', row_attr: {class: 'fr-mb-0'}, attr: {class: 'fr-input', spellcheck: false, autocomplete: false} }) }}
+        {{ form_row(form.save) }}
+    </div>
+{{ form_end(form) }}

--- a/templates/regulation/index.html.twig
+++ b/templates/regulation/index.html.twig
@@ -14,7 +14,8 @@
                 </a>
             {% endif %}
         </div>
-        <div class="fr-card fr-mt-2w fr-p-2w">
+        <div class="fr-card fr-grid-row fr-mt-2w fr-p-2w">
+            {% include 'regulation/_list_filters_form.html.twig' with { form } only %}
             {% include "regulation/_items.html.twig" with { pagination: regulations } only %}
             {% include "common/pagination.html.twig" with {
                 pagination: regulations,

--- a/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
@@ -113,7 +113,7 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
         $searchButton = $crawler->selectButton('Rechercher');
         $form = $searchButton->form();
         $values = $form->getPhpValues();
-        $values['list_regulations_form']['identifier'] = 'FO2';
+        $values['list_regulations_form']['identifier'] = 'o2/20'; // Case insensitive, contained anywhere in identifier
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
         $this->assertResponseStatusCodeSame(200);

--- a/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/ListRegulationsControllerTest.php
@@ -103,6 +103,26 @@ final class ListRegulationsControllerTest extends AbstractWebTestCase
         $this->assertSame('http://localhost/regulations/' . RegulationOrderRecordFixture::UUID_PUBLISHED, $links->eq(0)->link()->getUri());
     }
 
+    public function testIdentifierSearch(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/regulations');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+
+        $searchButton = $crawler->selectButton('Rechercher');
+        $form = $searchButton->form();
+        $values = $form->getPhpValues();
+        $values['list_regulations_form']['identifier'] = 'FO2';
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+
+        $this->assertResponseStatusCodeSame(200);
+        $rows = $crawler->filter('.app-regulation-table tbody > tr');
+        $this->assertSame(2, $rows->count());
+        $this->assertSame('FO2/2023', $rows->eq(0)->filter('td')->eq(0)->text());
+        $this->assertSame('FO2/2023-1', $rows->eq(1)->filter('td')->eq(0)->text());
+    }
+
     public function testInvalidPageSize(): void
     {
         $client = $this->login();

--- a/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
@@ -64,7 +64,7 @@ final class GetRegulationsQueryHandlerTest extends TestCase
         $regulationOrderRecordRepository
             ->expects(self::once())
             ->method('findAllRegulations')
-            ->with(20, 1, ['dcab837f-4460-4355-99d5-bf4891c35f8f'])
+            ->with(20, 1, ['dcab837f-4460-4355-99d5-bf4891c35f8f'], null)
             ->willReturn([
                 'count' => 3,
                 'items' => $rows,

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -168,6 +168,10 @@
                 <source>common.form.validate</source>
                 <target>Valider</target>
             </trans-unit>
+            <trans-unit id="common.form.search">
+                <source>common.form.search</source>
+                <target>Rechercher</target>
+            </trans-unit>
             <trans-unit id="common.autocomplete.results_count">
                 <source>common.autocomplete.results_count</source>
                 <target>{0} Aucun résultat | {1} 1 résultat | ]1,Inf[ %count% résultats</target>
@@ -255,6 +259,10 @@
             <trans-unit id="regulation.list.title">
                 <source>regulation.list.title</source>
                 <target>Arrêtés de circulation</target>
+            </trans-unit>
+            <trans-unit id="regulation.list.filters.identifier">
+                <source>regulation.list.filters.identifier</source>
+                <target>Identifiant de l'arrêté</target>
             </trans-unit>
             <trans-unit id="regulation">
                 <source>regulation</source>


### PR DESCRIPTION
* Closes #927 

Cette PR commence l'implémentation des filtres sur la page liste avec... un filtre pas prévu à la base :sweat_smile: 

Elle implémente une recherche "_contains_" sur l'identifiant arrêté (les résultats contiennent les arrêtés dont l'identifiant contient le terme de recherche)

![Screenshot 2024-08-21 at 18-05-54 Arrêtés de circulation - DiaLog](https://github.com/user-attachments/assets/05114a36-dfa0-4d5d-9f00-d3cf9fa05011)

En fait je me mets en avance de phase par rapport à la discussion ici https://github.com/MTES-MCT/dialog/issues/902#issuecomment-2302360246

J'ouvre ce brouillon pour qu'on puisse voir à quoi ça ressemble. Ça m'aurait été très utile pour retrouver facilement un arrêté à partir de son identifiant lors de la review de #874.

TODO

* [x] Aval sur l'idée de ce filtre (daily du 22/08/2024, comme premier filtre pas cher en attendant la reprise du reste)
* [x] Tests
