### PR TITLE
Configure l'import automatique des données Litteralis MEL

### DIFF
--- a/.github/workflows/litteralis_mel_import.yml
+++ b/.github/workflows/litteralis_mel_import.yml
@@ -5,10 +5,6 @@ on:
   # Décommenter quand on est prêt à intégrer les données en production.
   # schedule:
   #   - cron: '0 16 * * 1' # Voir https://crontab.guru/ : tous les lundis à 16h00 GMT
-  # TODO: Décommenter avant de merger
-  push:
-    branches:
-      - feat/litteralis-auto
 
 jobs:
   import:

--- a/.github/workflows/litteralis_mel_import.yml
+++ b/.github/workflows/litteralis_mel_import.yml
@@ -1,16 +1,17 @@
-name: MEL Litteralis Import
+name: Litteralis MEL Import
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '0 16 * * 1' # Voir https://crontab.guru/ : tous les lundis à 16h00
-  # temp
+  # Décommenter quand on est prêt à intégrer les données en production.
+  # schedule:
+  #   - cron: '0 16 * * 1' # Voir https://crontab.guru/ : tous les lundis à 16h00 GMT
+  # TODO: Décommenter avant de merger
   push:
     branches:
       - feat/litteralis-auto
 
 jobs:
-  mel_import:
+  import:
     runs-on: ubuntu-latest
 
     steps:
@@ -55,7 +56,7 @@ jobs:
           echo "APP_MEL_ORG_ID=${{ vars.APP_MEL_ORG_ID }}" >> .env.local
 
       - name: Run import
-        run: make ci_mel_import BIN_PHP="php" BIN_CONSOLE="php bin/console" BIN_COMPOSER="composer"
+        run: make ci_litteralis_mel_import BIN_PHP="php" BIN_CONSOLE="php bin/console" BIN_COMPOSER="composer"
         env:
           APP_MEL_IMPORT_APP: ${{ vars.APP_MEL_IMPORT_APP }}
 

--- a/.github/workflows/mel_import.yml
+++ b/.github/workflows/mel_import.yml
@@ -1,0 +1,73 @@
+name: MEL Litteralis Import
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 16 * * 1' # Voir https://crontab.guru/ : tous les lundis à 16h00
+  # temp
+  push:
+    branches:
+      - feat/litteralis-auto
+
+jobs:
+  mel_import:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Setup PHP with PECL extension
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+
+      - name: Get Composer Cache Directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - uses: actions/cache@v3
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install Scalingo CLI
+        run: curl -O https://cli-dl.scalingo.com/install && bash install
+
+      - name: Install SSH key
+        # Credit: https://stackoverflow.com/a/69234389
+        run: |
+          mkdir -p ~/.ssh
+          install -m 600 -D /dev/null ~/.ssh/id_rsa
+          echo "${{ secrets.GH_SCALINGO_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+
+      - name: Add Scalingo as a known host
+        run: |
+          ssh-keyscan -H ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
+
+      - name: Init environment variables
+        run: |
+          echo "DATABASE_URL=${{ secrets.APP_MEL_IMPORT_DATABASE_URL }}" >> .env.local
+          echo "BDTOPO_DATABASE_URL=${{ secrets.BDTOPO_DATABASE_URL }}" >> .env.local
+          echo "APP_MEL_LITTERALIS_CREDENTIALS=${{ secrets.APP_MEL_LITTERALIS_CREDENTIALS }}" >> .env.local
+          echo "APP_MEL_ORG_ID=${{ vars.APP_MEL_ORG_ID }}" >> .env.local
+
+      - name: Run import
+        run: make ci_mel_import BIN_PHP="php" BIN_CONSOLE="php bin/console" BIN_COMPOSER="composer"
+        env:
+          APP_MEL_IMPORT_APP: ${{ vars.APP_MEL_IMPORT_APP }}
+
+      - name: Get log file path
+        id: logfile
+        if: ${{ !cancelled() }}
+        run:
+          echo "path=$(find log/litteralis -type f -name '*.log' | head -n 1)" >> $GITHUB_OUTPUT
+
+      - uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        with:
+          name: litteralis_logfile
+          path:  ${{ steps.logfile.outputs.path }}
+          retention-days: 21

--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,12 @@ ci_eudonet_paris_import: ## Run CI steps for Eudonet Paris Import workflow
 	./tools/scalingodbtunnel ${EUDONET_PARIS_IMPORT_APP} --host-url --port 10000 & ./tools/wait-for-it.sh 127.0.0.1:10000
 	make console CMD="app:eudonet_paris:import"
 
+ci_mel_import: ## Run CI steps for MEL Import workflow
+	make composer CMD="install -n --prefer-dist"
+	scalingo login --ssh --ssh-identity ~/.ssh/id_rsa
+	./tools/scalingodbtunnel ${APP_MEL_IMPORT_APP} --host-url --port 10000 & ./tools/wait-for-it.sh 127.0.0.1:10000
+	make console CMD="app:mel:import"
+
 ci_bdtopo_migrate: ## Run CI steps for BD TOPO Migrate workflow
 	make composer CMD="install -n --prefer-dist"
 	make bdtopo_migrate

--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ ci_eudonet_paris_import: ## Run CI steps for Eudonet Paris Import workflow
 	./tools/scalingodbtunnel ${EUDONET_PARIS_IMPORT_APP} --host-url --port 10000 & ./tools/wait-for-it.sh 127.0.0.1:10000
 	make console CMD="app:eudonet_paris:import"
 
-ci_mel_import: ## Run CI steps for MEL Import workflow
+ci_litteralis_mel_import: ## Run CI steps for Litteralis MEL Import workflow
 	make composer CMD="install -n --prefer-dist"
 	scalingo login --ssh --ssh-identity ~/.ssh/id_rsa
 	./tools/scalingodbtunnel ${APP_MEL_IMPORT_APP} --host-url --port 10000 & ./tools/wait-for-it.sh 127.0.0.1:10000

--- a/docs/tools/eudonet_paris.md
+++ b/docs/tools/eudonet_paris.md
@@ -66,7 +66,7 @@ Notes :
 
 Les données Eudonet Paris sont automatiquement intégrées en production tous les lundis à 16h30.
 
-Cette automatisation est réalisée au moyen de la GitHub Action [`eudonet_paris_import.yml`](../../workflows/eudonet_paris_import.yml).
+Cette automatisation est réalisée au moyen de [GitHub Actions](./github_actions.md) via le workflow [`eudonet_paris_import.yml`](../../workflows/eudonet_paris_import.yml).
 
 La configuration passe par diverses variables d'environnement résumées ci-dessous :
 
@@ -77,41 +77,3 @@ La configuration passe par diverses variables d'environnement résumées ci-dess
 | `EUDONET_PARIS_IMPORT_DATABASE_URL` | Secret | L'URL d'accès à la base de données par la CI (voir ci-dessous) |
 | `EUDONET_PARIS_IMPORT_ORG_ID` | Variable | Le UUID de l'organisation "Ville de Paris" dans l'environnement défini apr `EUDONET_PARIS_IMPORT_APP` |
 | `GH_SCALINGO_SSH_PRIVATE_KEY` | Secret | Clé SSH privée permettant l'accès à Scalingo par la CI |
-
-### Configuration de l'organisation cible
-
-L'organisation cible de l'import est configurée via la variable `EUDONET_PARIS_IMPORT_ORG_ID` sur GitHub Actions.
-
-### Accès SSH de GitHub Actions à Scalingo
-
-La GitHub Action d'import a besoin d'un accès SSH à Scalingo pour accéder à la base de données de façon sécurisée.
-
-Pour cela des clés SSH ont été générées comme suit :
-
-```bash
-ssh-keygen -t ed25519 -q -N "" -f ~/.ssh/id_dialog_gh_scalingo
-```
-
-La clé publique `~/.ssh/id_dialog_gh_scalingo.pub` ainsi générée a été enregistrée sur Scalingo dans la section [Mes clés SSH](https://dashboard.scalingo.com/account/keys) du compte Scalingo professionnel de @florimondmanca.
-
-> 💡 Pour renouveler les clés, ou en cas de perte, de nouvelles clés peuvent être régénérées en utilisant la méthode ci-dessus, puis rattachées au compte de toute personne ayant un accès "Collaborator" sur l'app Scalingo `dialog`.
-
-La clé privée a été ajoutée comme secret `GH_SCALINGO_SSH_PRIVATE_KEY` au dépôt GitHub et est utilisée par la GitHub Action.
-
-### Accès de GitHub Actions à la base de données sur Scalingo
-
-L'accès à la base de données lors de l'import se fait via un [tunnel chiffré Scalingo](https://doc.scalingo.com/platform/databases/access#encrypted-tunnel).
-
-Le secret `EUDONET_PARIS_IMPORT_DATABASE_URL` doit contenir la `DATABASE_URL` de production où `host:port` est remplacé par `127.0.0.1:10000`.
-
-Si besoin de la reconfigurer, pour obtenir automatiquement cette URL, exécutez :
-
-```bash
-./tools/scalingodbtunnel dialog --host-url
-```
-
-Et recopiez l'URL qui s'affiche.
-
-> Cette commande nécessite le CLI Scalingo, voir [Utiliser une DB Scalingo en local](./db.md#utiliser-une-db-scalingo-en-local).
-
-Sinon il vous faut récupérer la `DATABASE_URL` dans l'interface web Scalingo.

--- a/docs/tools/github_actions.md
+++ b/docs/tools/github_actions.md
@@ -1,0 +1,39 @@
+# GitHub Actions
+
+GitHub Actions est utilisé dans ce projet pour la CI, mais aussi pour l'exécution automatique des intégrations de données.
+
+## Clés SSH pour les imports automatiques
+
+GitHub Actions a besoin d'un accès SSH à Scalingo pour accéder à la base de données de façon sécurisée.
+
+Pour cela des clés SSH ont été générées comme suit :
+
+```bash
+ssh-keygen -t ed25519 -q -N "" -f ~/.ssh/id_dialog_gh_scalingo
+```
+
+La clé publique `~/.ssh/id_dialog_gh_scalingo.pub` ainsi générée a été enregistrée sur Scalingo dans la section [Mes clés SSH](https://dashboard.scalingo.com/account/keys) du compte Scalingo professionnel de @florimondmanca.
+
+> 💡 Pour renouveler les clés, ou en cas de perte, de nouvelles clés peuvent être régénérées en utilisant la méthode ci-dessus, puis rattachées au compte de toute personne ayant un accès "Collaborator" sur l'app Scalingo `dialog`.
+
+La clé privée a été ajoutée comme secret `GH_SCALINGO_SSH_PRIVATE_KEY` au dépôt GitHub et est utilisée par la GitHub Action.
+
+### Accès de GitHub Actions à la base de données sur Scalingo
+
+L'accès à la base de données lors d'un import se fait via un [tunnel chiffré Scalingo](https://doc.scalingo.com/platform/databases/access#encrypted-tunnel).
+
+Le workflow de l'intégration doit faire en sorte qu'une `DATABASE_URL` appropriée soit configurée pour l'application.
+
+Pour obtenir automatiquement cette URL pour l'application `APP`, exécutez :
+
+```bash
+./tools/scalingodbtunnel APP --host-url
+# Exemple pour la prod :
+./tools/scalingodbtunnel dialog --host-url
+```
+
+Et recopiez l'URL qui s'affiche.
+
+> Cette commande nécessite le CLI Scalingo, voir [Utiliser une DB Scalingo en local](./db.md#utiliser-une-db-scalingo-en-local).
+
+Sinon il vous faut récupérer la `DATABASE_URL` dans l'interface web Scalingo.

--- a/docs/tools/litteralis.md
+++ b/docs/tools/litteralis.md
@@ -40,6 +40,24 @@ L'intégration peut être exécutée à l'aide de commandes Symfony spécifiques
 
 **Pour le dev local** : remplir `.env.local` au lieu de `.env.prod`, sauter es étapes 3 et 4 (utiliser votre DB locale), et ne pas inclure le flag `--env=prod`.
 
+## Déploiement périodique automatique
+
+### MEL
+
+Les données la MEL sont automatiquement intégrées en production tous les lundis à 16h00.
+
+Cette automatisation est réalisée au moyen de [GitHub Actions](./github_actions.md) via le workflow [`mel_import.yml`](../../workflows/mel_import.yml).
+
+La configuration passe par diverses variables d'environnement listées ci-dessous :
+
+| Variable d'environnement | Configuration | Description |
+|---|---|---|
+| `APP_MEL_IMPORT_APP` | [Variable](https://docs.github.com/fr/actions/learn-github-actions/variables) au sens GitHub Actions | L'application Scalingo cible (par exemple `dialog` pour la production) |
+| `APP_MEL_LITTERALIS_CREDENTIALS` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | Les identifiants d'accès à l'API Litteralis de la MEL |
+| `APP_MEL_IMPORT_DATABASE_URL` | Secret | L'URL d'accès à la base de données par la CI (`./tools/scalingodbtunnel APP  --host-url`|
+| `APP_MEL_ORG_ID` | Variable | Le UUID de l'organisation "Métropole Européenne de Lille" dans l'environnement défini par `APP_MEL_IMPORT_APP` |
+| `GH_SCALINGO_SSH_PRIVATE_KEY` | Secret | Clé SSH privée permettant l'accès à Scalingo par la CI |
+
 ## Références
 
 * [ADR-010 - Litteralis](../adr/010_litteralis.md)

--- a/docs/tools/litteralis.md
+++ b/docs/tools/litteralis.md
@@ -46,7 +46,7 @@ L'intégration peut être exécutée à l'aide de commandes Symfony spécifiques
 
 Les données la MEL sont automatiquement intégrées en production tous les lundis à 16h00.
 
-Cette automatisation est réalisée au moyen de [GitHub Actions](./github_actions.md) via le workflow [`mel_import.yml`](../../workflows/mel_import.yml).
+Cette automatisation est réalisée au moyen de [GitHub Actions](./github_actions.md) via le workflow [`litteralis_mel_import.yml`](../../workflows/litteralis_mel_import.yml).
 
 La configuration passe par diverses variables d'environnement listées ci-dessous :
 


### PR DESCRIPTION
* Suite de #874 

Cette PR met en place une exécution automatique de l'intégration Litteralis/MEL, les lundis à 16h.

J'ai extrait de la doc Eudonet la partie qui concernait la config GitHub Actions pour les imports, je l'ai mise dans un doc à part `github_actions.md`.

TODO

* [x] Déployer une review app https://dialog-staging-pr926.osc-fr1.scalingo.io/
* [x] Configurer dans GitHub Actions les variables d'environnement nécessaires, en pointant vers la review app
* [x] Exécuter le workflow pour le tester https://github.com/MTES-MCT/dialog/actions/runs/10561737069/job/29258128020