### PR TITLE
RegulationOrderRecordStatusEnum devient un vrai enum

### DIFF
--- a/src/Application/Regulation/Command/PublishRegulationCommandHandler.php
+++ b/src/Application/Regulation/Command/PublishRegulationCommandHandler.php
@@ -21,6 +21,6 @@ final class PublishRegulationCommandHandler
             throw new RegulationOrderRecordCannotBePublishedException();
         }
 
-        $command->regulationOrderRecord->updateStatus(RegulationOrderRecordStatusEnum::PUBLISHED);
+        $command->regulationOrderRecord->updateStatus(RegulationOrderRecordStatusEnum::PUBLISHED->value);
     }
 }

--- a/src/Application/Regulation/Command/SaveRegulationGeneralInfoCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveRegulationGeneralInfoCommandHandler.php
@@ -43,7 +43,7 @@ final class SaveRegulationGeneralInfoCommandHandler
                 new RegulationOrderRecord(
                     uuid: $this->idFactory->make(),
                     source: $command->source,
-                    status: RegulationOrderRecordStatusEnum::DRAFT,
+                    status: RegulationOrderRecordStatusEnum::DRAFT->value,
                     regulationOrder: $regulationOrder,
                     createdAt: $this->now,
                     organization: $command->organization,

--- a/src/Application/Regulation/View/GeneralInfoView.php
+++ b/src/Application/Regulation/View/GeneralInfoView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Application\Regulation\View;
 
+use App\Domain\Regulation\Enum\RegulationOrderRecordStatusEnum;
 use App\Domain\User\OrganizationRegulationAccessInterface;
 
 readonly class GeneralInfoView implements OrganizationRegulationAccessInterface
@@ -29,6 +30,6 @@ readonly class GeneralInfoView implements OrganizationRegulationAccessInterface
 
     public function isDraft(): bool
     {
-        return $this->status === 'draft';
+        return $this->status === RegulationOrderRecordStatusEnum::DRAFT->value;
     }
 }

--- a/src/Domain/Regulation/Enum/RegulationOrderRecordStatusEnum.php
+++ b/src/Domain/Regulation/Enum/RegulationOrderRecordStatusEnum.php
@@ -6,6 +6,6 @@ namespace App\Domain\Regulation\Enum;
 
 enum RegulationOrderRecordStatusEnum: string
 {
-    public const DRAFT = 'draft';
-    public const PUBLISHED = 'published';
+    case DRAFT = 'draft';
+    case PUBLISHED = 'published';
 }

--- a/src/Domain/Regulation/RegulationOrderRecord.php
+++ b/src/Domain/Regulation/RegulationOrderRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Domain\Regulation;
 
+use App\Domain\Regulation\Enum\RegulationOrderRecordStatusEnum;
 use App\Domain\User\Organization;
 use App\Domain\User\OrganizationRegulationAccessInterface;
 
@@ -66,7 +67,7 @@ class RegulationOrderRecord implements OrganizationRegulationAccessInterface, Re
 
     public function isDraft(): bool
     {
-        return $this->status === 'draft';
+        return $this->status === RegulationOrderRecordStatusEnum::DRAFT->value;
     }
 
     public function getSource(): string

--- a/src/Domain/Regulation/Specification/CanViewRegulationDetail.php
+++ b/src/Domain/Regulation/Specification/CanViewRegulationDetail.php
@@ -10,6 +10,6 @@ final class CanViewRegulationDetail
 {
     public function isSatisfiedBy(?string $userId, string $status): bool
     {
-        return $userId || $status === RegulationOrderRecordStatusEnum::PUBLISHED;
+        return $userId || $status === RegulationOrderRecordStatusEnum::PUBLISHED->value;
     }
 }

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderRecordFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderRecordFixture.php
@@ -42,7 +42,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $typicalRegulationOrderRecord = new RegulationOrderRecord(
             self::UUID_TYPICAL,
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::DRAFT,
+            RegulationOrderRecordStatusEnum::DRAFT->value,
             $this->getReference('typicalRegulationOrder'),
             new \DateTime('2022-01-10'),
             $this->getReference('mainOrg'),
@@ -51,7 +51,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $publishedRegulationOrderRecord = new RegulationOrderRecord(
             self::UUID_PUBLISHED,
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::PUBLISHED,
+            RegulationOrderRecordStatusEnum::PUBLISHED->value,
             $this->getReference('publishedRegulationOrder'),
             new \DateTime('2022-01-10'),
             $this->getReference('mainOrg'),
@@ -60,7 +60,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $regulationOrderRecordDuplicate = new RegulationOrderRecord(
             '0658c6bb-045e-74fd-8000-bc704e4e72cb',
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::PUBLISHED,
+            RegulationOrderRecordStatusEnum::PUBLISHED->value,
             $this->getReference('regulationOrderDuplicate'),
             new \DateTime('2022-01-10'),
             $this->getReference('mainOrg'),
@@ -69,7 +69,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $regulationOrderRecordPermanent = new RegulationOrderRecord(
             self::UUID_PERMANENT,
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::DRAFT,
+            RegulationOrderRecordStatusEnum::DRAFT->value,
             $this->getReference('regulationOrderPermanent'),
             new \DateTime('2022-01-11'),
             $this->getReference('mainOrg'),
@@ -78,7 +78,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $otherOrgRegulationOrderRecord = new RegulationOrderRecord(
             self::UUID_OTHER_ORG,
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::DRAFT,
+            RegulationOrderRecordStatusEnum::DRAFT->value,
             $this->getReference('otherOrgRegulationOrder'),
             new \DateTime('2022-01-11'),
             $this->getReference('otherOrg'),
@@ -87,7 +87,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $fullCityRegulationOrderRecord = new RegulationOrderRecord(
             self::UUID_FULL_CITY,
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::DRAFT,
+            RegulationOrderRecordStatusEnum::DRAFT->value,
             $this->getReference('fullCityRegulationOrder'),
             new \DateTime('2022-01-11'),
             $this->getReference('mainOrg'),
@@ -96,7 +96,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $regulationOrderRecordNoLocations = new RegulationOrderRecord(
             self::UUID_NO_LOCATIONS,
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::DRAFT,
+            RegulationOrderRecordStatusEnum::DRAFT->value,
             $this->getReference('regulationOrderNoLocations'),
             new \DateTime('2022-01-10'),
             $this->getReference('mainOrg'),
@@ -105,7 +105,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $regulationOrderRecordNoMeasures = new RegulationOrderRecord(
             self::UUID_NO_MEASURES,
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::DRAFT,
+            RegulationOrderRecordStatusEnum::DRAFT->value,
             $this->getReference('regulationOrderNoMeasures'),
             new \DateTime('2022-01-10'),
             $this->getReference('mainOrg'),
@@ -114,7 +114,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $regulationOrderRecordCifs = new RegulationOrderRecord(
             self::UUID_CIFS,
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::PUBLISHED,
+            RegulationOrderRecordStatusEnum::PUBLISHED->value,
             $this->getReference('regulationOrderCifs'),
             new \DateTime('2023-09-06'),
             $this->getReference('mainOrg'),
@@ -123,7 +123,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $outDatedRegulationOrderRecordCifs = new RegulationOrderRecord(
             '9d408332-d30f-4530-be66-dfb2d98ebae5',
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::PUBLISHED,
+            RegulationOrderRecordStatusEnum::PUBLISHED->value,
             $this->getReference('outDatedRegulationOrderCifs'),
             new \DateTime('2021-11-02'),
             $this->getReference('otherOrg'),
@@ -132,7 +132,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
         $rawGeoJSONRegulationOrderRecord = new RegulationOrderRecord(
             self::UUID_RAWGEOJSON,
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::DRAFT,
+            RegulationOrderRecordStatusEnum::DRAFT->value,
             $this->getReference('rawGeoJSONRegulationOrder'),
             new \DateTime('2020-06-05'),
             $this->getReference('mainOrg'),

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
@@ -103,7 +103,7 @@ final class LocationRepository extends ServiceEntityRepository implements Locati
                 $regulationDatesWhereClause,
             ),
             [
-                'status' => RegulationOrderRecordStatusEnum::PUBLISHED,
+                'status' => RegulationOrderRecordStatusEnum::PUBLISHED->value,
                 'now' => $this->dateUtils->getNow()->format('Y-m-d'),
             ],
         );

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/RegulationOrderRecordRepository.php
@@ -70,14 +70,14 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
                 ->where('(roc.status = :published) OR (roc.status = :draft AND roc.organization IN (:organizationUuids))')
                 ->setParameters([
                     'organizationUuids' => $organizationUuids,
-                    'published' => RegulationOrderRecordStatusEnum::PUBLISHED,
-                    'draft' => RegulationOrderRecordStatusEnum::DRAFT,
+                    'published' => RegulationOrderRecordStatusEnum::PUBLISHED->value,
+                    'draft' => RegulationOrderRecordStatusEnum::DRAFT->value,
                 ]);
         } else {  // the user is not connected -> no draft regulations
             $query
                 ->where('roc.status = :published')
                 ->setParameters([
-                    'published' => RegulationOrderRecordStatusEnum::PUBLISHED,
+                    'published' => RegulationOrderRecordStatusEnum::PUBLISHED->value,
                 ]);
         }
 
@@ -201,7 +201,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->leftJoin('p.timeSlots', 't')
             ->where('roc.status = :status')
             ->setParameters([
-                'status' => RegulationOrderRecordStatusEnum::PUBLISHED,
+                'status' => RegulationOrderRecordStatusEnum::PUBLISHED->value,
             ])
             ->andWhere('loc.geometry IS NOT NULL')
             ->orderBy('roc.uuid')
@@ -239,7 +239,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
                 ...($allowedSources ? ['allowedSources' => $allowedSources] : []),
                 ...($excludedIdentifiers ? ['excludedIdentifiers' => $excludedIdentifiers] : []),
                 ...($allowedLocationIds ? ['allowedLocationIds' => $allowedLocationIds] : []),
-                'status' => RegulationOrderRecordStatusEnum::PUBLISHED,
+                'status' => RegulationOrderRecordStatusEnum::PUBLISHED->value,
                 'measureType' => MeasureTypeEnum::NO_ENTRY->value,
                 'today' => $this->dateUtils->getNow(),
                 'excludedRoadTypes' => [RoadTypeEnum::RAW_GEOJSON->value],
@@ -264,7 +264,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->setParameters([
                 'source' => RegulationOrderRecordSourceEnum::LITTERALIS->value,
                 'organizationId' => $organizationId,
-                'status' => RegulationOrderRecordStatusEnum::PUBLISHED,
+                'status' => RegulationOrderRecordStatusEnum::PUBLISHED->value,
                 'laterThan' => $laterThan,
             ])
             ->getQuery()
@@ -316,7 +316,7 @@ final class RegulationOrderRecordRepository extends ServiceEntityRepository impl
             ->andWhere('o.uuid <> :uuid')
             ->setParameter('uuid', $this->dialogOrgId)
             ->innerJoin('roc.organization', 'o')
-            ->setParameter('status', RegulationOrderRecordStatusEnum::PUBLISHED)
+            ->setParameter('status', RegulationOrderRecordStatusEnum::PUBLISHED->value)
             ->getQuery()
             ->getSingleScalarResult();
     }

--- a/templates/regulation/create.html.twig
+++ b/templates/regulation/create.html.twig
@@ -33,7 +33,10 @@
                     <div class="app-card app-card--raised">
                         <div class="app-card__content">
                             <h3 class="fr-h4">{{ 'regulation.status'|trans }}</h3>
-                                {% include 'regulation/_status_badge.html.twig' with { status: 'draft', withHint: true } %}
+                                {% include 'regulation/_status_badge.html.twig' with {
+                                    status: 'draft',
+                                    withHint: true,
+                                } %}
                             <hr class="fr-mt-2w"/>
 
                             <h3 class="fr-h4">{{ 'common.actions'|trans }}</h3>

--- a/tests/Unit/Application/Regulation/Command/SaveRegulationGeneralInfoCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/SaveRegulationGeneralInfoCommandHandlerTest.php
@@ -74,7 +74,7 @@ final class SaveRegulationGeneralInfoCommandHandlerTest extends TestCase
                     new RegulationOrderRecord(
                         uuid: 'f40f95eb-a7dd-4232-9f03-2db10f04f37f',
                         source: RegulationOrderRecordSourceEnum::DIALOG->value,
-                        status: RegulationOrderRecordStatusEnum::DRAFT,
+                        status: RegulationOrderRecordStatusEnum::DRAFT->value,
                         regulationOrder: $createdRegulationOrder,
                         createdAt: $now,
                         organization: $this->organization,

--- a/tests/Unit/Application/Regulation/Query/GetGeneralInfoQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetGeneralInfoQueryHandlerTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Application\Regulation\Query;
 use App\Application\Regulation\Query\GetGeneralInfoQuery;
 use App\Application\Regulation\Query\GetGeneralInfoQueryHandler;
 use App\Application\Regulation\View\GeneralInfoView;
+use App\Domain\Regulation\Enum\RegulationOrderRecordStatusEnum;
 use App\Domain\Regulation\Exception\RegulationOrderRecordNotFoundException;
 use App\Domain\Regulation\Repository\RegulationOrderRecordRepositoryInterface;
 use PHPUnit\Framework\TestCase;
@@ -22,7 +23,7 @@ final class GetGeneralInfoQueryHandlerTest extends TestCase
             identifier: 'FO1/2024',
             organizationName: 'DiaLog',
             organizationUuid: 'a8439603-40f7-4b1e-8a35-cee9e53b98d4',
-            status: 'draft',
+            status: RegulationOrderRecordStatusEnum::DRAFT->value,
             category: 'other',
             otherCategoryText: 'Other category 1',
             description: 'Description 1',

--- a/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationsQueryHandlerTest.php
@@ -10,6 +10,7 @@ use App\Application\Regulation\View\NamedStreetView;
 use App\Application\Regulation\View\NumberedRoadView;
 use App\Application\Regulation\View\RegulationOrderListItemView;
 use App\Domain\Pagination;
+use App\Domain\Regulation\Enum\RegulationOrderRecordStatusEnum;
 use App\Domain\Regulation\Repository\RegulationOrderRecordRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -24,7 +25,7 @@ final class GetRegulationsQueryHandlerTest extends TestCase
             [
                 'uuid' => '247edaa2-58d1-43de-9d33-9753bf6f4d30',
                 'identifier' => 'F02/2023',
-                'status' => 'draft',
+                'status' => RegulationOrderRecordStatusEnum::DRAFT->value,
                 'startDate' => $startDate1,
                 'endDate' => null,
                 'nbLocations' => 0,
@@ -36,7 +37,7 @@ final class GetRegulationsQueryHandlerTest extends TestCase
             [
                 'uuid' => '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
                 'identifier' => 'F01/2023',
-                'status' => 'draft',
+                'status' => RegulationOrderRecordStatusEnum::DRAFT->value,
                 'startDate' => $startDate2,
                 'endDate' => null,
                 'nbLocations' => 2,
@@ -48,7 +49,7 @@ final class GetRegulationsQueryHandlerTest extends TestCase
             [
                 'uuid' => 'ef5b3632-8525-41b5-9e84-3116d9089610',
                 'identifier' => 'F01/2024',
-                'status' => 'draft',
+                'status' => RegulationOrderRecordStatusEnum::DRAFT->value,
                 'startDate' => $startDate2,
                 'endDate' => null,
                 'nbLocations' => 1,
@@ -82,7 +83,7 @@ final class GetRegulationsQueryHandlerTest extends TestCase
                 new RegulationOrderListItemView(
                     '247edaa2-58d1-43de-9d33-9753bf6f4d30',
                     'F02/2023',
-                    'draft',
+                    RegulationOrderRecordStatusEnum::DRAFT->value,
                     0,
                     'DiaLog',
                     'dcab837f-4460-4355-99d5-bf4891c35f8f',
@@ -93,7 +94,7 @@ final class GetRegulationsQueryHandlerTest extends TestCase
                 new RegulationOrderListItemView(
                     '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
                     'F01/2023',
-                    'draft',
+                    RegulationOrderRecordStatusEnum::DRAFT->value,
                     2,
                     'DiaLog',
                     'dcab837f-4460-4355-99d5-bf4891c35f8f',
@@ -108,7 +109,7 @@ final class GetRegulationsQueryHandlerTest extends TestCase
                 new RegulationOrderListItemView(
                     'ef5b3632-8525-41b5-9e84-3116d9089610',
                     'F01/2024',
-                    'draft',
+                    RegulationOrderRecordStatusEnum::DRAFT->value,
                     1,
                     'DiaLog',
                     'dcab837f-4460-4355-99d5-bf4891c35f8f',

--- a/tests/Unit/Application/Regulation/View/GeneralInfoViewTest.php
+++ b/tests/Unit/Application/Regulation/View/GeneralInfoViewTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Application\Regulation\View;
 
 use App\Application\Regulation\View\GeneralInfoView;
+use App\Domain\Regulation\Enum\RegulationOrderRecordStatusEnum;
 use PHPUnit\Framework\TestCase;
 
 final class GeneralInfoViewTest extends TestCase
@@ -18,7 +19,7 @@ final class GeneralInfoViewTest extends TestCase
             identifier: 'FO1/2024',
             organizationName: 'DiaLog',
             organizationUuid: 'a8439603-40f7-4b1e-8a35-cee9e53b98d4',
-            status: 'draft',
+            status: RegulationOrderRecordStatusEnum::DRAFT->value,
             category: 'other',
             otherCategoryText: 'Other category 1',
             description: 'Description 1',
@@ -33,7 +34,7 @@ final class GeneralInfoViewTest extends TestCase
             identifier: 'FO1/2024',
             organizationName: 'DiaLog',
             organizationUuid: 'a8439603-40f7-4b1e-8a35-cee9e53b98d4',
-            status: 'published',
+            status: RegulationOrderRecordStatusEnum::PUBLISHED->value,
             category: 'other',
             otherCategoryText: 'Other category 1',
             description: 'Description 1',

--- a/tests/Unit/Domain/Regulation/RegulationOrderRecordTest.php
+++ b/tests/Unit/Domain/Regulation/RegulationOrderRecordTest.php
@@ -29,7 +29,7 @@ final class RegulationOrderRecordTest extends TestCase
         $regulationOrderRecord = new RegulationOrderRecord(
             '6598fd41-85cb-42a6-9693-1bc45f4dd392',
             RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::PUBLISHED,
+            RegulationOrderRecordStatusEnum::PUBLISHED->value,
             $regulationOrder,
             $createdAt,
             $organization,
@@ -42,11 +42,11 @@ final class RegulationOrderRecordTest extends TestCase
         $this->assertSame('Dialog', $regulationOrderRecord->getOrganizationName());
         $this->assertSame(RegulationOrderRecordSourceEnum::DIALOG->value, $regulationOrderRecord->getSource());
         $this->assertSame($createdAt, $regulationOrderRecord->getCreatedAt());
-        $this->assertSame(RegulationOrderRecordStatusEnum::PUBLISHED, $regulationOrderRecord->getStatus());
+        $this->assertSame(RegulationOrderRecordStatusEnum::PUBLISHED->value, $regulationOrderRecord->getStatus());
         $this->assertFalse($regulationOrderRecord->isDraft());
 
-        $regulationOrderRecord->updateStatus(RegulationOrderRecordStatusEnum::DRAFT);
-        $this->assertSame(RegulationOrderRecordStatusEnum::DRAFT, $regulationOrderRecord->getStatus());
+        $regulationOrderRecord->updateStatus(RegulationOrderRecordStatusEnum::DRAFT->value);
+        $this->assertSame(RegulationOrderRecordStatusEnum::DRAFT->value, $regulationOrderRecord->getStatus());
         $this->assertTrue($regulationOrderRecord->isDraft());
     }
 }

--- a/tests/Unit/Domain/Regulation/Specification/CanViewRegulationDetailTest.php
+++ b/tests/Unit/Domain/Regulation/Specification/CanViewRegulationDetailTest.php
@@ -21,17 +21,17 @@ final class CanViewRegulationDetailTest extends TestCase
     {
         $this->assertTrue($this->spec->isSatisfiedBy(
             userId: null,
-            status: RegulationOrderRecordStatusEnum::PUBLISHED,
+            status: RegulationOrderRecordStatusEnum::PUBLISHED->value,
         ));
 
         $this->assertTrue($this->spec->isSatisfiedBy(
             userId: '066868b3-accf-7f18-8000-7daddb86cc7a',
-            status: RegulationOrderRecordStatusEnum::PUBLISHED,
+            status: RegulationOrderRecordStatusEnum::PUBLISHED->value,
         ));
 
         $this->assertTrue($this->spec->isSatisfiedBy(
             userId: '066868b3-accf-7f18-8000-7daddb86cc7a',
-            status: RegulationOrderRecordStatusEnum::DRAFT,
+            status: RegulationOrderRecordStatusEnum::DRAFT->value,
         ));
     }
 
@@ -39,7 +39,7 @@ final class CanViewRegulationDetailTest extends TestCase
     {
         $this->assertFalse($this->spec->isSatisfiedBy(
             userId: null,
-            status: RegulationOrderRecordStatusEnum::DRAFT,
+            status: RegulationOrderRecordStatusEnum::DRAFT->value,
         ));
     }
 }


### PR DESCRIPTION
* Vu https://github.com/MTES-MCT/dialog/pull/928#discussion_r1735804763

Je m'assure aussi qu'on l'utilise partout au lieu des strings 'draft' et 'published'