### PR TITLE
EasyAdmin: Ajoute champ Rôles lors de la création d'un User

### DIFF
--- a/src/Infrastructure/Controller/Admin/UserCrudController.php
+++ b/src/Infrastructure/Controller/Admin/UserCrudController.php
@@ -63,8 +63,7 @@ final class UserCrudController extends AbstractCrudController
                 ->setLabel('Rôles')
                 ->allowMultipleChoices()
                 ->setChoices(array_combine($roles, $roles))
-                ->renderAsBadges()
-                ->setDisabled($pageName === Crud::PAGE_EDIT),
+                ->renderAsBadges(),
         ];
 
         $password = TextField::new('password')

--- a/src/Infrastructure/Controller/Admin/UserCrudController.php
+++ b/src/Infrastructure/Controller/Admin/UserCrudController.php
@@ -5,12 +5,14 @@ declare(strict_types=1);
 namespace App\Infrastructure\Controller\Admin;
 
 use App\Application\IdFactoryInterface;
+use App\Domain\User\Enum\UserRolesEnum;
 use App\Domain\User\User;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Config\KeyValueStore;
 use EasyCorp\Bundle\EasyAdminBundle\Context\AdminContext;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
 use EasyCorp\Bundle\EasyAdminBundle\Dto\EntityDto;
+use EasyCorp\Bundle\EasyAdminBundle\Field\ChoiceField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\DateField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\EmailField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
@@ -49,11 +51,19 @@ final class UserCrudController extends AbstractCrudController
 
     public function configureFields(string $pageName): iterable
     {
+        $roles = array_column(UserRolesEnum::cases(), 'value');
+
         $fields = [
             TextField::new('fullName')->setLabel('Prénom / Nom'),
             EmailField::new('email'),
             DateField::new('registrationDate')
                 ->setLabel('Date d\'inscription')
+                ->setDisabled($pageName === Crud::PAGE_EDIT),
+            ChoiceField::new('roles')
+                ->setLabel('Rôles')
+                ->allowMultipleChoices()
+                ->setChoices(array_combine($roles, $roles))
+                ->renderAsBadges()
                 ->setDisabled($pageName === Crud::PAGE_EDIT),
         ];
 


### PR DESCRIPTION
* Vu https://github.com/MTES-MCT/dialog/pull/936#issuecomment-2345636648

Cette PR rend obligatoire le fait de définir les rôles d'un utilisateur quand on le crée manuellement

Ça corrige le bug suivant :

1. Créer un utilisateur de façon "brute" (sans demande d'accès) en allant dans /admin -> "Utilisateurs" -> "Créer"
2. Constater qu'on ne peut pas configurer les Rôles (donc l'array `roles` du `user` sera vide en DB)
3. Créer l'utilisateur
4. Se déconnecter puis se connecter avec le nouvel utilisateur
5. Aller sur /organizations -> Access Denied Exception
    * Raison : `roles` est vide en DB donc l'utilisateur n'a accès qu'aux /organizations
