### PR TITLE
Active l'import automatique Litteralis MEL

### DIFF
--- a/.github/workflows/litteralis_mel_import.yml
+++ b/.github/workflows/litteralis_mel_import.yml
@@ -2,9 +2,8 @@ name: Litteralis MEL Import
 
 on:
   workflow_dispatch:
-  # Décommenter quand on est prêt à intégrer les données en production.
-  # schedule:
-  #   - cron: '0 16 * * 1' # Voir https://crontab.guru/ : tous les lundis à 16h00 GMT
+  schedule:
+    - cron: '0 16 * * 1' # Voir https://crontab.guru/ : tous les lundis à 16h00 GMT
 
 jobs:
   import:


### PR DESCRIPTION
* Suite à #874 et #930 

Cette PR active la CI d'import automatique des données de la MEL

TODO

* [x] Mettre à jour le secret `APP_LITTERALIS_MEL_IMPORT_DATABASE_URL` dans GitHub Actions : utiliser le résultat de `./tools/scalingodbtunnel dialog --host-url`
