### PR TITLE
Remonte le viewport en cas d'erreur dans un formulaire

### DIFF
--- a/assets/controllers/viewport_controller.js
+++ b/assets/controllers/viewport_controller.js
@@ -1,0 +1,36 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+    static targets = ['scroll'];
+
+    constructor(...args) {
+        super(...args);
+
+        // Throttle to scroll the first target and ignore the ones further down for a short delay.
+        // We do this to show the topmost target in the viewport.
+        this._scheduleScroll = throttle((/** @type {HTMLElement} */ element) => {
+            console.log(element);
+            element.scrollIntoView(true);
+        }, 500);
+    }
+
+    scrollTargetConnected(element) {
+        this._scheduleScroll(element);
+    }
+}
+
+function throttle(fn, duration) {
+    let isThrottled = false;
+
+    return (...args) => {
+        if (!isThrottled) {
+            fn(...args);
+
+            isThrottled = true;
+
+            setTimeout(() => {
+                isThrottled = false;
+            }, duration);
+        }
+    }
+}

--- a/templates/common/form/dsfr_theme.html.twig
+++ b/templates/common/form/dsfr_theme.html.twig
@@ -4,6 +4,13 @@ https://github.com/symfony/symfony/blob/6.3/src/Symfony/Bridge/Twig/Resources/vi
 #}
 {% use "form_div_layout.html.twig" %}
 
+{% block form_start %}
+  {% set attr = attr|default({}) %}
+  {% set attr = attr|merge({'data-controller': (attr['data-controller']|default('')) ~ ' viewport'}) %}
+
+  {{ parent() }}
+{% endblock form_start %}
+
 {% block form_row %}
   {%- set widget_attr = {} -%}
   {%- if errors|length > 0 -%}
@@ -171,7 +178,7 @@ https://github.com/symfony/symfony/blob/6.3/src/Symfony/Bridge/Twig/Resources/vi
   {% if errors|length > 0 %}
     <div class="fr-messages-group" id="{{ id }}_error" aria-live="polite">
       {%- for error in errors -%}
-        <p class="fr-message fr-message--error">
+        <p class="fr-message fr-message--error" data-viewport-target="scroll">
           {{ error.message }}
         </p>
       {%- endfor -%}


### PR DESCRIPTION
* Closes #603 

Cette PR branche un contrôler Stimulus sur les messages d'erreur de sorte à déclencher un `scrollIntoView()` quand un tel message d'erreur apparaît dans le DOM

Cela a pour effet de faire remonter la fenêtre si le formulaire est en erreur, au lieu de laisser l'utilisateur en bas au niveau du bouton "Valider"

## Pour tester

* Dans une mesure :
  * Choisir un véhicule concerné "Poids lourds" avec un poids -1 (déclenchera une 1ère erreur)
  * Saisir une date de fin antérieure à la date de début (déclenchera une 2nde erreur)
* Cliquer sur Valider
* Le viewport remonte jusqu'à l'erreur sur le tonnage (les 2 sont visibles)