### PR TITLE
POC : Création d'un endpoint WFS / OGC API Features

### DIFF
--- a/.env
+++ b/.env
@@ -23,6 +23,7 @@ APP_BAC_IDF_DECREES_FILE=data/bac_idf/decrees.json
 APP_BAC_IDF_CITIES_FILE=data/bac_idf/cities.csv
 DATABASE_URL="postgresql://dialog:dialog@database:5432/dialog"
 REDIS_URL="redis://redis:6379"
+PGFS_DATABASE_URL="postgresql://dialog:dialog@database:5432/dialog"
 API_ADRESSE_BASE_URL=https://api-adresse.data.gouv.fr
 APP_IGN_GEOCODER_BASE_URL=https://data.geopf.fr
 MATOMO_ENABLED=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,3 +68,12 @@ services:
       # Allow accessing host ports from this container via host.docker.internal on Linux
       # https://stackoverflow.com/a/43541732
       - host.docker.internal:host-gateway
+
+  pg_featureserv:
+    # https://github.com/crunchydata/pg_featureserv
+    image: pramsey/pg_featureserv:20240706
+    ports:
+      - 8889:8889
+    environment:
+      DATABASE_URL: ${PGFS_DATABASE_URL}
+      PGFS_SERVER_HTTPPORT: 8889


### PR DESCRIPTION
Vu [cette réaction sur LinkedIn](https://www.linkedin.com/posts/jean-roc-morreale-279009293_la-r%C3%A9glementation-routi%C3%A8re-de-la-m%C3%A9tropole-activity-7244616584135159808-lKtp?utm_source=share&utm_medium=member_ios) et la discussion correspondante avec @MathieuFV sur Mattermost

La personne mentionne le standard "OGC API Features" (successeur au WFS si je comprends bien) comme moyen d'exposer nos données sous un format qui soit facilement réutilisable grâce à un large outillage GIS

Il y a des solutions sur étagère auxquelles il "suffit" de donner l'URL de notre DB.

Il "suffirait" donc de construire une vue sur la DB (une `MATERIALIZED VIEW` en PostgreSQL) qui contiendrait ce qu'on veut exposer (en gros je dirais la géométrie + les colonnes permettant de reproduire le contenu d'une popup sur la carto)

Dans cette PR de preuve de concept, je démarre un conteneur du logiciel [pg_featureserv](https://access.crunchydata.com/documentation/pg_featureserv/latest/) (écrit en Go) et ça donne un endpoint d'API avec vue sur la table `location` que je réussis sans problème à charger dans QGIS

Ledit logiciel gère les requêtes faites à PostGIS quand on se déplace / zoome sur la carte. L'API ainsi créée permet aussi de filtrer avec le langage CQL qui fait partie du standard OGC API (même fonctionnement que l'API WFS de Sogelink)

![Capture d’écran du 2024-09-25 12-03-41](https://github.com/user-attachments/assets/37ce1926-c1bd-4507-9e79-b3f9b0fa3d32)
