### PR TITLE
Configure un export Metabase avec l'indicateur "Utilisateurs actifs"

### DIFF
--- a/.github/workflows/metabase_export.yml
+++ b/.github/workflows/metabase_export.yml
@@ -2,9 +2,6 @@ name: Metabase Export
 
 on:
   workflow_dispatch:
-  push:
-    branches: ## TODO retirer avant de merger
-      - feat/metabase-user
   schedule:
     - cron: '0 9 * * 1' # Voir https://crontab.guru/ : tous les lundis à 9h00 GMT
 

--- a/.github/workflows/metabase_export.yml
+++ b/.github/workflows/metabase_export.yml
@@ -27,13 +27,10 @@ jobs:
         run: |
           ssh-keyscan -H ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
 
-      - name: Init environment variables
-        run: |
-          echo "SRC_DATABASE_URL=${{ secrets.METABASE_EXPORT_SRC_DATABASE_URL }}" >> .env.metabase
-          echo "DEST_METABASE_DATABASE_URL=${{ secrets.METABASE_EXPORT_DEST_METABASE_DATABASE_URL }}" >> .env.metabase
-
       - name: Run export
         run: make ci_metabase_export
         env:
           METABASE_SRC_APP: ${{ vars.METABASE_EXPORT_SRC_APP }}
+          METABASE_SRC_DATABASE_URL: ${{ secrets.METABASE_EXPORT_SRC_DATABASE_URL }}
           METABASE_DEST_APP: ${{ vars.METABASE_EXPORT_DEST_APP }}
+          METABASE_DEST_DATABASE_URL: ${{ secrets.METABASE_EXPORT_DEST_DATABASE_URL }}

--- a/.github/workflows/metabase_export.yml
+++ b/.github/workflows/metabase_export.yml
@@ -1,0 +1,39 @@
+name: Metabase Export
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ## TODO retirer avant de merger
+      - feat/metabase-user
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install Scalingo CLI
+        run: curl -O https://cli-dl.scalingo.com/install && bash install
+
+      - name: Install SSH key
+        # Credit: https://stackoverflow.com/a/69234389
+        run: |
+          mkdir -p ~/.ssh
+          install -m 600 -D /dev/null ~/.ssh/id_rsa
+          echo "${{ secrets.GH_SCALINGO_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+
+      - name: Add Scalingo as a known host
+        run: |
+          ssh-keyscan -H ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
+
+      - name: Init environment variables
+        run: |
+          echo "SRC_DATABASE_URL=${{ secrets.METABASE_EXPORT_SRC_DATABASE_URL }}" >> .env.metabase
+          echo "DEST_METABASE_DATABASE_URL=${{ secrets.METABASE_EXPORT_DEST_METABASE_DATABASE_URL }}" >> .env.metabase
+
+      - name: Run export
+        run: make ci_metabase_export
+        env:
+          METABASE_SRC_APP: ${{ vars.METABASE_EXPORT_SRC_APP }}
+          METABASE_DEST_APP: ${{ vars.METABASE_EXPORT_DEST_APP }}

--- a/.github/workflows/metabase_export.yml
+++ b/.github/workflows/metabase_export.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches: ## TODO retirer avant de merger
       - feat/metabase-user
+  schedule:
+    - cron: '0 9 * * 1' # Voir https://crontab.guru/ : tous les lundis à 9h00 GMT
 
 jobs:
   build:

--- a/Makefile
+++ b/Makefile
@@ -263,9 +263,8 @@ ci_bdtopo_migrate: ## Run CI steps for BD TOPO Migrate workflow
 
 ci_metabase_export: ## Export data to Metabase
 	scalingo login --ssh --ssh-identity ~/.ssh/id_rsa
-	./tools/scalingodbtunnel ${METABASE_SRC_APP} --host-url --port 10000 & ./tools/wait-for-it.sh 127.0.0.1:10000
 	./tools/scalingodbtunnel ${METABASE_DEST_APP} --host-url --port 10001 & ./tools/wait-for-it.sh 127.0.0.1:10001
-	./tools/metabase-export.sh
+	./tools/metabase-export.sh ${METABASE_SRC_DATABASE_URL} ${METABASE_DEST_DATABASE_URL}
 
 ##
 ## ----------------

--- a/Makefile
+++ b/Makefile
@@ -261,6 +261,12 @@ ci_bdtopo_migrate: ## Run CI steps for BD TOPO Migrate workflow
 	make composer CMD="install -n --prefer-dist"
 	make bdtopo_migrate
 
+ci_metabase_export: ## Export data to Metabase
+	scalingo login --ssh --ssh-identity ~/.ssh/id_rsa
+	./tools/scalingodbtunnel ${METABASE_SRC_APP} --host-url --port 10000 & ./tools/wait-for-it.sh 127.0.0.1:10000
+	./tools/scalingodbtunnel ${METABASE_DEST_APP} --host-url --port 10001 & ./tools/wait-for-it.sh 127.0.0.1:10001
+	./tools/metabase-export.sh
+
 ##
 ## ----------------
 ## Prod

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -53,22 +53,32 @@ L'infrastructure d'un environnement est déployée et gérée par Scalingo et s'
 * Le serveur PHP communique avec la base de données Redis, notamment pour le stockage des sessions utilisateurs.
 * Le serveur PHP communique avec des services tiers :
   * API Adresse : géocodage d'adresses.
-  * Sentry : collecte et analyse des erreurs applicatives.
-  * Matomo : collecte et analyse de données de trafic utilisateur.
+  * [BD TOPO](../tools/bdtopo.md) : données géographiques (hébergées sur l'app `dialog-bdtopo`).
+  * [Sentry](../tools/monitoring.md) : collecte et analyse des erreurs applicatives.
+  * [Matomo](../tools/analytics.md) : collecte et analyse de données de trafic utilisateur.
+  * [Metabase](../tools/metabase.md) : statistiques et suivi d'indicateurs (hébergé sur l'app `dialog-metabase`).
 
 Diagramme :
 
 ```
-                    Scalingo
-        ┌---------------------------------┐  ┌ - - - - - - ┐
-WWW ------ nginx (:443) --- php --------┬----  API Adresse
+                                            dialog-bdtopo
+                                             ┌ - - - - ┐
+                                        ┌----  BD TOPO
+                                        |    └ - - - - ┘
+                      dialog            |
+        ┌-------------------------------|-┐  ┌ - - - - - - ┐
+WWW ------ nginx (:443) --- php --------┼----  API Adresse
         |                    |          | |  └ - - - - - - ┘
         |               ┌----┴----┐     | |  ┌ - - - -┐
         |           ┌ - ┴ - ┐ ┌ - ┴ - ┐ ├----  Sentry
         |             PgSQL     Redis   | |  └ - - - -┘
-        |           └ - - - ┘ └ - - - ┘ | |  ┌ - - - -┐
-        |                               └----  Matomo
-        └---------------------------------┘  └ - - - -┘
+        |           └ - ┬ - ┘ └ - - - ┘ | |  ┌ - - - -┐
+        |               |               └----  Matomo
+        └---------------|-----------------┘  └ - - - -┘
+                        | dialog-metabase
+                        |  ┌ - - - - -┐ 
+                        └--  Metabase
+                           └ - - - - -┘
 ```
 
 ### Ressources
@@ -77,12 +87,14 @@ Voici, à date, une liste des ressources utilisées dans un environnement.
 
 | Ressource | Localisation | Contact |
 |-----------|------|---------|
-| Application Scalingo | Scalingo BetaGouv | tristan.robert[ @ ]beta.gouv.fr |
-| Base de données PostgreSQL | Scalingo BetaGouv (add-on) | tristan.robert[ @ ]beta.gouv.fr |
-| Serveur Redis | Scalingo BetaGouv (add-on) | tristan.robert[ @ ]beta.gouv.fr |
+| Application Scalingo | Scalingo BetaGouv (`dialog`) | tristan.robert[ @ ]beta.gouv.fr |
+| Base de données PostgreSQL | Scalingo BetaGouv (`dialog`, add-on) | tristan.robert[ @ ]beta.gouv.fr |
+| Serveur Redis | Scalingo BetaGouv (`dialog`, add-on) | tristan.robert[ @ ]beta.gouv.fr |
 | Enregistrement DNS | Zone DNS de BetaGouv | tristan.robert[ @ ]beta.gouv.fr |
+| BD TOPO | Scalingo BetaGouv (`dialog-bdtopo`) |  tristan.robert[ @ ]beta.gouv.fr
 | Projet Sentry | [Sentry de BetaGouv](https://sentry.incubateur.net) | tristan.robert[ @ ]beta.gouv.fr |
 | Site Matomo | [Matomo BetaGouv](https://stats.beta.gouv.fr) | ~incubateur-ops |
+| Metabase et son PostgreSQL | Scalingo BetaGouv (`dialog-metabase`) |  tristan.robert[ @ ]beta.gouv.fr |
 
 ### Configuration
 

--- a/docs/tools/litteralis.md
+++ b/docs/tools/litteralis.md
@@ -46,7 +46,7 @@ L'intégration peut être exécutée à l'aide de commandes Symfony spécifiques
 
 Les données la MEL sont automatiquement intégrées en production tous les lundis à 16h00.
 
-Cette automatisation est réalisée au moyen de [GitHub Actions](./github_actions.md) via le workflow [`litteralis_mel_import.yml`](../../workflows/litteralis_mel_import.yml).
+Cette automatisation est réalisée au moyen de [GitHub Actions](./github_actions.md) via le workflow [`litteralis_mel_import.yml`](../../.github/workflows/litteralis_mel_import.yml).
 
 La configuration passe par diverses variables d'environnement listées ci-dessous :
 
@@ -54,7 +54,7 @@ La configuration passe par diverses variables d'environnement listées ci-dessou
 |---|---|---|
 | `APP_MEL_IMPORT_APP` | [Variable](https://docs.github.com/fr/actions/learn-github-actions/variables) au sens GitHub Actions | L'application Scalingo cible (par exemple `dialog` pour la production) |
 | `APP_MEL_LITTERALIS_CREDENTIALS` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | Les identifiants d'accès à l'API Litteralis de la MEL |
-| `APP_MEL_IMPORT_DATABASE_URL` | Secret | L'URL d'accès à la base de données par la CI (`./tools/scalingodbtunnel APP  --host-url`|
+| `APP_MEL_IMPORT_DATABASE_URL` | Secret | L'URL d'accès à la base de données par la CI (`./tools/scalingodbtunnel APP  --host-url`) |
 | `APP_MEL_ORG_ID` | Variable | Le UUID de l'organisation "Métropole Européenne de Lille" dans l'environnement défini par `APP_MEL_IMPORT_APP` |
 | `GH_SCALINGO_SSH_PRIVATE_KEY` | Secret | Clé SSH privée permettant l'accès à Scalingo par la CI |
 

--- a/docs/tools/metabase.md
+++ b/docs/tools/metabase.md
@@ -10,18 +10,22 @@ Vous devez disposer d'un compte pour y accéder. Demandez pour cela à un membre
 
 Le Metabase de DiaLog est hébergé sur Scalingo sous l'application `dialog-metabase`. (Demandez à un membre de l'équipe de vous ajouter à cette application pour y avoir accès.)
 
-Conformément aux recommendations Beta, une base de données dédiée aux données Metabase a été créée afin de la séparer des données de production. Elle est hébergée sur l'application `dialog-metabase` via un add-on PostgreSQL, comme indiqué dans [cette doc](https://doc.incubateur.net/communaute/les-outils-de-la-communaute/autres-services/metabase/metabase#connecter-metabase-a-une-base-de-donnees-anonymisee).
+Cette application dispose de sa propre base de données où nous stockons les données nécessaires au calcul des indicateurs, conformément aux [recommendations Beta](https://doc.incubateur.net/communaute/les-outils-de-la-communaute/autres-services/metabase/metabase#connecter-metabase-a-une-base-de-donnees-anonymisee)
 
-## Lancer l'export
+La collecte des données d'indicateur est réalisée au moyen d'un [script](../../tools/metabase-export.sh). Ce script exécute des requêtes SQL depuis la base Metabase vers la base applicative. Pour cela un utilisateur `dialog_metabase` avec droits en lecture seule a été créé sur la base applicative (identifiants dans le Vaultwarden de l'équipe DiaLog).
+
+## Lancer l'export depuis GitHub Actions
 
 L'export Metabase peut être déclenché via [GitHub Actions](./github_actions.md) à l'aide du workflow [`metabase_export.yml`](../../.github/workflows/metabase_export.yml).
 
-La configuration passe par diverses variables d'environnement listées ci-dessous :
+### Configuration
+
+La configuration de la GitHub Action passe par diverses variables d'environnement listées ci-dessous :
 
 | Variable d'environnement | Configuration | Description |
 |---|---|---|
 | `METABASE_EXPORT_SRC_APP` | [Variable](https://docs.github.com/fr/actions/learn-github-actions/variables) au sens GitHub Actions | `dialog` (pour la production) |
-| `METABASE_EXPORT_DEST_APP` | [Variable](https://docs.github.com/fr/actions/learn-github-actions/variables) au sens GitHub Actions | `dialog-metabase` |
-| `METABASE_EXPORT_SRC_DATABASE_URL` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | L'URL d'accès à la base de données applicative par la CI (`./tools/scalingodbtunnel dialog  --host-url`) |
-| `METABASE_EXPORT_DEST_METABASE_DATABASE_URL` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | L'URL d'accès à la base de données Metabase par la CI (`./tools/scalingodbtunnel dialog-metabase  --host-url --port 10001`) |
+| `METABASE_EXPORT_SRC_DATABASE_URL` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | L'URL d'accès à la base de données applicative par la DB Metabase : utiliser la `METABASE_EXPORT_SRC_DATABASE_URL` de l'app `dialog` |
+| `METABASE_EXPORT_DEST_APP` | Variable | `dialog-metabase` |
+| `METABASE_EXPORT_DEST_DATABASE_URL` | Secret | L'URL d'accès à la base de données Metabase par la CI (`./tools/scalingodbtunnel dialog-metabase  --host-url --port 10001`) |
 | `GH_SCALINGO_SSH_PRIVATE_KEY` | Secret | Clé SSH privée permettant l'accès à Scalingo par la CI |

--- a/docs/tools/metabase.md
+++ b/docs/tools/metabase.md
@@ -1,0 +1,27 @@
+# Metabase
+
+Conformément aux usages de la communauté beta.gouv.fr, DiaLog utilise Metabase pour la collecte de statistiques relatives à son utilisation.
+
+L'instance Metabase est accessible ici : https://dialog-metabase.osc-fr1.scalingo.io/
+
+Vous devez disposer d'un compte pour y accéder. Demandez pour cela à un membre de l'équipe.
+
+## Aperçu de l'installation
+
+Le Metabase de DiaLog est hébergé sur Scalingo sous l'application `dialog-metabase`. (Demandez à un membre de l'équipe de vous ajouter à cette application pour y avoir accès.)
+
+Conformément aux recommendations Beta, une base de données dédiée aux données Metabase a été créée afin de la séparer des données de production. Elle est hébergée sur l'application `dialog-metabase` via un add-on PostgreSQL, comme indiqué dans [cette doc](https://doc.incubateur.net/communaute/les-outils-de-la-communaute/autres-services/metabase/metabase#connecter-metabase-a-une-base-de-donnees-anonymisee).
+
+## Lancer l'export
+
+L'export Metabase peut être déclenché via [GitHub Actions](./github_actions.md) à l'aide du workflow [`metabase_export.yml`](../../.github/workflows/metabase_export.yml).
+
+La configuration passe par diverses variables d'environnement listées ci-dessous :
+
+| Variable d'environnement | Configuration | Description |
+|---|---|---|
+| `METABASE_EXPORT_SRC_APP` | [Variable](https://docs.github.com/fr/actions/learn-github-actions/variables) au sens GitHub Actions | `dialog` (pour la production) |
+| `METABASE_EXPORT_DEST_APP` | [Variable](https://docs.github.com/fr/actions/learn-github-actions/variables) au sens GitHub Actions | `dialog-metabase` |
+| `METABASE_EXPORT_SRC_DATABASE_URL` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | L'URL d'accès à la base de données applicative par la CI (`./tools/scalingodbtunnel dialog  --host-url`) |
+| `METABASE_EXPORT_DEST_METABASE_DATABASE_URL` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | L'URL d'accès à la base de données Metabase par la CI (`./tools/scalingodbtunnel dialog-metabase  --host-url --port 10001`) |
+| `GH_SCALINGO_SSH_PRIVATE_KEY` | Secret | Clé SSH privée permettant l'accès à Scalingo par la CI |

--- a/tools/metabase-export.sh
+++ b/tools/metabase-export.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Inspiré de : https://doc.incubateur.net/communaute/les-outils-de-la-communaute/autres-services/metabase/metabase#connecter-metabase-a-une-base-de-donnees-anonymisee
+set -euxo pipefail
+
+source .env.metabase ## Créé dans le workflow GitHub Actions
+
+# Création des tables (persistera dans la DB source jusqu'à prochaine exécution de ce script)
+
+psql $SRC_DATABASE_URL -c "DROP TABLE IF EXISTS analytics_user"
+psql $SRC_DATABASE_URL -c "
+CREATE TABLE analytics_user AS
+SELECT
+  uuid_generate_v4() AS id,
+  u.registration_date
+FROM \"user\" AS u"
+psql $SRC_DATABASE_URL -c "ALTER TABLE analytics_user ADD PRIMARY KEY (id)"
+
+# Création des index
+
+# Copie vers la DB Metabase
+
+pg_dump $SRC_DATABASE_URL -O -x -t analytics_user -c | psql "$DEST_METABASE_DATABASE_URL"

--- a/tools/metabase-export.sql
+++ b/tools/metabase-export.sql
@@ -1,0 +1,31 @@
+-- metabase-export.sql
+-- Ce script est conçu pour être exécuté sur la base de données PostgreSQL de l'instance Metabase (destination).
+-- Il consiste à extraire des données de la base applicative (source) pour les charger dans des tables Metabase.
+
+-- Configuration générale
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- CONNEXION À LA DB APPLICATIVE (source)
+-- Voir : https://www.postgresql.org/docs/current/contrib-dblink-connect.html
+CREATE EXTENSION IF NOT EXISTS dblink;
+SELECT dblink_connect('src', current_setting('custom.src_database_url'));
+
+-- COLLECTE DES DONNÉES D'INDICATEURS
+
+-- # Utilisateurs actifs
+-- À chaque exécution, on ajoute la liste des dates de dernière activité pour chaque utilisateur, assortie de la date d'exécution.
+-- Dans Metabase cela permet de calculer le nombre d'utilisateurs actif au moment de chaque exécution.
+-- (Par exemple avec un filtre : "[last_active_at] >= [uploaded_at] - 7 jours", puis en groupant sur le uploaded_at.)
+CREATE TABLE IF NOT EXISTS analytics_user_active (id UUID NOT NULL, uploaded_at TIMESTAMP(0), last_active_at TIMESTAMP(0), PRIMARY KEY(id));
+CREATE INDEX IF NOT EXISTS idx_analytics_user_active_uploaded_at ON analytics_user_active (uploaded_at);
+
+WITH params AS (
+    -- Calculé 1 bonne fois pour toute pour que toutes les lignes utilisent exactement la même valeur à des fins de groupement dans Metabase
+    SELECT NOW() as current_date
+)
+INSERT INTO analytics_user_active(id, uploaded_at, last_active_at)
+SELECT uuid_generate_v4() AS id, p.current_date AS uploaded_at, u.last_active_at AS last_active_at
+FROM
+    dblink('src', 'SELECT last_active_at FROM "user"') AS u(last_active_at TIMESTAMP(0) WITH TIME ZONE),
+    params AS p
+;


### PR DESCRIPTION
* Contribue à #564 

La PR inclut les données permettant de calculer l'indicateur "Utilisateurs actifs"

TODO

* [x] Script d'export avec [dblink](https://www.postgresql.org/docs/current/contrib-dblink-function.html)
* [x] Documentation sur la configuration Metabase (config inspirée de cette [doc BetaGouv](https://doc.incubateur.net/communaute/les-outils-de-la-communaute/autres-services/metabase/metabase))
* [x] GitHub Action d'exécution automatique (tous les lundis à 09h00 UTC)
* [x] Ajouter les secrets au repo
* [x] (Avant de merger) Dans le workflow, retirer l'exécution sur cette branche
