### PR TITLE
Visas et Motifs dans un arrêté (Partie 1)

### DIFF
--- a/config/validator/Application/Regulation/Command/SaveRegulationGeneralInfoCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveRegulationGeneralInfoCommand.xml
@@ -66,6 +66,20 @@
                 <option name="type">\DateTimeInterface</option>
             </constraint>
         </property>
+        <property name="additionalVisas">
+            <constraint name="All">
+                <option name="constraints">
+                    <constraint name="NotBlank"/>
+                </option>
+            </constraint>
+        </property>
+        <property name="additionalReasons">
+            <constraint name="All">
+                <option name="constraints">
+                    <constraint name="NotBlank"/>
+                </option>
+            </constraint>
+        </property>
         <constraint name="App\Infrastructure\Validator\SaveRegulationGeneralInfoCommandConstraint" />
     </class>
 </constraint-mapping>

--- a/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
+++ b/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
@@ -55,6 +55,8 @@ final class DuplicateRegulationCommandHandler
         $generalInfo->description = $originalRegulationOrder->getDescription();
         $generalInfo->startDate = $originalRegulationOrder->getStartDate();
         $generalInfo->endDate = $originalRegulationOrder->getEndDate();
+        $generalInfo->additionalVisas = $originalRegulationOrder->getAdditionalVisas();
+        $generalInfo->additionalReasons = $originalRegulationOrder->getAdditionalReasons();
 
         return $this->commandBus->handle($generalInfo);
     }

--- a/src/Application/Regulation/Command/SaveRegulationGeneralInfoCommand.php
+++ b/src/Application/Regulation/Command/SaveRegulationGeneralInfoCommand.php
@@ -20,6 +20,8 @@ final class SaveRegulationGeneralInfoCommand implements CommandInterface
     public ?Organization $organization;
     public ?\DateTimeInterface $startDate;
     public ?\DateTimeInterface $endDate = null;
+    public array $additionalVisas = [];
+    public array $additionalReasons = [];
 
     public function __construct(
         public readonly ?RegulationOrderRecord $regulationOrderRecord = null,
@@ -40,6 +42,8 @@ final class SaveRegulationGeneralInfoCommand implements CommandInterface
         $command->description = $regulationOrder?->getDescription();
         $command->startDate = $startDate ?? $regulationOrder?->getStartDate();
         $command->endDate = $regulationOrder?->getEndDate();
+        $command->additionalVisas = $regulationOrder?->getAdditionalVisas() ?? [];
+        $command->additionalReasons = $regulationOrder?->getAdditionalReasons() ?? [];
 
         return $command;
     }

--- a/src/Application/Regulation/Command/SaveRegulationGeneralInfoCommandHandler.php
+++ b/src/Application/Regulation/Command/SaveRegulationGeneralInfoCommandHandler.php
@@ -36,6 +36,8 @@ final class SaveRegulationGeneralInfoCommandHandler
                     startDate: $command->startDate,
                     endDate: $command->endDate,
                     otherCategoryText: $command->otherCategoryText,
+                    additionalVisas: $command->additionalVisas,
+                    additionalReasons: $command->additionalReasons,
                 ),
             );
 
@@ -61,6 +63,8 @@ final class SaveRegulationGeneralInfoCommandHandler
             startDate: $command->startDate,
             endDate: $command->endDate,
             otherCategoryText: $command->otherCategoryText,
+            additionalVisas: $command->additionalVisas,
+            additionalReasons: $command->additionalReasons,
         );
 
         return $command->regulationOrderRecord;

--- a/src/Domain/Regulation/RegulationOrder.php
+++ b/src/Domain/Regulation/RegulationOrder.php
@@ -95,7 +95,7 @@ class RegulationOrder
         return $this->additionalVisas;
     }
 
-    public function getaAdditionalReasons(): ?array
+    public function getAdditionalReasons(): ?array
     {
         return $this->additionalReasons;
     }
@@ -107,6 +107,8 @@ class RegulationOrder
         \DateTimeInterface $startDate,
         ?\DateTimeInterface $endDate = null,
         ?string $otherCategoryText = null,
+        array $additionalVisas = [],
+        array $additionalReasons = [],
     ): void {
         $this->identifier = $identifier;
         $this->category = $category;
@@ -114,5 +116,7 @@ class RegulationOrder
         $this->startDate = $startDate;
         $this->endDate = $endDate;
         $this->otherCategoryText = $otherCategoryText;
+        $this->additionalVisas = $additionalVisas;
+        $this->additionalReasons = $additionalReasons;
     }
 }

--- a/src/Infrastructure/Form/Regulation/GeneralInfoFormType.php
+++ b/src/Infrastructure/Form/Regulation/GeneralInfoFormType.php
@@ -11,6 +11,7 @@ use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\Form\Extension\Core\Type\SubmitType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
@@ -91,6 +92,38 @@ final class GeneralInfoFormType extends AbstractType
                 options: [
                     'label' => 'regulation.general_info.description',
                     'help' => 'regulation.general_info.description.help',
+                ],
+            )
+            ->add(
+                'additionalVisas',
+                CollectionType::class,
+                options: [
+                    'entry_type' => TextareaType::class,
+                    'label' => null,
+                    'prototype_name' => '__visa_name__',
+                    'entry_options' => [
+                        'label' => 'regulation.general_info.visa',
+                    ],
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'keep_as_list' => true,
+                    'error_bubbling' => false,
+                ],
+            )
+            ->add(
+                'additionalReasons',
+                CollectionType::class,
+                options: [
+                    'entry_type' => TextareaType::class,
+                    'label' => null,
+                    'prototype_name' => '__reason_name__',
+                    'entry_options' => [
+                        'label' => 'regulation.general_info.reason',
+                    ],
+                    'allow_add' => true,
+                    'allow_delete' => true,
+                    'keep_as_list' => true,
+                    'error_bubbling' => false,
                 ],
             )
             ->add(

--- a/templates/regulation/_general_info_form.html.twig
+++ b/templates/regulation/_general_info_form.html.twig
@@ -1,33 +1,128 @@
+{% macro collection_item(form, index) %}
+    <li
+        class="app-card app-card--no-header fr-mb-2w"
+        data-controller="remove"
+        data-remove-target="this"
+        data-form-collection-target="collectionItem"
+    >
+        <div class="app-card__content">
+            {{ form_row(form, {group_class: 'fr-input-group', attr: {class: 'fr-input'}}) }}
+        </div>
+        <div class="app-card__actions">
+            <button
+                type="button"
+                class="fr-btn fr-btn--sm fr-btn--secondary fr-icon-delete-bin-line"
+                data-action="remove#removeElement"
+                aria-label="{{ 'common.delete'|trans }}"
+            >
+            </button>
+        </div>
+    </li>
+{% endmacro %}
+
 <div class="app-card app-card--raised">
-    <div class="app-card__header">
-        <span class="app-card__img fr-icon-article-fill fr-x-icon-decorative--blue-france fr-x-icon--xl" aria-hidden="true"></span>
-        <h3 class="app-card__title fr-h4 fr-mb-0">
-            {{ form.description.vars.value|default('regulation.general_info'|trans)|u.truncate(36, '...', false) }}
-        </h3>
-    </div>
     <div class="app-card__content">
         {{ form_start(form) }}
-            {{ form_row(form.identifier, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
-            {{ form_row(form.organization, {group_class: 'fr-select-group', widget_class: 'fr-select'}) }}
-            <div class="fr-fieldset" data-controller="form-reveal">
-                <div class="fr-fieldset__element">
-                    {{ form_row(form.category, {
-                        group_class: 'fr-select-group',
-                        widget_class: 'fr-select',
-                        attr: {
-                            'data-controller': 'condition',
-                            'data-condition-equals-value': 'other',
-                            'data-action': 'change->condition#dispatchFromInputChange condition:yes->form-reveal#open condition:no->form-reveal#close',
-                        }
-                    }) }}
+            <div class="fr-tabs fr-mb-3w">
+                <ul class="fr-tabs__list" role="tablist" aria-label="{{ 'regulation.general_info'|trans }}">
+                    <li role="presentation">
+                        <button type="button" id="general-form" class="fr-tabs__tab" tabindex="0" role="tab" aria-selected="true" aria-controls="general-form-panel">
+                            {{ 'regulation.general_info'|trans }}
+                        </button>
+                    </li>
+                    <li role="presentation">
+                        <button type="button" id="reasons" class="fr-tabs__tab" tabindex="-1" role="tab" aria-selected="false" aria-controls="reasons-panel">
+                            {{ 'regulation.general_info.visas_and_reasons'|trans }}
+                        </button>
+                    </li>
+                </ul>
+                <div id="general-form-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="general-form" tabindex="0">
+                    {{ form_row(form.identifier, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
+                    {{ form_row(form.organization, {group_class: 'fr-select-group', widget_class: 'fr-select'}) }}
+                    <div class="fr-fieldset" data-controller="form-reveal">
+                        <div class="fr-fieldset__element">
+                            {{ form_row(form.category, {
+                                group_class: 'fr-select-group',
+                                widget_class: 'fr-select',
+                                attr: {
+                                    'data-controller': 'condition',
+                                    'data-condition-equals-value': 'other',
+                                    'data-action': 'change->condition#dispatchFromInputChange condition:yes->form-reveal#open condition:no->form-reveal#close',
+                                }
+                            }) }}
+                        </div>
+                        <div id="otherCategoryText-output" class="fr-fieldset__element" data-form-reveal-target="section" {% if form.category.vars.value != 'other' %}hidden{% endif %}>
+                            {{ form_row(form.otherCategoryText, { group_class: 'fr-input-group', widget_class: 'fr-input', attr: { 'data-form-reveal-target': 'form-control' } }) }}
+                        </div>
+                    </div>
+                    {{ form_row(form.description, {group_class: 'fr-input-group', attr: {class: 'fr-input'}, help_attr: {class: 'fr-hint-text'}}) }}
+                    {{ form_row(form.startDate, {group_class: 'fr-input-group', widget_class: 'fr-input', row_attr: {class: 'fr-col-12 fr-col-sm-6 fr-col-lg-5'}}) }}
+                    {{ form_row(form.endDate, {group_class: 'fr-input-group', widget_class: 'fr-input', row_attr: {class: 'fr-col-12 fr-col-sm-6 fr-col-lg-5'}}) }}
                 </div>
-                <div id="otherCategoryText-output" class="fr-fieldset__element" data-form-reveal-target="section" {% if form.category.vars.value != 'other' %}hidden{% endif %}>
-                    {{ form_row(form.otherCategoryText, { group_class: 'fr-input-group', widget_class: 'fr-input', attr: { 'data-form-reveal-target': 'form-control' } }) }}
+                <div id="reasons-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="reasons" tabindex="0">
+                    <p>{{ 'regulation.general_info.visas_and_reasons.description'|trans }}</p>
+                    <div
+                        class="fr-mb-2w"
+                        data-controller="form-collection"
+                        data-form-collection-prototype-key-value="visa"
+                        data-form-collection-next-index-value="{{ form.additionalVisas|length > 0 ? form.additionalVisas|last.vars.name + 1 : 0 }}"
+                        data-form-collection-prototype-value="{{ _self.collection_item(form.additionalVisas.vars.prototype, '__visa_name__')|e('html_attr') }}"
+                    >
+                        <h3 class="fr-h4">{{ 'regulation.general_info.visas'|trans }}</h3>
+                        <p class="fr-text--sm">{{ 'regulation.general_info.visas.help'|trans }}</p>
+                        {{ form_errors(form.additionalVisas) }}
+                        <ul
+                            id="visa-list"
+                            class="fr-raw-list"
+                            data-form-collection-target="collectionContainer"
+                        >
+                            {% for item in form.additionalVisas %}
+                                {{ _self.collection_item(item) }}
+                            {% else %}
+                                {% do form.additionalVisas.setRendered %}
+                            {% endfor %}
+                        </ul>
+                        <button
+                            type="button"
+                            class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-add-line"
+                            data-action="form-collection#addCollectionElement"
+                            aria-controls="visa-list"
+                        >
+                            {{ 'visa.add'|trans }}
+                        </button>
+                    </div>
+                    <div
+                        class="fr-mb-2w"
+                        data-controller="form-collection"
+                        data-form-collection-prototype-key-value="reason"
+                        data-form-collection-next-index-value="{{ form.additionalReasons|length > 0 ? form.additionalReasons|last.vars.name + 1 : 0 }}"
+                        data-form-collection-prototype-value="{{ _self.collection_item(form.additionalReasons.vars.prototype, '__reason_name__')|e('html_attr') }}"
+                    >
+                        <h3 class="fr-h4">{{ 'regulation.general_info.reasons'|trans }}</h3>
+                        <p class="fr-text--sm">{{ 'regulation.general_info.reasons.help'|trans }}</p>
+                        {{ form_errors(form.additionalReasons) }}
+                        <ul
+                            id="reason-list"
+                            class="fr-raw-list"
+                            data-form-collection-target="collectionContainer"
+                        >
+                            {% for item in form.additionalReasons %}
+                                {{ _self.collection_item(item) }}
+                            {% else %}
+                                {% do form.additionalReasons.setRendered %}
+                            {% endfor %}
+                        </ul>
+                        <button
+                            type="button"
+                            class="fr-btn fr-btn--tertiary fr-btn--icon-left fr-icon-add-line"
+                            data-action="form-collection#addCollectionElement"
+                            aria-controls="reason-list"
+                        >
+                            {{ 'regulation.general_info.reasons.add'|trans }}
+                        </button>
+                    </div>
                 </div>
             </div>
-            {{ form_row(form.description, {group_class: 'fr-input-group', attr: {class: 'fr-input'}, help_attr: {class: 'fr-hint-text'}}) }}
-            {{ form_row(form.startDate, {group_class: 'fr-input-group', widget_class: 'fr-input', row_attr: {class: 'fr-col-12 fr-col-sm-6 fr-col-lg-5'}}) }}
-            {{ form_row(form.endDate, {group_class: 'fr-input-group', widget_class: 'fr-input', row_attr: {class: 'fr-col-12 fr-col-sm-6 fr-col-lg-5'}}) }}
             <a href="{{ cancelUrl }}" class="fr-btn fr-btn--tertiary fr-mr-3w">
                 {{ "common.cancel"|trans }}
             </a>

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/SaveRegulationGeneralInfoControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/SaveRegulationGeneralInfoControllerTest.php
@@ -20,29 +20,28 @@ final class SaveRegulationGeneralInfoControllerTest extends AbstractWebTestCase
 
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
-        $this->assertSame('Description 3', $crawler->filter('h3')->text());
 
         $saveButton = $crawler->selectButton('Valider');
         $form = $saveButton->form();
         $identifier = RegulationOrderFixture::TYPICAL_IDENTIFIER;
-        $form['general_info_form[identifier]'] = $identifier;
-        $form['general_info_form[organization]'] = OrganizationFixture::MAIN_ORG_ID;
-        $form['general_info_form[category]'] = RegulationOrderCategoryEnum::ROAD_MAINTENANCE->value;
-        $form['general_info_form[description]'] = 'Travaux';
-        $form['general_info_form[startDate]'] = '2023-02-12';
-        $form['general_info_form[endDate]'] = '2024-02-11';
-        $crawler = $client->submit($form);
+
+        // Get the raw values.
+        $values = $form->getPhpValues();
+        $values['general_info_form']['identifier'] = $identifier;
+        $values['general_info_form']['organization'] = OrganizationFixture::MAIN_ORG_ID;
+        $values['general_info_form']['description'] = 'Interdiction de circuler dans Paris';
+        $values['general_info_form']['startDate'] = '2023-02-12';
+        $values['general_info_form']['endDate'] = '2024-02-11';
+        $values['general_info_form']['category'] = RegulationOrderCategoryEnum::ROAD_MAINTENANCE->value;
+        $values['general_info_form']['otherCategoryText'] = 'Travaux';
+        $values['general_info_form']['additionalVisas'][0] = 'Vu 1';
+        $values['general_info_form']['additionalVisas'][1] = 'Vu 2';
+        $values['general_info_form']['additionalReasons'][0] = 'Motif 1';
+        $values['general_info_form']['additionalReasons'][1] = 'Motif 2';
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+
         $this->assertResponseStatusCodeSame(422);
         $this->assertSame(\sprintf('Un arrêté avec l\'identifiant "%s" existe déjà. Veuillez saisir un autre identifiant.', $identifier), $crawler->filter('#general_info_form_identifier_error')->text());
-    }
-
-    public function testEditDescriptionTruncated(): void
-    {
-        $client = $this->login();
-        $crawler = $client->request('GET', '/_fragment/regulations/general_info/form/' . RegulationOrderRecordFixture::UUID_LONG_DESCRIPTION);
-        $this->assertResponseStatusCodeSame(200);
-        $this->assertSecurityHeaders();
-        $this->assertSame('Description 5 that is very long and...', $crawler->filter('h3')->text());
     }
 
     public function testRegulationOrderRecordNotFound(): void
@@ -62,12 +61,19 @@ final class SaveRegulationGeneralInfoControllerTest extends AbstractWebTestCase
 
         $saveButton = $crawler->selectButton('Valider');
         $form = $saveButton->form();
-        $form['general_info_form[identifier]'] = 'FIOIUS';
-        $form['general_info_form[organization]'] = OrganizationFixture::OTHER_ORG_ID;
-        $form['general_info_form[description]'] = 'Interdiction de circuler dans Paris';
-        $form['general_info_form[startDate]'] = '2023-02-14';
-        $form['general_info_form[category]'] = RegulationOrderCategoryEnum::ROAD_MAINTENANCE->value;
-        $client->submit($form);
+
+        // Get the raw values.
+        $values = $form->getPhpValues();
+        $values['general_info_form']['identifier'] = 'FIOIUS';
+        $values['general_info_form']['organization'] = OrganizationFixture::OTHER_ORG_ID;
+        $values['general_info_form']['description'] = 'Interdiction de circuler dans Paris';
+        $values['general_info_form']['startDate'] = '2023-02-14';
+        $values['general_info_form']['category'] = RegulationOrderCategoryEnum::ROAD_MAINTENANCE->value;
+        $values['general_info_form']['additionalVisas'][0] = 'Vu 1';
+        $values['general_info_form']['additionalVisas'][1] = 'Vu 2';
+        $values['general_info_form']['additionalReasons'][0] = 'Motif 1';
+        $values['general_info_form']['additionalReasons'][1] = 'Motif 2';
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
         $this->assertResponseStatusCodeSame(303);
 
         $client->followRedirect();
@@ -98,6 +104,27 @@ final class SaveRegulationGeneralInfoControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(422);
         $this->assertSame('Cette chaîne est trop longue. Elle doit avoir au maximum 60 caractères.', $crawler->filter('#general_info_form_identifier_error')->text());
         $this->assertSame('Cette chaîne est trop longue. Elle doit avoir au maximum 255 caractères.', $crawler->filter('#general_info_form_description_error')->text());
+    }
+
+    public function testEmptyReasonsAndVisas(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/_fragment/regulations/general_info/form/' . RegulationOrderRecordFixture::UUID_TYPICAL);
+        $this->assertResponseStatusCodeSame(200);
+
+        $saveButton = $crawler->selectButton('Valider');
+        $form = $saveButton->form();
+
+        // Get the raw values.
+        $values = $form->getPhpValues();
+        $values['general_info_form']['additionalVisas'][0] = '';
+        $values['general_info_form']['additionalReasons'][0] = '';
+
+        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#general_info_form_additionalVisas_0_error')->text());
+        $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#general_info_form_additionalReasons_0_error')->text());
     }
 
     public function testCannotAccessBecauseDifferentOrganization(): void

--- a/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
@@ -284,6 +284,16 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
             ->willReturn($endDate);
 
         $this->originalRegulationOrder
+            ->expects(self::once())
+            ->method('getAdditionalVisas')
+            ->willReturn(['Vu 1']);
+
+        $this->originalRegulationOrder
+            ->expects(self::once())
+            ->method('getAdditionalReasons')
+            ->willReturn(['Motif 1']);
+
+        $this->originalRegulationOrder
             ->expects(self::exactly(2))
             ->method('getMeasures')
             ->willReturn([$measure1, $measure2]);
@@ -308,6 +318,8 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
         $generalInfoCommand->startDate = $startDate;
         $generalInfoCommand->endDate = $endDate;
         $generalInfoCommand->organization = $originalOrganization;
+        $generalInfoCommand->additionalVisas = ['Vu 1'];
+        $generalInfoCommand->additionalReasons = ['Motif 1'];
 
         $vehicleSetCommand = new SaveVehicleSetCommand();
         $vehicleSetCommand->allVehicles = true;

--- a/tests/Unit/Domain/Regulation/RegulationOrderTest.php
+++ b/tests/Unit/Domain/Regulation/RegulationOrderTest.php
@@ -44,7 +44,7 @@ final class RegulationOrderTest extends TestCase
         $this->assertFalse($regulationOrder->isPermanent());
         $this->assertSame($visaModel, $regulationOrder->getVisaModel());
         $this->assertSame(['vu que 1'], $regulationOrder->getAdditionalVisas());
-        $this->assertSame(['considérant que'], $regulationOrder->getaAdditionalReasons());
+        $this->assertSame(['considérant que'], $regulationOrder->getAdditionalReasons());
     }
 
     public function testUpdate(): void

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -428,6 +428,42 @@
                 <source>regulation.general_info</source>
                 <target>Informations générales</target>
             </trans-unit>
+            <trans-unit id="regulation.general_info.visas_and_reasons">
+                <source>regulation.general_info.visas_and_reasons</source>
+                <target>Visas et motifs</target>
+            </trans-unit>
+            <trans-unit id="regulation.general_info.visas">
+                <source>regulation.general_info.visas</source>
+                <target>Visas</target>
+            </trans-unit>
+            <trans-unit id="regulation.general_info.visas.help">
+                <source>regulation.general_info.visas.help</source>
+                <target>Ajouter les visas que vous souhaitez voir dans votre arrêté. Par exemple, “Vu le code de la route...”.</target>
+            </trans-unit>
+            <trans-unit id="regulation.general_info.reasons.help">
+                <source>regulation.general_info.reasons.help</source>
+                <target>Ajouter les motifs que vous souhaitez voir dans votre arrêté. Par exemple, “Considérant qu'en raison du déroulement des travaux de...”.</target>
+            </trans-unit>
+            <trans-unit id="regulation.general_info.reasons.add">
+                <source>regulation.general_info.reasons.add</source>
+                <target>Ajouter un motif</target>
+            </trans-unit>
+            <trans-unit id="regulation.general_info.visa">
+                <source>regulation.general_info.visa</source>
+                <target>Visa (Vu ...)</target>
+            </trans-unit>
+            <trans-unit id="regulation.general_info.reason">
+                <source>regulation.general_info.reason</source>
+                <target>Motif (Considérant ...)</target>
+            </trans-unit>
+            <trans-unit id="regulation.general_info.reasons">
+                <source>regulation.general_info.reasons</source>
+                <target>Motifs</target>
+            </trans-unit>
+            <trans-unit id="regulation.general_info.visas_and_reasons.description">
+                <source>regulation.general_info.visas_and_reasons.description</source>
+                <target>Vous pouvez exporter votre arrêté de circulation à partir de Dialog, pour cela vous devez spécifier les visas (Vu le ...) et les motifs (Considérant...).</target>
+            </trans-unit>
             <trans-unit id="regulation.general_info.identifier">
                 <source>regulation.general_info.identifier</source>
                 <target>Identifiant</target>


### PR DESCRIPTION
* Refs #992

Cette PR est la première partie de l'implémentation "Visas et Motifs" dans un arrêté.
 
Je voudrais séparer la partie choix du modèle dans une autre PR car ce n'est pas encore sec d'un point de vue design et allons tester une implémentation. En résumé (discussion sur Mattermost), le choix du modèle va dépendre du choix de l'organisation dans l'onglet information générale.

![image](https://github.com/user-attachments/assets/02fa0358-7d46-4b1e-8bd1-b6964fab3882)