### PR TITLE
Corrige import Litteralis : Undefined array key "regulationId"

### DIFF
--- a/src/Infrastructure/Litteralis/LitteralisExtractor.php
+++ b/src/Infrastructure/Litteralis/LitteralisExtractor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Litteralis;
 
+use App\Infrastructure\IntegrationReport\CommonRecordEnum;
 use App\Infrastructure\IntegrationReport\Reporter;
 
 final class LitteralisExtractor
@@ -44,9 +45,9 @@ final class LitteralisExtractor
             if (empty($feature['geometry'])) {
                 // Parfois la 'geometry' est absente
                 $reporter->addWarning(LitteralisRecordEnum::WARNING_MISSING_GEOMETRY->value, [
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => $identifier,
+                    CommonRecordEnum::ATTR_URL->value => $feature['properties']['shorturl'],
                     'idemprise' => $feature['properties']['idemprise'],
-                    'arretesrcid' => $identifier,
-                    'shorturl' => $feature['properties']['shorturl'],
                 ]);
                 continue;
             }

--- a/src/Infrastructure/Litteralis/LitteralisPeriodParser.php
+++ b/src/Infrastructure/Litteralis/LitteralisPeriodParser.php
@@ -7,6 +7,7 @@ namespace App\Infrastructure\Litteralis;
 use App\Application\Regulation\Command\Period\SavePeriodCommand;
 use App\Application\Regulation\Command\Period\SaveTimeSlotCommand;
 use App\Domain\Condition\Period\Enum\PeriodRecurrenceTypeEnum;
+use App\Infrastructure\IntegrationReport\CommonRecordEnum;
 use App\Infrastructure\IntegrationReport\Reporter;
 
 final class LitteralisPeriodParser
@@ -52,9 +53,9 @@ final class LitteralisPeriodParser
             $reporter->addError(
                 LitteralisRecordEnum::ERROR_DATE_PARSING_FAILED->value,
                 [
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
+                    CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
                     'idemprise' => $properties['idemprise'],
-                    'arretesrcid' => $properties['arretesrcid'],
-                    'shorturl' => $properties['shorturl'],
                     $startDateProperty => $properties[$startDateProperty],
                     'format' => $dateFormat,
                 ],
@@ -79,9 +80,9 @@ final class LitteralisPeriodParser
             $reporter->addError(
                 LitteralisRecordEnum::ERROR_DATE_PARSING_FAILED->value,
                 [
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
+                    CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
                     'idemprise' => $properties['idemprise'],
-                    'arretesrcid' => $properties['arretesrcid'],
-                    'shorturl' => $properties['shorturl'],
                     $endDateProperty => $properties[$endDateProperty],
                     'format' => $dateFormat,
                 ],
@@ -165,9 +166,9 @@ final class LitteralisPeriodParser
         // * 'de 21h00 à 06h00 du lundi soir au samedi matin'
 
         $reporter->addError(LitteralisRecordEnum::ERROR_PERIOD_UNPARSABLE->value, [
+            CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
+            CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
             'idemprise' => $properties['idemprise'],
-            'arretesrcid' => $properties['arretesrcid'],
-            'shorturl' => $properties['shorturl'],
             'jours et horaires' => $value,
         ]);
 

--- a/src/Infrastructure/Litteralis/LitteralisTransformer.php
+++ b/src/Infrastructure/Litteralis/LitteralisTransformer.php
@@ -17,6 +17,7 @@ use App\Domain\Regulation\Enum\RoadTypeEnum;
 use App\Domain\Regulation\Enum\VehicleTypeEnum;
 use App\Domain\Regulation\Specification\CanUseRawGeoJSON;
 use App\Domain\User\Organization;
+use App\Infrastructure\IntegrationReport\CommonRecordEnum;
 use App\Infrastructure\IntegrationReport\Reporter;
 
 final readonly class LitteralisTransformer
@@ -95,8 +96,8 @@ final readonly class LitteralisTransformer
         // Il faut donc zapper cet arrêté.
         if (\count($measureCommands) === 0) {
             $reporter->addNotice(LitteralisRecordEnum::NOTICE_NO_MEASURES_FOUND->value, [
-                'arretesrcid' => $properties['arretesrcid'],
-                'shorturl' => $properties['shorturl'],
+                CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
+                CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
             ]);
 
             return null;
@@ -170,8 +171,8 @@ final readonly class LitteralisTransformer
             $command->startDate = $startDate;
         } else {
             $reporter->addError(LitteralisRecordEnum::ERROR_REGULATION_START_DATE_PARSING_FAILED->value, [
-                'arretesrcid' => $properties['arretesrcid'],
-                'shorturl' => $properties['shorturl'],
+                CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
+                CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
                 'arretedebut' => $properties['arretedebut'],
             ]);
         }
@@ -187,8 +188,8 @@ final readonly class LitteralisTransformer
             $command->endDate = $endDate;
         } else {
             $reporter->addError(LitteralisRecordEnum::ERROR_REGULATION_END_DATE_PARSING_FAILED->value, [
-                'arretesrcid' => $properties['arretesrcid'],
-                'shorturl' => $properties['shorturl'],
+                CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
+                CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
                 'arretefin' => $properties['arretefin'],
             ]);
         }
@@ -257,9 +258,9 @@ final readonly class LitteralisTransformer
         foreach ($allMeasureNames as $name) {
             if (!\array_key_exists($name, self::MEASURE_MAP)) {
                 $reporter->addNotice(LitteralisRecordEnum::NOTICE_UNSUPPORTED_MEASURE->value, [
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
                     'name' => $name,
                     'idemprise' => $properties['idemprise'],
-                    'arretesrcid' => $properties['arretesrcid'],
                 ]);
                 continue;
             }
@@ -316,9 +317,9 @@ final readonly class LitteralisTransformer
                     // Le numéro indiqué ne correspond pas au 1-index de la mesure dans 'mesures'.
                     // On traite ce cas comme une erreur car on ne peut pas savoir à quelle mesure ces paramètres se rattachent.
                     $reporter->addError(LitteralisRecordEnum::ERROR_MEASURE_PARAMETER_INCONSISTENT_NUMBER->value, [
+                        CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
+                        CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
                         'idemprise' => $properties['idemprise'],
-                        'arretesrcid' => $properties['arretesrcid'],
-                        'shorturl' => $properties['shorturl'],
                         'measureName' => $name,
                         'expected' => $index + 1,
                         'actual' => $number,
@@ -415,9 +416,9 @@ final readonly class LitteralisTransformer
 
         if (!$value) {
             $reporter->addError(LitteralisRecordEnum::ERROR_MAX_SPEED_VALUE_MISSING->value, [
+                CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
+                CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
                 'idemprise' => $properties['idemprise'],
-                'arretesrcid' => $properties['arretesrcid'],
-                'shorturl' => $properties['shorturl'],
                 'mesures' => $properties['mesures'],
             ]);
 
@@ -426,9 +427,9 @@ final readonly class LitteralisTransformer
 
         if (!preg_match('/^(?P<speed>\d+)/i', $value, $matches)) {
             $reporter->addError(LitteralisRecordEnum::ERROR_MAX_SPEED_VALUE_INVALID->value, [
+                CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
+                CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
                 'idemprise' => $properties['idemprise'],
-                'arretesrcid' => $properties['arretesrcid'],
-                'shorturl' => $properties['shorturl'],
                 'limite de vitesse' => $value,
             ]);
 

--- a/tests/Unit/Infrastructure/Litteralis/LitteralisExtractorTest.php
+++ b/tests/Unit/Infrastructure/Litteralis/LitteralisExtractorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Infrastructure\Litteralis;
 
+use App\Infrastructure\IntegrationReport\CommonRecordEnum;
 use App\Infrastructure\IntegrationReport\Reporter;
 use App\Infrastructure\Litteralis\LitteralisClient;
 use App\Infrastructure\Litteralis\LitteralisExtractor;
@@ -95,8 +96,8 @@ final class LitteralisExtractorTest extends TestCase
             ->method('addWarning')
             ->with(LitteralisRecordEnum::WARNING_MISSING_GEOMETRY->value, [
                 'idemprise' => 'emprise4',
-                'arretesrcid' => 'arrete3',
-                'shorturl' => 'https://dl.sogelink.fr/?n3omzTyS',
+                CommonRecordEnum::ATTR_REGULATION_ID->value => 'arrete3',
+                CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
             ]);
 
         $extractor = new LitteralisExtractor($this->client);

--- a/tests/Unit/Infrastructure/Litteralis/LitteralisTransformerTest.php
+++ b/tests/Unit/Infrastructure/Litteralis/LitteralisTransformerTest.php
@@ -20,6 +20,7 @@ use App\Domain\Regulation\Enum\RoadTypeEnum;
 use App\Domain\Regulation\Enum\VehicleTypeEnum;
 use App\Domain\Regulation\Specification\CanUseRawGeoJSON;
 use App\Domain\User\Organization;
+use App\Infrastructure\IntegrationReport\CommonRecordEnum;
 use App\Infrastructure\IntegrationReport\RecordTypeEnum;
 use App\Infrastructure\IntegrationReport\Reporter;
 use App\Infrastructure\Litteralis\LitteralisPeriodParser;
@@ -285,28 +286,28 @@ final class LitteralisTransformerTest extends TestCase
                 RecordTypeEnum::ERROR->value,
                 [
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_REGULATION_START_DATE_PARSING_FAILED->value,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
+                    CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
                     'arretedebut' => 'BAD FORMAT',
-                    'arretesrcid' => '24-A-0126',
-                    'shorturl' => 'https://dl.sogelink.fr/?n3omzTyS',
                 ],
             ],
             [
                 RecordTypeEnum::ERROR->value,
                 [
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_REGULATION_END_DATE_PARSING_FAILED->value,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
+                    CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
                     'arretefin' => 'BAD FORMAT',
-                    'arretesrcid' => '24-A-0126',
-                    'shorturl' => 'https://dl.sogelink.fr/?n3omzTyS',
                 ],
             ],
             [
                 RecordTypeEnum::ERROR->value,
                 [
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_DATE_PARSING_FAILED->value,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
+                    CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
                     'arretedebut' => 'BAD FORMAT',
                     'idemprise' => 493136,
-                    'arretesrcid' => '24-A-0126',
-                    'shorturl' => 'https://dl.sogelink.fr/?n3omzTyS',
                     'format' => \DateTimeInterface::ISO8601,
                 ],
             ],
@@ -314,10 +315,10 @@ final class LitteralisTransformerTest extends TestCase
                 RecordTypeEnum::ERROR->value,
                 [
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_DATE_PARSING_FAILED->value,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
+                    CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
                     'arretefin' => 'BAD FORMAT',
                     'idemprise' => 493136,
-                    'arretesrcid' => '24-A-0126',
-                    'shorturl' => 'https://dl.sogelink.fr/?n3omzTyS',
                     'format' => \DateTimeInterface::ISO8601,
                 ],
             ],
@@ -325,9 +326,9 @@ final class LitteralisTransformerTest extends TestCase
                 RecordTypeEnum::ERROR->value,
                 [
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_MAX_SPEED_VALUE_MISSING->value,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
+                    CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
                     'idemprise' => 493136,
-                    'arretesrcid' => '24-A-0126',
-                    'shorturl' => 'https://dl.sogelink.fr/?n3omzTyS',
                     'mesures' => 'Limitation de vitesse',
                 ],
             ],
@@ -335,9 +336,9 @@ final class LitteralisTransformerTest extends TestCase
                 RecordTypeEnum::ERROR->value,
                 [
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_MAX_SPEED_VALUE_INVALID->value,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
+                    CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
                     'idemprise' => 493136,
-                    'arretesrcid' => '24-A-0126',
-                    'shorturl' => 'https://dl.sogelink.fr/?n3omzTyS',
                     'limite de vitesse' => 'foo km/h',
                 ],
             ],
@@ -345,9 +346,9 @@ final class LitteralisTransformerTest extends TestCase
                 RecordTypeEnum::ERROR->value,
                 [
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_MEASURE_PARAMETER_INCONSISTENT_NUMBER->value,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
+                    CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
                     'idemprise' => 493136,
-                    'arretesrcid' => '24-A-0126',
-                    'shorturl' => 'https://dl.sogelink.fr/?n3omzTyS',
                     'measureName' => 'Circulation interdite 4',
                     'expected' => 1,
                     'actual' => 4,
@@ -357,9 +358,9 @@ final class LitteralisTransformerTest extends TestCase
                 RecordTypeEnum::ERROR->value,
                 [
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_PERIOD_UNPARSABLE->value,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
+                    CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
                     'idemprise' => 493136,
-                    'arretesrcid' => '24-A-0126',
-                    'shorturl' => 'https://dl.sogelink.fr/?n3omzTyS',
                     'jours et horaires' => 'foo',
                 ],
             ],
@@ -380,17 +381,17 @@ final class LitteralisTransformerTest extends TestCase
                 RecordTypeEnum::NOTICE->value,
                 [
                     RecordTypeEnum::NOTICE->value => LitteralisRecordEnum::NOTICE_UNSUPPORTED_MEASURE->value,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
                     'name' => 'unknown measure',
                     'idemprise' => 493136,
-                    'arretesrcid' => '24-A-0126',
                 ],
             ],
             [
                 RecordTypeEnum::NOTICE->value,
                 [
                     RecordTypeEnum::NOTICE->value => LitteralisRecordEnum::NOTICE_NO_MEASURES_FOUND->value,
-                    'arretesrcid' => '24-A-0126',
-                    'shorturl' => 'https://dl.sogelink.fr/?n3omzTyS',
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
+                    CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
                 ],
             ],
         ], $this->reporter->getRecords());


### PR DESCRIPTION
Les dernières exécutions auto des intégrations MEL et Fougères étaient KO... Cf https://github.com/MTES-MCT/dialog/actions/runs/11219685124/job/31186187380#step:10:255

Le problème a été introduit par #957, où on voit que je n'avais pas mis à jour les noms des champs traités par le formateur de rapport, par ex ici https://github.com/MTES-MCT/dialog/pull/957/files#diff-65606357ab5191174d78542a96c89a99230f12a413fddeade7fc002c2aa9966eL55

Pourquoi on ne s'en est pas rendu compte ? Car il n'y a pas de test d'intégration entre les différents cas d'erreur et le générateur de rapport... Chacun est uniquement testé unitairement. Il aurait fallu des données de mock faisant passer par tous les cas d'erreur, ce qui est + "cher" à maintenir que des tests unitaires. Après ce fix il est peu probable que l'erreur ressorte car les champs communs sont bien définis cette fois.