### PR TITLE
Corrige le géocodage de PR en cas d'ordre de numérisation inversé

### DIFF
--- a/tests/Integration/Infrastructure/Adapter/BdTopoRoadGeocoderTest.php
+++ b/tests/Integration/Infrastructure/Adapter/BdTopoRoadGeocoderTest.php
@@ -152,7 +152,15 @@ final class BdTopoRoadGeocoderTest extends KernelTestCase
                 '34',
                 'U',
                 500,
-                Coordinates::fromLonLat(3.905982782, 44.596555025),
+                Coordinates::fromLonLat(3.906088321, 44.596375194),
+            ],
+            'pr-and-line-inverted-order' => [
+                'D978',
+                'Corrèze',
+                '1',
+                'U',
+                100,
+                Coordinates::fromLonLat(2.182054281, 45.221764408),
             ],
         ];
     }


### PR DESCRIPTION
* Contribue à #777 

Cette PR traite un problème lié au géocodage de PR + abscisse

La différence entre ordre de numérisation (ordre des points dans la `(Multi)LineString` vs ordre numérotation (ordre des PR) n'était pas prise en compte

Il restera le cas des RD en plusieurs morceaux : les PR+abs calculés sont moins fantaisistes avec cette PR, mais le résultat semble "décalés" (cas de la D1120, PR 35/36/37 : on tombe plusieurs centaines de mètres trop loin).