### PR TITLE
Retire les arrêtés de test inutiles

### DIFF
--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderFixture.php
@@ -34,30 +34,12 @@ final class RegulationOrderFixture extends Fixture
             endDate: new \DateTimeImmutable('2023-03-20'),
         );
 
-        $regulationOrderDuplicate = new RegulationOrder(
-            uuid: '0658c6ab-6b49-7a3b-8000-0683622905a3',
-            identifier: 'FO2/2023-1',
-            category: RegulationOrderCategoryEnum::ROAD_MAINTENANCE->value,
-            description: 'Description 2',
-            startDate: new \DateTimeImmutable('2023-03-10'),
-            endDate: new \DateTimeImmutable('2023-03-20'),
-        );
-
         $regulationOrderPermanent = new RegulationOrder(
             uuid: 'c147cc20-ed02-4bd9-9f6b-91b67df296bd',
             identifier: 'FO3/2023',
             category: RegulationOrderCategoryEnum::PERMANENT_REGULATION->value,
             description: 'Description 3',
             startDate: new \DateTimeImmutable('2023-03-11'),
-            endDate: null,
-        );
-
-        $otherOrgRegulationOrder = new RegulationOrder(
-            uuid: 'fd5d2e24-64e4-45c9-a8fc-097c7df796b2',
-            identifier: 'FO4/2023',
-            category: RegulationOrderCategoryEnum::ROAD_MAINTENANCE->value,
-            description: 'Description 4',
-            startDate: null, // Simulate a regulation order before migration
             endDate: null,
         );
 
@@ -127,9 +109,7 @@ final class RegulationOrderFixture extends Fixture
 
         $manager->persist($typicalRegulationOrder);
         $manager->persist($publishedRegulationOrder);
-        $manager->persist($regulationOrderDuplicate);
         $manager->persist($regulationOrderPermanent);
-        $manager->persist($otherOrgRegulationOrder);
         $manager->persist($fullCityRegulationOrder);
         $manager->persist($regulationOrderNoLocations);
         $manager->persist($regulationOrderNoMeasures);
@@ -142,11 +122,9 @@ final class RegulationOrderFixture extends Fixture
         $this->addReference('typicalRegulationOrder', $typicalRegulationOrder);
         $this->addReference('publishedRegulationOrder', $publishedRegulationOrder);
         $this->addReference('regulationOrderPermanent', $regulationOrderPermanent);
-        $this->addReference('otherOrgRegulationOrder', $otherOrgRegulationOrder);
         $this->addReference('fullCityRegulationOrder', $fullCityRegulationOrder);
         $this->addReference('regulationOrderNoLocations', $regulationOrderNoLocations);
         $this->addReference('regulationOrderNoMeasures', $regulationOrderNoMeasures);
-        $this->addReference('regulationOrderDuplicate', $regulationOrderDuplicate);
         $this->addReference('regulationOrderCifs', $regulationOrderCifs);
         $this->addReference('outDatedRegulationOrderCifs', $outDatedRegulationOrderCifs);
         $this->addReference('rawGeoJSONRegulationOrder', $rawGeoJSONRegulationOrder);

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderRecordFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/RegulationOrderRecordFixture.php
@@ -58,15 +58,6 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
             $this->getReference('mainOrg'),
         );
 
-        $regulationOrderRecordDuplicate = new RegulationOrderRecord(
-            '0658c6bb-045e-74fd-8000-bc704e4e72cb',
-            RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::PUBLISHED->value,
-            $this->getReference('regulationOrderDuplicate'),
-            new \DateTime('2022-01-10'),
-            $this->getReference('mainOrg'),
-        );
-
         $regulationOrderRecordPermanent = new RegulationOrderRecord(
             self::UUID_PERMANENT,
             RegulationOrderRecordSourceEnum::DIALOG->value,
@@ -74,15 +65,6 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
             $this->getReference('regulationOrderPermanent'),
             new \DateTime('2022-01-11'),
             $this->getReference('mainOrg'),
-        );
-
-        $otherOrgRegulationOrderRecord = new RegulationOrderRecord(
-            self::UUID_OTHER_ORG,
-            RegulationOrderRecordSourceEnum::DIALOG->value,
-            RegulationOrderRecordStatusEnum::DRAFT->value,
-            $this->getReference('otherOrgRegulationOrder'),
-            new \DateTime('2022-01-11'),
-            $this->getReference('otherOrg'),
         );
 
         $fullCityRegulationOrderRecord = new RegulationOrderRecord(
@@ -150,9 +132,7 @@ final class RegulationOrderRecordFixture extends Fixture implements DependentFix
 
         $manager->persist($typicalRegulationOrderRecord);
         $manager->persist($publishedRegulationOrderRecord);
-        $manager->persist($regulationOrderRecordDuplicate);
         $manager->persist($regulationOrderRecordPermanent);
-        $manager->persist($otherOrgRegulationOrderRecord);
         $manager->persist($fullCityRegulationOrderRecord);
         $manager->persist($regulationOrderRecordNoLocations);
         $manager->persist($regulationOrderRecordNoMeasures);

--- a/tests/Integration/Infrastructure/Controller/Regulation/DuplicateRegulationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/DuplicateRegulationControllerTest.php
@@ -100,16 +100,6 @@ final class DuplicateRegulationControllerTest extends AbstractWebTestCase
         $this->assertSame('Copiée avec succès Vous pouvez modifier les informations que vous souhaitez dans cette copie de la réglementation.', $crawler->filter('div.fr-alert--success')->text());
     }
 
-    public function testDuplicateWithNoStartDateYet(): void
-    {
-        $client = $this->login(UserFixture::OTHER_ORG_USER_EMAIL);
-        $client->request('POST', '/regulations/' . RegulationOrderRecordFixture::UUID_OTHER_ORG_NO_START_DATE . '/duplicate', [
-            '_token' => $this->generateCsrfToken($client, 'duplicate-regulation'),
-        ]);
-
-        $this->assertResponseStatusCodeSame(303);
-    }
-
     public function testCannotDuplicateBecauseDifferentOrg(): void
     {
         $client = $this->login(UserFixture::OTHER_ORG_USER_EMAIL);

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/SaveRegulationGeneralInfoControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/SaveRegulationGeneralInfoControllerTest.php
@@ -52,35 +52,6 @@ final class SaveRegulationGeneralInfoControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(404);
     }
 
-    public function testEditRegulationOrderWithNoStartDateYet(): void
-    {
-        $client = $this->login(UserFixture::OTHER_ORG_USER_EMAIL);
-        $crawler = $client->request('GET', '/_fragment/regulations/general_info/form/' . RegulationOrderRecordFixture::UUID_OTHER_ORG_NO_START_DATE);
-
-        $this->assertResponseStatusCodeSame(200);
-
-        $saveButton = $crawler->selectButton('Valider');
-        $form = $saveButton->form();
-
-        // Get the raw values.
-        $values = $form->getPhpValues();
-        $values['general_info_form']['identifier'] = 'FIOIUS';
-        $values['general_info_form']['organization'] = OrganizationFixture::OTHER_ORG_ID;
-        $values['general_info_form']['description'] = 'Interdiction de circuler dans Paris';
-        $values['general_info_form']['startDate'] = '2023-02-14';
-        $values['general_info_form']['category'] = RegulationOrderCategoryEnum::ROAD_MAINTENANCE->value;
-        $values['general_info_form']['additionalVisas'][0] = 'Vu 1';
-        $values['general_info_form']['additionalVisas'][1] = 'Vu 2';
-        $values['general_info_form']['additionalReasons'][0] = 'Motif 1';
-        $values['general_info_form']['additionalReasons'][1] = 'Motif 2';
-        $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
-        $this->assertResponseStatusCodeSame(303);
-
-        $client->followRedirect();
-        $this->assertResponseStatusCodeSame(200);
-        $this->assertRouteSame('fragment_regulations_general_info');
-    }
-
     public function testBadUuid(): void
     {
         $client = $this->login();

--- a/tests/Integration/Infrastructure/Controller/StatisticsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/StatisticsControllerTest.php
@@ -21,9 +21,9 @@ final class StatisticsControllerTest extends AbstractWebTestCase
 
         $this->assertSame("Nombre total d'utilisateurs 3", $stats->eq(0)->text());
         $this->assertSame("Nombre total d'organisations 1", $stats->eq(1)->text());
-        $this->assertSame("Nombre total d'arrếtés 2", $stats->eq(2)->text());
+        $this->assertSame("Nombre total d'arrếtés 1", $stats->eq(2)->text());
         $this->assertSame("Nombre total d'arrếtés publiés 1", $stats->eq(3)->text());
-        $this->assertSame("Nombre total d'arrếtés permanents 1", $stats->eq(4)->text());
+        $this->assertSame("Nombre total d'arrếtés permanents 0", $stats->eq(4)->text());
         $this->assertSame("Nombre total d'arrếtés temporaires 1", $stats->eq(5)->text());
     }
 }


### PR DESCRIPTION
En travaillant sur #1011 j'ai remarqué deux arrêtés dans les fixtures qui n'étaient pas utiles (et me bloquaient car leur conversion à l'absence de champs de dates globales ne faisait pas vraiment de sens)

Donc je les supprime

* FO4/2023 -> Jamais référencé dans les tests
* FO2/2023-1 -> Référence dans les tests mais sur un cas obsolète (arrêté sans date de début, ça date de quand on a rendu la date de début obligatoire, il y a bien longtemps)