### PR TITLE
Intègre le dashboard Metabase à la page stats

### DIFF
--- a/.env
+++ b/.env
@@ -51,6 +51,11 @@ APP_MEL_ORG_ID=
 SENTRY_DSN=
 ###< sentry/sentry-symfony ###
 
+###> Metabase ###
+APP_METABASE_SITE_URL=https://dialog-metabase.osc-fr1.scalingo.io
+APP_METABASE_SECRET_KEY=
+###< Metabase ###
+
 ###> symfony/lock ###
 # Choose one of the stores below
 # postgresql+advisory://db_user:db_password@localhost/db_name

--- a/assets/customElements/index.js
+++ b/assets/customElements/index.js
@@ -3,3 +3,4 @@ import './modal_trigger';
 import './map';
 import './map_form';
 import './map_search_form';
+import './responsive_iframe';

--- a/assets/customElements/responsive_iframe.js
+++ b/assets/customElements/responsive_iframe.js
@@ -1,0 +1,43 @@
+// @ts-check
+
+import { getAttributeOrError, querySelectorOrError } from "./util";
+
+customElements.define('d-responsive-iframe', class extends HTMLElement {
+    connectedCallback() {
+        /** @type {HTMLIFrameElement} */
+        const iframe = querySelectorOrError(this, 'iframe');
+
+        // On vérifie la 'origin' pour éviter le risque de Cross-Site Scripting (XSS)
+        // Voir : https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concerns
+        const targetOrigin = getAttributeOrError(this, 'targetOrigin');
+
+        // Inspiré de : https://towardsdev.com/the-most-elegant-way-to-implement-dynamic-size-iframe-2-0-319b974f1048
+
+        const resizeObserver = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                window.parent.postMessage({
+                    type: 'dialog.resize',
+                    width: entry.borderBoxSize[0].inlineSize,
+                });
+            }
+        });
+
+        resizeObserver.observe(document.body);
+
+        const maxWidth = +(this.getAttribute('maxWidth') || iframe.clientWidth);
+        const extraPadding = +(this.getAttribute('extraPadding') || '0'); // px
+
+        window.addEventListener('message', function (event) {
+            if (event.origin === targetOrigin && event.data.type === 'dialog.resize') {
+                const windowWidth = event.data.width;
+                const newWidth = Math.min(windowWidth - extraPadding, maxWidth);
+
+                try {
+                    iframe.style.width = `${newWidth}px`;
+                } catch (e) {
+                    console.error(e);
+                }
+            }
+        });
+    }
+});

--- a/assets/styles/utilities/dsfr-extensions/sizing.css
+++ b/assets/styles/utilities/dsfr-extensions/sizing.css
@@ -6,6 +6,10 @@
     max-width: calc(37 * 0.5rem);
 }
 
+.fr-x-max-w-156w {
+    max-width: calc(156 * 0.5rem);
+}
+
 .fr-x-h-full {
     height: 100%;
 }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.2",
         "doctrine/orm": "^2.13",
         "easycorp/easyadmin-bundle": "^4.7",
+        "firebase/php-jwt": "^6.10",
         "jsor/doctrine-postgis": "^2.1",
         "league/commonmark": "^2.4",
         "martin-georgiev/postgresql-for-doctrine": "^2.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7c37857ccfbd8f3782161451dd6bf3d9",
+    "content-hash": "dde8613e0f47772836e00e3a974a2a28",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -1647,6 +1647,69 @@
                 }
             ],
             "time": "2024-10-20T09:45:57+00:00"
+        },
+        {
+            "name": "firebase/php-jwt",
+            "version": "v6.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/firebase/php-jwt.git",
+                "reference": "500501c2ce893c824c801da135d02661199f60c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/500501c2ce893c824c801da135d02661199f60c5",
+                "reference": "500501c2ce893c824c801da135d02661199f60c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "guzzlehttp/guzzle": "^7.4",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0"
+            },
+            "suggest": {
+                "ext-sodium": "Support EdDSA (Ed25519) signatures",
+                "paragonie/sodium_compat": "Support EdDSA (Ed25519) signatures when libsodium is not present"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Firebase\\JWT\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Neuman Vong",
+                    "email": "neuman+pear@twilio.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Anant Narayanan",
+                    "email": "anant@php.net",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A simple library to encode and decode JSON Web Tokens (JWT) in PHP. Should conform to the current spec.",
+            "homepage": "https://github.com/firebase/php-jwt",
+            "keywords": [
+                "jwt",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/firebase/php-jwt/issues",
+                "source": "https://github.com/firebase/php-jwt/tree/v6.10.1"
+            },
+            "time": "2024-05-18T18:05:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",

--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -30,15 +30,15 @@ nelmio_security:
         enabled: true
         enforce:
             default-src: ['self']
-            script-src: ['self']
-            style-src: ['self']
+            script-src: ['self', 'https://dialog-metabase.osc-fr1.scalingo.io']
+            style-src: ['self', 'https://dialog-metabase.osc-fr1.scalingo.io']
             connect-src: ['self', 'https://data.geopf.fr']
             font-src: ['self']
             img-src: ['self', 'data:', 'blob:']
             # maplibre-gl
             # https://maplibre.org/maplibre-gl-js/docs/#csp-directives
             worker-src: ['blob:']
-            child-src: ['blob:']
+            child-src: ['blob:', 'https://dialog-metabase.osc-fr1.scalingo.io']
             block-all-mixed-content: true
 
 when@dev:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -27,6 +27,8 @@ services:
             $melCredentials: '%env(APP_MEL_LITTERALIS_CREDENTIALS)%' # format: 'user:pass'
             $fougeresOrgId: '%env(APP_FOUGERES_ORG_ID)%'
             $fougeresCredentials: '%env(APP_FOUGERES_LITTERALIS_CREDENTIALS)%' # format: 'user:pass'
+            $metabaseSiteUrl: '%env(APP_METABASE_SITE_URL)%'
+            $metabaseSecretKey: '%env(APP_METABASE_SECRET_KEY)%'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -109,6 +109,7 @@ Chaque application peut être configurée avec les variables d'environnement sui
 | `APP_JOP_ORG_ID` | UUID de l'organisation où intégrer les données JOP | _Vide_ | |
 | `APP_SECRET` | Correspond au paramètre Symfony [`secret`](https://symfony.com/doc/current/reference/configuration/framework.html#secret) | _(Obligatoire)_ | Longueur recommandée : 32 caractères. Exemple : générer avec `python3 -c 'import secrets; print(secrets.token_hex(16))'` |
 | `APP_CIFS_FILTERS` | Filtre les données exportées vers CIFS | `{}` | Format JSON, champs acceptés : `allowed_sources`, `excluded_identifiers`, `allowed_location_isd`. L'objet vide `{}` a pour effet de continuer de toute exporter. |
+| `METABASE_SECRET_KEY` | Clé secrète pour la signature JWT des graphiques Metabase | _(Obligatoire)_ | À récupérer dans [l'administration Metabase](https://dialog-metabase.osc-fr1.scalingo.io/admin/settings/embedding-in-other-applications/standalone) |
 | `DATABASE_URL` | URL vers le serveur PostgreSQL | _(Obligatoire)_ `$SCALINGO_POSTGRESQL_URL` | La variable `$SCALINGO_POSTGRESQL_URL` est configurée automatiquement par Scalingo |
 | `MATOMO_ENABLED` | `true` (ou autre valeur truthy) pour activer les [analytics](../tools/analytics.md), `false` pour ne pas les activer | `false` | |
 | `PHP_BUILDPACK_NO_NODE` | Désactive le support Node.js dans le buildpack PHP, puisqu'on utilise le buildpack Node.js complet (voir `.buildpacks`). | _(Obligatoire)_ `true` | Voir : [PHP application with Node.js (Scalingo docs)](https://doc.scalingo.com/languages/php/php-nodejs) |

--- a/docs/tools/metabase.md
+++ b/docs/tools/metabase.md
@@ -12,13 +12,13 @@ Le Metabase de DiaLog est hébergé sur Scalingo sous l'application `dialog-meta
 
 Cette application dispose de sa propre base de données où nous stockons les données nécessaires au calcul des indicateurs, conformément aux [recommendations Beta](https://doc.incubateur.net/communaute/les-outils-de-la-communaute/autres-services/metabase/metabase#connecter-metabase-a-une-base-de-donnees-anonymisee)
 
-La collecte des données d'indicateur est réalisée au moyen d'un [script](../../tools/metabase-export.sh). Ce script exécute des requêtes SQL depuis la base Metabase vers la base applicative. Pour cela un utilisateur `dialog_metabase` avec droits en lecture seule a été créé sur la base applicative (identifiants dans le Vaultwarden de l'équipe DiaLog).
+La collecte des données d'indicateurs est réalisée au moyen d'un [script](../../tools/metabase-export.sh). Ce script exécute des requêtes SQL depuis la base Metabase vers la base applicative. Pour cela un utilisateur `dialog_metabase` avec droits en lecture seule a été créé sur la base applicative (identifiants dans le Vaultwarden de l'équipe DiaLog).
 
 ## Lancer l'export depuis GitHub Actions
 
 L'export Metabase peut être déclenché via [GitHub Actions](./github_actions.md) à l'aide du workflow [`metabase_export.yml`](../../.github/workflows/metabase_export.yml).
 
-### Configuration
+### Configuration de la GitHub Action
 
 La configuration de la GitHub Action passe par diverses variables d'environnement listées ci-dessous :
 

--- a/src/Infrastructure/Adapter/JWTEncoder.php
+++ b/src/Infrastructure/Adapter/JWTEncoder.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Adapter;
+
+use Firebase\JWT\JWT;
+
+final class JWTEncoder
+{
+    public function encode(array $payload, string $secretKey): string
+    {
+        return JWT::encode($payload, $secretKey, 'HS256');
+    }
+}

--- a/src/Infrastructure/Adapter/MetabaseEmbedFactory.php
+++ b/src/Infrastructure/Adapter/MetabaseEmbedFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Adapter;
+
+use App\Application\DateUtilsInterface;
+
+final class MetabaseEmbedFactory
+{
+    private const DASHBOARD_ID_STATS = 2;
+
+    public function __construct(
+        private string $metabaseSiteUrl,
+        private string $metabaseSecretKey,
+        private JWTEncoder $jwtEncoder,
+        private DateUtilsInterface $dateUtils,
+    ) {
+    }
+
+    public function makeDashboardUrl(): string
+    {
+        // Ce code a été adapté du code d'intégration fourni par Metabase dans les options de partage d'une visualisation.
+        // Plus d'infos sur le "static embedding" : https://www.metabase.com/docs/latest/embedding/static-embedding
+
+        $payload = [
+            'resource' => ['dashboard' => self::DASHBOARD_ID_STATS],
+            'params' => (object) [], // sic: L'array doit être converti en 'object', voir : https://github.com/metabase/metabase/issues/6487#issuecomment-1535278810
+            'exp' => round($this->dateUtils->getNow()->getTimestamp()) + 10 * 60, // 10 minute expiration
+        ];
+
+        $token = $this->jwtEncoder->encode($payload, $this->metabaseSecretKey);
+
+        return \sprintf('%s/embed/dashboard/%s#bordered=true&titled=true', $this->metabaseSiteUrl, $token);
+    }
+}

--- a/src/Infrastructure/Controller/StatisticsController.php
+++ b/src/Infrastructure/Controller/StatisticsController.php
@@ -6,6 +6,7 @@ namespace App\Infrastructure\Controller;
 
 use App\Application\QueryBusInterface;
 use App\Application\Regulation\Query\GetStatisticsQuery;
+use App\Infrastructure\Adapter\MetabaseEmbedFactory;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -14,6 +15,7 @@ final class StatisticsController
     public function __construct(
         private \Twig\Environment $twig,
         private QueryBusInterface $queryBus,
+        private MetabaseEmbedFactory $metabaseEmbedFactory,
     ) {
     }
 
@@ -22,8 +24,11 @@ final class StatisticsController
     {
         $statistics = $this->queryBus->handle(new GetStatisticsQuery());
 
+        $dashboardEmbedUrl = $this->metabaseEmbedFactory->makeDashboardUrl();
+
         return new Response($this->twig->render('statistics.html.twig', [
             'statistics' => $statistics,
+            'dashboardEmbedUrl' => $dashboardEmbedUrl,
         ]));
     }
 }

--- a/templates/statistics.html.twig
+++ b/templates/statistics.html.twig
@@ -5,12 +5,32 @@
 {% endblock %}
 
 {% block body %}
-    <div class="fr-container fr-py-2w fr-py-md-5w">
+    <div class="fr-container fr-x-max-w-156w fr-py-2w fr-py-md-5w">
         <h1>{{ 'statistics.title'|trans }}</h1>
+
+        <div class="fr-grid-row fr-mb-3w">
+            <div class="fr-col">
+                <d-responsive-iframe
+                    maxWidth="1200" {# Corresponds to 156w #}
+                    extraPadding="32"
+                    targetOrigin="{{ app.request.schemeAndHttpHost }}"
+                >
+                    <iframe
+                        src="{{ dashboardEmbedUrl }}"
+                        frameborder="0"
+                        width="1200"
+                        height="800"
+                        allowtransparency
+                        title="{{ 'statistics.dashboard.title'|trans }}"
+                        data-testid="stat"
+                    ></iframe>
+                </d-responsive-iframe>
+            </div>
+        </div>
 
         <div class="fr-grid-row fr-grid-row--gutters fr-grid-row--middle fr-mb-3w">
             <div class="fr-col fr-col-12 fr-col-md-6">
-                <div class="fr-card">
+                <div class="fr-card" data-testid="stat">
                     <div class="fr-card__body">
                         <div class="fr-card__content">
                             <h3 class="fr-card__title">{{ 'statistics.users'|trans }}</h3>
@@ -20,7 +40,7 @@
                 </div>
             </div>
             <div class="fr-col fr-col-12 fr-col-md-6">
-                <div class="fr-card">
+                <div class="fr-card" data-testid="stat">
                     <div class="fr-card__body">
                         <div class="fr-card__content">
                             <h3 class="fr-card__title">{{ 'statistics.organizations'|trans }}</h3>
@@ -30,7 +50,7 @@
                 </div>
             </div>
             <div class="fr-col fr-col-12 fr-col-md-6">
-                <div class="fr-card">
+                <div class="fr-card" data-testid="stat">
                     <div class="fr-card__body">
                         <div class="fr-card__content">
                             <h3 class="fr-card__title">{{ 'statistics.totalRegulationOrderRecords'|trans }}</h3>
@@ -40,7 +60,7 @@
                 </div>
             </div>
             <div class="fr-col fr-col-12 fr-col-md-6">
-                <div class="fr-card">
+                <div class="fr-card" data-testid="stat">
                     <div class="fr-card__body">
                         <div class="fr-card__content">
                             <h3 class="fr-card__title">{{ 'statistics.publishedRegulationOrderRecords'|trans }}</h3>
@@ -50,7 +70,7 @@
                 </div>
             </div>
             <div class="fr-col fr-col-12 fr-col-md-6">
-                <div class="fr-card">
+                <div class="fr-card" data-testid="stat">
                     <div class="fr-card__body">
                         <div class="fr-card__content">
                             <h3 class="fr-card__title">{{ 'statistics.permanentRegulationOrderRecords'|trans }}</h3>
@@ -60,7 +80,7 @@
                 </div>
             </div>
             <div class="fr-col fr-col-12 fr-col-md-6">
-                <div class="fr-card">
+                <div class="fr-card" data-testid="stat">
                     <div class="fr-card__body">
                         <div class="fr-card__content">
                             <h3 class="fr-card__title">{{ 'statistics.temporaryRegulationOrderRecords'|trans }}</h3>

--- a/templates/statistics.html.twig
+++ b/templates/statistics.html.twig
@@ -19,7 +19,7 @@
                         src="{{ dashboardEmbedUrl }}"
                         frameborder="0"
                         width="1200"
-                        height="800"
+                        height="500"
                         allowtransparency
                         title="{{ 'statistics.dashboard.title'|trans }}"
                         data-testid="stat"

--- a/tests/Integration/Infrastructure/Controller/StatisticsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/StatisticsControllerTest.php
@@ -16,14 +16,15 @@ final class StatisticsControllerTest extends AbstractWebTestCase
         $this->assertMetaTitle('Statistiques - DiaLog', $crawler);
         $this->assertSame('Statistiques', $crawler->filter('h1')->text());
 
-        $stats = $crawler->filter('div.fr-card');
-        $this->assertSame(6, $stats->count());
+        $stats = $crawler->filter('[data-testid=stat]');
+        $this->assertSame(7, $stats->count());
 
-        $this->assertSame("Nombre total d'utilisateurs 3", $stats->eq(0)->text());
-        $this->assertSame("Nombre total d'organisations 2", $stats->eq(1)->text());
-        $this->assertSame("Nombre total d'arrếtés 1", $stats->eq(2)->text());
-        $this->assertSame("Nombre total d'arrếtés publiés 1", $stats->eq(3)->text());
-        $this->assertSame("Nombre total d'arrếtés permanents 0", $stats->eq(4)->text());
-        $this->assertSame("Nombre total d'arrếtés temporaires 1", $stats->eq(5)->text());
+        $this->assertSame('Tableau de bord des indicateurs', $stats->eq(0)->attr('title'));
+        $this->assertSame("Nombre total d'utilisateurs 3", $stats->eq(1)->text());
+        $this->assertSame("Nombre total d'organisations 2", $stats->eq(2)->text());
+        $this->assertSame("Nombre total d'arrếtés 1", $stats->eq(3)->text());
+        $this->assertSame("Nombre total d'arrếtés publiés 1", $stats->eq(4)->text());
+        $this->assertSame("Nombre total d'arrếtés permanents 0", $stats->eq(5)->text());
+        $this->assertSame("Nombre total d'arrếtés temporaires 1", $stats->eq(6)->text());
     }
 }

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -2040,6 +2040,10 @@
                 <source>statistics.title</source>
                 <target>Statistiques</target>
             </trans-unit>
+            <trans-unit id="statistics.dashboard.title">
+                <source>statistics.dashboard.title</source>
+                <target>Tableau de bord des indicateurs</target>
+            </trans-unit>
             <trans-unit id="statistics.users">
                 <source>statistics.users</source>
                 <target>Nombre total d'utilisateurs</target>


### PR DESCRIPTION
* Closes #564 

Cette PR intègre un dashboard créé sur Metabase à la page stats

Ce dashboard peut être configuré dans Metabase ce qui permet de faire cette intégration "une bonne fois pour toute"

À noter, l'intégration est responsive (la largeur du iframe est recalculé quand la largeur de la fenêtre change)

TODO

* [x] Configurer le domaine pour sécuriser le message iframe (actuellement localhost:8000 en dur)
* [x] Configurer la variable d'environnement `APP_METABASE_SECRET_KEY` sur dialog et dialog-staging

## Aperçu

![Screenshot 2024-10-29 at 14-52-39 Statistiques - DiaLog](https://github.com/user-attachments/assets/b5bd7e47-13c7-4483-912c-01d749c428c8)
