### PR TITLE
Supprime le lien d'édition dans l'organisation DiaLog

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,7 +1,8 @@
 twig:
     default_path: '%kernel.project_dir%/templates'
     form_themes: ['common/form/dsfr_theme.html.twig']
-
+    globals:
+        dialogOrgId: '%env(DIALOG_ORG_ID)%'
 when@test:
     twig:
         strict_variables: true

--- a/templates/my_area/organization/detail.html.twig
+++ b/templates/my_area/organization/detail.html.twig
@@ -21,7 +21,7 @@
                         <p>{{ 'organization.siret'|trans }} : {{ organization.siret }}</p>
                     </div>
                     <div class="fr-mb-3w">
-                        {% if is_granted(constant('App\\Infrastructure\\Security\\Voter\\OrganizationVoter::EDIT'), organization) %}
+                        {% if is_granted(constant('App\\Infrastructure\\Security\\Voter\\OrganizationVoter::EDIT'), organization) and dialogOrgId != organization.uuid %}
                             <a href="{{ path('app_config_organization_edit', { uuid: organization.uuid }) }}" class="fr-ml-auto fr-btn fr-btn--secondary fr-x-btn-sm--icon-left fr-icon-edit-line" title="{{ 'common.update'|trans }}">
                                 {{ 'common.update'|trans }}
                             </a>


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cee3ab4a-40b8-4f6f-be02-e5117f7abb7f)

En tant qu'administrateur de l'organisation DiaLog, je ne peux plus l'éditer. Cette PR permet donc de retirer le lien du client.