### PR TITLE
Corrige le filtre permanent / temporaire : ro.end_date is not defined

### DIFF
--- a/tests/Integration/Infrastructure/Controller/Map/Fragment/MapDataControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Map/Fragment/MapDataControllerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\Infrastructure\Controller\Map\Fragment;
 
 use App\Domain\Regulation\Enum\MeasureTypeEnum;
+use App\Domain\Regulation\Enum\RegulationOrderCategoryEnum;
 use App\Infrastructure\Persistence\Doctrine\Fixtures\LocationFixture;
 use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
 
@@ -26,6 +27,25 @@ final class MapDataControllerTest extends AbstractWebTestCase
 
         foreach ($dataArray['features'] as $feature) {
             $this->assertSame(MeasureTypeEnum::NO_ENTRY->value, $feature['properties']['measure_type']);
+        }
+    }
+
+    public function testRegulationTypeFilterTemporaryOnly(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/carte/data.geojson?map_filter_form[measureTypes][]=noEntry&map_filter_form[displayTemporaryRegulations]=yes');
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
+
+        $jsonData = $client->getResponse()->getContent();
+        $dataArray = json_decode($jsonData, true);
+
+        $this->assertCount(8, $dataArray['features']);
+
+        foreach ($dataArray['features'] as $feature) {
+            $this->assertNotSame(RegulationOrderCategoryEnum::PERMANENT_REGULATION->value, $feature['properties']['regulation_category']);
         }
     }
 


### PR DESCRIPTION
* Vu https://github.com/MTES-MCT/dialog/pull/1010/files#r1824163445

On ne s'en est pas rendu compte car le filtre permanent / temporaire n'était pas testé...

On n'a pas de fixture avec un arrêté permanent publié pour qu'il apparaisse dans les données carto, donc j'ai juste testé la partie temporaire, mais ça aurait déjà permis de détecter le bug.