### PR TITLE
Fait renvoyer array aux getters qui renvoient ?array

### DIFF
--- a/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
+++ b/src/Application/Regulation/Command/DuplicateRegulationCommandHandler.php
@@ -53,8 +53,8 @@ final class DuplicateRegulationCommandHandler
         $generalInfo->organization = $organization;
         $generalInfo->identifier = $identifier;
         $generalInfo->description = $originalRegulationOrder->getDescription();
-        $generalInfo->additionalVisas = $originalRegulationOrder->getAdditionalVisas() ?? [];
-        $generalInfo->additionalReasons = $originalRegulationOrder->getAdditionalReasons() ?? [];
+        $generalInfo->additionalVisas = $originalRegulationOrder->getAdditionalVisas();
+        $generalInfo->additionalReasons = $originalRegulationOrder->getAdditionalReasons();
         $generalInfo->visaModelUuid = $originalRegulationOrder->getVisaModel()?->getUuid();
 
         return $this->commandBus->handle($generalInfo);

--- a/src/Domain/Regulation/RegulationOrder.php
+++ b/src/Domain/Regulation/RegulationOrder.php
@@ -79,14 +79,14 @@ class RegulationOrder
         return $this->visaModel;
     }
 
-    public function getAdditionalVisas(): ?array
+    public function getAdditionalVisas(): array
     {
-        return $this->additionalVisas;
+        return $this->additionalVisas ?? [];
     }
 
-    public function getAdditionalReasons(): ?array
+    public function getAdditionalReasons(): array
     {
-        return $this->additionalReasons;
+        return $this->additionalReasons ?? [];
     }
 
     public function update(

--- a/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/DuplicateRegulationCommandHandlerTest.php
@@ -283,7 +283,7 @@ final class DuplicateRegulationCommandHandlerTest extends TestCase
         $this->originalRegulationOrder
             ->expects(self::once())
             ->method('getAdditionalVisas')
-            ->willReturn(null);
+            ->willReturn([]);
         $this->originalRegulationOrder
             ->expects(self::once())
             ->method('getVisaModel')


### PR DESCRIPTION
* Closes #1026 

@mmarchois Je n'ai pas trouvé d'autre exemple de getters qui renverraient `?array` que getAdditionalVisas() et getAdditionalReasons()