### PR TITLE
Aligne texte du blog à gauche

### DIFF
--- a/blog/public/css/index.css
+++ b/blog/public/css/index.css
@@ -192,7 +192,6 @@ div.fr-callout__text p {
 
 /** Classe spécifique au contenu des articles **/
 .contenu-article {
-    text-align: justify;
     margin-left: 200px; 
     margin-right: 200px;
 }


### PR DESCRIPTION
Tel que suggéré par Stéphane S

> en passant si on pouvait mettre le corps du texte du blog par défaut justifié en "drapeau" (à gauche) ce serait super. Merci !