### PR TITLE
Rafraîchit le logo après upload

### DIFF
--- a/src/Application/Organization/Logo/Command/SaveOrganizationLogoCommandHandler.php
+++ b/src/Application/Organization/Logo/Command/SaveOrganizationLogoCommandHandler.php
@@ -22,6 +22,6 @@ final class SaveOrganizationLogoCommandHandler
             $this->storage->delete($logo);
         }
 
-        $organization->setLogo($this->storage->write($folder, 'logo', $command->file));
+        $organization->setLogo($this->storage->write($folder, $command->file));
     }
 }

--- a/src/Application/StorageInterface.php
+++ b/src/Application/StorageInterface.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 interface StorageInterface
 {
-    public function write(string $folder, string $fileName, UploadedFile $file): string;
+    public function write(string $folder, UploadedFile $file): string;
 
     public function delete(string $path): void;
 

--- a/src/Infrastructure/Adapter/Storage.php
+++ b/src/Infrastructure/Adapter/Storage.php
@@ -16,9 +16,9 @@ final class Storage implements StorageInterface
     ) {
     }
 
-    public function write(string $folder, string $fileName, UploadedFile $file): string
+    public function write(string $folder, UploadedFile $file): string
     {
-        $path = \sprintf('%s/%s.%s', $folder, $fileName, $file->getClientOriginalExtension());
+        $path = \sprintf('%s/%s.%s', $folder, $file->getFilename(), $file->getClientOriginalExtension());
         $this->storage->write($path, $file->getContent(), [
             'visibility' => 'public',
             'directory_visibility' => 'public',

--- a/tests/Unit/Application/Organization/Logo/Command/SaveOrganizationLogoCommandHandlerTest.php
+++ b/tests/Unit/Application/Organization/Logo/Command/SaveOrganizationLogoCommandHandlerTest.php
@@ -42,7 +42,7 @@ final class SaveOrganizationLogoCommandHandlerTest extends TestCase
         $this->storage
             ->expects(self::once())
             ->method('write')
-            ->with('organizations/496bd752-c217-4625-ba0c-7454dc218516', 'logo', $file)
+            ->with('organizations/496bd752-c217-4625-ba0c-7454dc218516', $file)
             ->willReturn('organizations/496bd752-c217-4625-ba0c-7454dc218516/logo.png');
 
         $organization


### PR DESCRIPTION
Actuellement le fichier uploadé s'appelle toujours `logo.png` donc l'ancienne version reste en cache dans le navigateur, et la nouvelle version ne s'affiche pas directement après un nouvel upload

Je me suis demandé comment forcer le rafraîchissement

Cette PR utilise le nom de fichier généré par le framework, qui change à chaque upload, ce qui fait que le navigateur charge la nouvelle version

Une autre option serait de toucher aux règles de cache (mettre à jour l'ETag ?) mais ça m'a paru plus compliqué