### PR TITLE
Ajoute des commandes utilitaires createdb, usedb, dropdb, listdb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,25 @@ dbmigration: ## Generate new db migration
 dbmigrate: ## Run db migration
 	${BIN_CONSOLE} doctrine:migrations:migrate -n --all-or-nothing ${ARGS}
 
+createdb: ## Create branch db from dialog db
+	docker compose exec database createdb -U dialog -T dialog dialog_${NAME}
+
+usedb: ## Update .env.local files with branch DATABASE_URL
+	@if [ -z ${NAME} ]; then\
+		sed -i -r 's/^DATABASE_URL=.+/DATABASE_URL="postgresql:\/\/dialog:dialog@database:5432\/dialog"/' .env.local;\
+		sed -i -r 's/^DATABASE_URL=.+/DATABASE_URL="postgresql:\/\/dialog:dialog@database:5432\/dialog"/' .env.test.local;\
+	else\
+		sed -i -r 's/^DATABASE_URL=.+/DATABASE_URL="postgresql:\/\/dialog:dialog@database:5432\/dialog_${NAME}"/' .env.local;\
+		sed -i -r 's/^DATABASE_URL=.+/DATABASE_URL="postgresql:\/\/dialog:dialog@database:5432\/dialog_${NAME}"/' .env.test.local;\
+	fi
+
+dropdb: ## Remove branch db
+	docker compose exec database dropdb --if-exists -U dialog dialog_${NAME}
+	docker compose exec database dropdb --if-exists -U dialog dialog_${NAME}_test
+
+listdb: ## Show local databases
+	docker compose exec database psql -U dialog -c "\l"
+
 bdtopo_migration: ## Generate new db migration for bdtopo
 	${BIN_CONSOLE} doctrine:migrations:generate --configuration ./config/packages/bdtopo/doctrine_migrations.yaml
 

--- a/docs/tools/db.md
+++ b/docs/tools/db.md
@@ -41,6 +41,32 @@ Une configuration est nécéssaire à la première connection pour relier pgAdmi
 
 Et c'est tout ! Vous aurez maintenant accès à l'interface graphique pour gérer la base de données.
 
+## Base de données de branche
+
+Pour développer sur une branche contenant de nouvelles migrations, il peut être utile d'utiliser une DB dédiée afin de ne pas affecter votre DB de développement principale.
+
+Pour cela utilisez `make createdb` :
+
+```bash
+make createdb NAME=_ma_feature # Noter le "_" devant
+```
+
+Une base de données `dialog_ma_feature` sera créée à partir de la base `dialog`.
+
+Pour l'utiliser, il faut mettre à jour `DATABASE_URL` dans les fichiers `.env.local` et `.env.test.local`. Vous pouvez le faire en une commande avec `make usedb` :
+
+```bash
+make usedb NAME=ma_feature
+```
+
+Pour retourner à la DB principale, utilisez `make usdb` (sans paramètre `NAME`).
+
+Quand vous n'avez plus besoin de la DB, utilisez `make dropdb` :
+
+```bash
+make dropdb NAME=ma_feature
+```
+
 ## Utiliser une DB Scalingo en local
 
 Vous pouvez utiliser en local une base de données hébergée sur Scalingo (staging, PR...) à l'aide d'un utilitaire.


### PR DESCRIPTION
Suggéré par @mmarchois au motif que ça pouvait servir à tout le monde :)

En local j'utilise des DB de branche pour éviter de devoir recréer ma DB locale dès que je travaille sur une branche avec des migrations (en dev ou en review)

Cette PR ajoute commandes make pour faire ça plus facilement

```bash
make createdb NAME=circulation
make usedb NAME=circulation
make dropdb NAME=circulation
make listdb
```