### PR TITLE
Remonte le champ "intitulé" dans le formulaire de création d'un arrêté

### DIFF
--- a/templates/regulation/_general_info_form.html.twig
+++ b/templates/regulation/_general_info_form.html.twig
@@ -43,6 +43,7 @@
                     </ul>
                     <div id="general-form-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="general-form" tabindex="0">
                         {{ form_row(form.identifier, {group_class: 'fr-input-group', widget_class: 'fr-input'}) }}
+                        {{ form_row(form.title, {group_class: 'fr-input-group', attr: {class: 'fr-input'}, help_attr: {class: 'fr-hint-text'}}) }}
                         {{ form_row(
                             form.organization,
                             {
@@ -72,7 +73,6 @@
                                 {{ form_row(form.otherCategoryText, { group_class: 'fr-input-group', widget_class: 'fr-input', attr: { 'data-form-reveal-target': 'form-control' } }) }}
                             </div>
                         </div>
-                        {{ form_row(form.title, {group_class: 'fr-input-group', attr: {class: 'fr-input'}, help_attr: {class: 'fr-hint-text'}}) }}
                     </div>
                     <div id="reasons-panel" class="fr-tabs__panel" role="tabpanel" aria-labelledby="reasons" tabindex="0">
                         <p>{{ 'regulation.general_info.visas_and_reasons.description'|trans }}</p>


### PR DESCRIPTION
Petite modification dans l'ordre des champs du formulaire de création d'un arrêté pour coller à la maquette.

![Capture d’écran du 2024-12-04 15-40-35](https://github.com/user-attachments/assets/f214bd5d-1e8d-418d-ac71-ae8e8ddfb2e3)
