### PR TITLE
Evite les GeometryCollection à 1 seul élément

### DIFF
--- a/src/Infrastructure/Adapter/BdTopoRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/BdTopoRoadGeocoder.php
@@ -33,7 +33,7 @@ final class BdTopoRoadGeocoder implements RoadGeocoderInterface, IntersectionGeo
                         AND code_insee = :code_insee
                         LIMIT 1
                     )
-                    SELECT ST_AsGeoJSON(ST_Force2D(ST_Collect(geometrie))) AS geometry
+                    SELECT ST_AsGeoJSON(ST_Force2D(f_ST_NormalizeGeometryCollection(ST_Collect(geometrie)))) AS geometry
                     FROM troncon_de_route
                     INNER JOIN voie_nommee ON true
                     WHERE voie_nommee.id_pseudo_fpb = identifiant_voie_1_gauche
@@ -363,7 +363,7 @@ final class BdTopoRoadGeocoder implements RoadGeocoderInterface, IntersectionGeo
         try {
             $row = $this->bdtopoConnection->fetchAssociative(
                 \sprintf(
-                    'SELECT ST_AsGeoJSON(ST_Force2D(ST_Collect(%s))) AS geom
+                    'SELECT ST_AsGeoJSON(ST_Force2D(f_ST_NormalizeGeometryCollection(ST_Collect(%s)))) AS geom
                     FROM troncon_de_route AS t
                     WHERE ST_Intersects(t.geometrie, :areaGeometry)
                     %s

--- a/src/Infrastructure/Adapter/LineSectionMaker.php
+++ b/src/Infrastructure/Adapter/LineSectionMaker.php
@@ -92,7 +92,7 @@ final class LineSectionMaker implements LineSectionMakerInterface
                 FROM linestring AS l
             )
             SELECT ST_AsGeoJSON(
-                ST_Split(
+                f_ST_NormalizeGeometryCollection(ST_Split(
                     -- ST_Snap avoids intersection issues due to numerical rounding errors
                     -- https://postgis.net/docs/ST_Split.html
                     ST_Snap(
@@ -102,7 +102,7 @@ final class LineSectionMaker implements LineSectionMakerInterface
                         0.00001
                     ),
                     endpoints.geom
-                )
+                ))
             ) AS geom
             FROM merged_section AS s
             JOIN endpoints on true

--- a/src/Infrastructure/BacIdf/BacIdfTransformer.php
+++ b/src/Infrastructure/BacIdf/BacIdfTransformer.php
@@ -401,10 +401,11 @@ final class BacIdfTransformer
             $geometries[] = $feature['geometry'];
         }
 
-        $geometry = [
-            'type' => 'GeometryCollection',
-            'geometries' => $geometries,
-        ];
+        // Attention : une GeometryCollection à un seul élément ne serait pas conforme à la spec GeoJSON
+        // https://github.com/MTES-MCT/dialog/issues/1099
+        $geometry = \count($geometries) === 1
+            ? $geometries[0]
+            : ['type' => 'GeometryCollection', 'geometries' => $geometries];
 
         $locationCommand->namedStreet = new SaveNamedStreetCommand();
         $locationCommand->namedStreet->roadType = RoadTypeEnum::LANE->value;

--- a/src/Infrastructure/Persistence/Doctrine/BdTopoMigrations/Version20241204152107.php
+++ b/src/Infrastructure/Persistence/Doctrine/BdTopoMigrations/Version20241204152107.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\BdTopoMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241204152107 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'CREATE OR REPLACE FUNCTION public.f_ST_NormalizeGeometryCollection(geometry)
+            RETURNS geometry
+            LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+            AS $func$
+                SELECT CASE
+                    -- Les GeometryCollection à 1 seul élément ne sont pas conformes à la spec GeoJSON.
+                    WHEN ST_GeometryType($1) = \'ST_GeometryCollection\' AND ST_NumGeometries($1) = 1
+                        THEN ST_CollectionHomogenize($1)
+                    ELSE $1
+                END
+            $func$;',
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP FUNCTION IF EXISTS public.f_ST_NormalizeGeometryCollection');
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20241204142019.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20241204142019.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241204142019 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql(
+            'CREATE OR REPLACE FUNCTION public.f_ST_NormalizeGeometryCollection(geometry)
+            RETURNS geometry
+            LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT
+            AS $func$
+                SELECT CASE
+                    -- Les GeometryCollection à 1 seul élément ne sont pas conformes à la spec GeoJSON.
+                    WHEN ST_GeometryType($1) = \'ST_GeometryCollection\' AND ST_NumGeometries($1) = 1
+                        THEN ST_CollectionHomogenize($1)
+                    ELSE $1
+                END
+            $func$;',
+        );
+
+        $this->addSql(
+            'UPDATE location
+            SET geometry = f_ST_NormalizeGeometryCollection(geometry)
+        ',
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP FUNCTION IF EXISTS public.f_ST_NormalizeGeometryCollection');
+    }
+}

--- a/tests/Integration/Infrastructure/Adapter/LineSectionMakerTest.php
+++ b/tests/Integration/Infrastructure/Adapter/LineSectionMakerTest.php
@@ -134,15 +134,10 @@ final class LineSectionMakerTest extends KernelTestCase
                 'fromCoords' => Coordinates::fromLonLat(6, 1), // Maps to (6, 2) and (7, 1) on c
                 'toCoords' => Coordinates::fromLonLat(9, 2), // Maps to (7, 2) on c
                 'section' => json_encode([
-                    'type' => 'GeometryCollection',
-                    'geometries' => [
-                        [
-                            'type' => 'LineString',
-                            'coordinates' => [
-                                [6, 2],
-                                [7, 2],
-                            ],
-                        ],
+                    'type' => 'LineString',
+                    'coordinates' => [
+                        [6, 2],
+                        [7, 2],
                     ],
                 ]),
             ],
@@ -150,15 +145,10 @@ final class LineSectionMakerTest extends KernelTestCase
                 'fromCoords' => Coordinates::fromLonLat(1, 2), // 3rd point of a (1st segment)
                 'toCoords' => Coordinates::fromLonLat(1, 1), // 1st point of a (1st segment)
                 'section' => json_encode([
-                    'type' => 'GeometryCollection',
-                    'geometries' => [
-                        [
-                            'type' => 'LineString',
-                            'coordinates' => [
-                                [1, 1],
-                                [1, 2],
-                            ],
-                        ],
+                    'type' => 'LineString',
+                    'coordinates' => [
+                        [1, 1],
+                        [1, 2],
                     ],
                 ]),
             ],
@@ -166,15 +156,10 @@ final class LineSectionMakerTest extends KernelTestCase
                 'fromCoords' => Coordinates::fromLonLat(5, 1), // Maps to (5, 2) (intersection point) on a, b, c
                 'toCoords' => Coordinates::fromLonLat(9, 2), // Maps to (8, 2) on b
                 'section' => json_encode([
-                    'type' => 'GeometryCollection',
-                    'geometries' => [
-                        [
-                            'type' => 'LineString',
-                            'coordinates' => [
-                                [5, 2],
-                                [7, 2],
-                            ],
-                        ],
+                    'type' => 'LineString',
+                    'coordinates' => [
+                        [5, 2],
+                        [7, 2],
                     ],
                 ]),
             ],
@@ -182,15 +167,10 @@ final class LineSectionMakerTest extends KernelTestCase
                 'fromCoords' => Coordinates::fromLonLat(7, 1),
                 'toCoords' => Coordinates::fromLonLat(9.6, 2), // P
                 'section' => json_encode([
-                    'type' => 'GeometryCollection',
-                    'geometries' => [
-                        [
-                            'type' => 'LineString',
-                            'coordinates' => [
-                                [7, 2],
-                                [7, 1],
-                            ],
-                        ],
+                    'type' => 'LineString',
+                    'coordinates' => [
+                        [7, 2],
+                        [7, 1],
                     ],
                 ]),
                 'getTolerance' => fn ($bdtopoConnection) => 1.01 // Just above

--- a/tests/Unit/Infrastructure/BacIdf/BacIdfTransformerTest.php
+++ b/tests/Unit/Infrastructure/BacIdf/BacIdfTransformerTest.php
@@ -75,17 +75,12 @@ final class BacIdfTransformerTest extends TestCase
         $locationCommand->namedStreet->toHouseNumber = null;
         $locationCommand->namedStreet->geometry = json_encode(
             [
-                'type' => 'GeometryCollection',
-                'geometries' => [
-                    [
-                        'type' => 'LineString',
-                        'coordinates' => [
-                            [2.3844267, 48.9207082],
-                            [2.3844462, 48.9207571],
-                            [2.3847146, 48.9214287],
-                            [2.3847305, 48.9214627],
-                        ],
-                    ],
+                'type' => 'LineString',
+                'coordinates' => [
+                    [2.3844267, 48.9207082],
+                    [2.3844462, 48.9207571],
+                    [2.3847146, 48.9214287],
+                    [2.3847305, 48.9214627],
                 ],
             ],
         );
@@ -194,15 +189,10 @@ final class BacIdfTransformerTest extends TestCase
         $locationCommand->namedStreet->toHouseNumber = null;
         $locationCommand->namedStreet->geometry = json_encode(
             [
-                'type' => 'GeometryCollection',
-                'geometries' => [
-                    [
-                        'type' => 'LineString',
-                        'coordinates' => [
-                            [2.3820543, 48.9220036],
-                            [2.3821628, 48.9221769],
-                        ],
-                    ],
+                'type' => 'LineString',
+                'coordinates' => [
+                    [2.3820543, 48.9220036],
+                    [2.3821628, 48.9221769],
                 ],
             ],
         );
@@ -606,15 +596,10 @@ final class BacIdfTransformerTest extends TestCase
         $locationCommand->namedStreet->toHouseNumber = null;
         $locationCommand->namedStreet->geometry = json_encode(
             [
-                'type' => 'GeometryCollection',
-                'geometries' => [
-                    [
-                        'type' => 'LineString',
-                        'coordinates' => [
-                            [2.3820543, 48.9220036],
-                            [2.3821628, 48.9221769],
-                        ],
-                    ],
+                'type' => 'LineString',
+                'coordinates' => [
+                    [2.3820543, 48.9220036],
+                    [2.3821628, 48.9221769],
                 ],
             ],
         );


### PR DESCRIPTION
* Closes #1099 

La PR corrige les géomtries existantes avec une migration et corrige les endroits où on manipule des GeometryCollection pour les "normaliser" (utiliser la géométrie s'il n'y a qu'elle dans la GeometryCollection)