### PR TITLE
Supprime heure de début pour arrêté permanent

### DIFF
--- a/config/validator/Application/Regulation/Command/SavePeriodCommand.xml
+++ b/config/validator/Application/Regulation/Command/SavePeriodCommand.xml
@@ -10,9 +10,14 @@
             </constraint>
         </property>
         <property name="startTime">
-            <constraint name="NotBlank"/>
-            <constraint name="Type">
-                <option name="type">\DateTimeInterface</option>
+            <constraint name="When">
+                <option name="expression"> !this.isPermanent </option>
+                <option name="constraints">
+                    <constraint name="NotBlank"/>
+                    <constraint name="Type">
+                        <option name="type">\DateTimeInterface</option>
+                    </constraint>
+                </option>
             </constraint>
         </property>
         <property name="endDate">

--- a/src/Application/Regulation/Command/Period/SavePeriodCommandHandler.php
+++ b/src/Application/Regulation/Command/Period/SavePeriodCommandHandler.php
@@ -25,7 +25,12 @@ final class SavePeriodCommandHandler
     public function __invoke(SavePeriodCommand $command): Period
     {
         $command->clean();
-        $command->startDate = $this->dateUtils->mergeDateAndTime($command->startDate, $command->startTime);
+
+        // In the case of a temporary order only
+        if ($command->startTime) {
+            $command->startDate = $this->dateUtils->mergeDateAndTime($command->startDate, $command->startTime);
+        }
+
         $command->endDate = $command->endDate && $command->endTime
             ? $this->dateUtils->mergeDateAndTime($command->endDate, $command->endTime)
             : null;

--- a/src/Application/Regulation/Command/Period/SavePeriodCommandHandler.php
+++ b/src/Application/Regulation/Command/Period/SavePeriodCommandHandler.php
@@ -26,8 +26,11 @@ final class SavePeriodCommandHandler
     {
         $command->clean();
 
-        // In the case of a temporary order only
-        if ($command->startTime) {
+        // Les arrêtés permanents n'ont qu'un champ date de début,
+        // mais pour les temporaires il faut joindre la date et l'heure
+        // dans un même datetime.
+
+        if (!$command->isPermanent) {
             $command->startDate = $this->dateUtils->mergeDateAndTime($command->startDate, $command->startTime);
         }
 

--- a/src/Application/Regulation/View/PeriodView.php
+++ b/src/Application/Regulation/View/PeriodView.php
@@ -8,7 +8,7 @@ readonly class PeriodView
 {
     public function __construct(
         public string $recurrenceType,
-        public \DateTimeInterface $startDateTime,
+        public ?\DateTimeInterface $startDateTime,
         public ?\DateTimeInterface $endDateTime,
         public ?DailyRangeView $dailyRange,
         public ?array $timeSlots,

--- a/src/Infrastructure/Form/Regulation/PeriodFormType.php
+++ b/src/Infrastructure/Form/Regulation/PeriodFormType.php
@@ -35,20 +35,29 @@ final class PeriodFormType extends AbstractType
                     'label' => 'regulation.period.endTime',
                     'widget' => 'choice',
                     'view_timezone' => $this->clientTimezone,
+                ])
+                ->add('startDate', DateType::class, [
+                    'label' => 'regulation.period.startDate',
+                    'widget' => 'single_text',
+                    'view_timezone' => $this->clientTimezone,
+                ])
+                ->add('startTime', TimeType::class, [
+                    'label' => 'regulation.period.startTime',
+                    'widget' => 'choice',
+                    'view_timezone' => $this->clientTimezone,
+                ]);
+        }
+
+        if ($options['isPermanent']) {
+            $builder
+                ->add('startDate', DateType::class, [
+                    'label' => 'regulation.period.startDate',
+                    'widget' => 'single_text',
+                    'view_timezone' => $this->clientTimezone,
                 ]);
         }
 
         $builder
-            ->add('startDate', DateType::class, [
-                'label' => 'regulation.period.startDate',
-                'widget' => 'single_text',
-                'view_timezone' => $this->clientTimezone,
-            ])
-            ->add('startTime', TimeType::class, [
-                'label' => 'regulation.period.startTime',
-                'widget' => 'choice',
-                'view_timezone' => $this->clientTimezone,
-            ])
             ->add('recurrenceType', ChoiceType::class,
                 options: $this->getRecurrenceTypeOptions(),
             )

--- a/src/Infrastructure/Form/Regulation/PeriodFormType.php
+++ b/src/Infrastructure/Form/Regulation/PeriodFormType.php
@@ -24,7 +24,14 @@ final class PeriodFormType extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
-        if (!$options['isPermanent']) {
+        if ($options['isPermanent']) {
+            $builder
+                ->add('startDate', DateType::class, [
+                    'label' => 'regulation.period.startDate',
+                    'widget' => 'single_text',
+                    'view_timezone' => $this->clientTimezone,
+                ]);
+        } else {
             $builder
                 ->add('endDate', DateType::class, [
                     'label' => 'regulation.period.endDate',
@@ -44,15 +51,6 @@ final class PeriodFormType extends AbstractType
                 ->add('startTime', TimeType::class, [
                     'label' => 'regulation.period.startTime',
                     'widget' => 'choice',
-                    'view_timezone' => $this->clientTimezone,
-                ]);
-        }
-
-        if ($options['isPermanent']) {
-            $builder
-                ->add('startDate', DateType::class, [
-                    'label' => 'regulation.period.startDate',
-                    'widget' => 'single_text',
                     'view_timezone' => $this->clientTimezone,
                 ]);
         }

--- a/templates/regulation/_period.html.twig
+++ b/templates/regulation/_period.html.twig
@@ -4,7 +4,8 @@
     {%- elseif period.startDateTime and not period.endDateTime  -%}
         {{ 'common.date.starting'|trans({'%date%': app_datetime(period.startDateTime, true) }) }}
     {%- else -%}
-        {{ app_datetime(period.startDateTime, true) }}
+        { {{ app_datetime(period.startDateTime, true) }} }
+       
     {%- endif -%}
     {%- if period.dailyRange -%}
         ,&nbsp;

--- a/templates/regulation/_period.html.twig
+++ b/templates/regulation/_period.html.twig
@@ -4,7 +4,7 @@
     {%- elseif period.startDateTime and not period.endDateTime  -%}
         {{ 'common.date.starting'|trans({'%date%': app_datetime(period.startDateTime, true) }) }}
     {%- else -%}
-        { {{ app_datetime(period.startDateTime, true) }} }
+        {{ app_datetime(period.startDateTime, true) }}
        
     {%- endif -%}
     {%- if period.dailyRange -%}

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -24,15 +24,15 @@
         </div>
         <div class="app-card__content">
             <div class="fr-x-container--fluid">
-				{% if form.isPermanent.vars.value %}
+                {% if form.isPermanent.vars.value %}
                 	<div class="fr-grid-row fr-grid-row--gutters">
                 	    {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5'}, attr: {class: 'fr-input'}}) }}
                 	</div>
-				{% endif %}
+                {% endif %}
                 {% if not form.isPermanent.vars.value %}
                     <div class="fr-grid-row fr-grid-row--gutters">
-						{{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5'}, attr: {class: 'fr-input'}}) }}
-						{{ form_row(form.startTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col fr-mb-3w fr-col-md-6 fr-mt-1w'} }) }}
+                        {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5'}, attr: {class: 'fr-input'}}) }}
+                        {{ form_row(form.startTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col fr-mb-3w fr-col-md-6 fr-mt-1w'} }) }}
                         {{ form_row(form.endDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5 '}, attr: {class: 'fr-input'}}) }}
                         {{ form_row(form.endTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col fr-mb-3w fr-col-md-6 fr-mt-1w'} }) }}
                     </div>

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -26,10 +26,9 @@
             <div class="fr-x-container--fluid">
                 {% if form.isPermanent.vars.value %}
                 	<div class="fr-grid-row fr-grid-row--gutters">
-                	    {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5'}, attr: {class: 'fr-input'}}) }}
+                	    {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5 fr-mb-3w'}, attr: {class: 'fr-input'}}) }}
                 	</div>
-                {% endif %}
-                {% if not form.isPermanent.vars.value %}
+                {% else %}
                     <div class="fr-grid-row fr-grid-row--gutters">
                         {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5'}, attr: {class: 'fr-input'}}) }}
                         {{ form_row(form.startTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col fr-mb-3w fr-col-md-6 fr-mt-1w'} }) }}

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -24,12 +24,15 @@
         </div>
         <div class="app-card__content">
             <div class="fr-x-container--fluid">
-                <div class="fr-grid-row fr-grid-row--gutters">
-                    {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5'}, attr: {class: 'fr-input'}}) }}
-                    {{ form_row(form.startTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col fr-mb-3w fr-col-md-6 fr-mt-1w'} }) }}
-                </div>
+				{% if form.isPermanent.vars.value %}
+                	<div class="fr-grid-row fr-grid-row--gutters">
+                	    {{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5'}, attr: {class: 'fr-input'}}) }}
+                	</div>
+				{% endif %}
                 {% if not form.isPermanent.vars.value %}
                     <div class="fr-grid-row fr-grid-row--gutters">
+						{{ form_row(form.startDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5'}, attr: {class: 'fr-input'}}) }}
+						{{ form_row(form.startTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col fr-mb-3w fr-col-md-6 fr-mt-1w'} }) }}
                         {{ form_row(form.endDate, {group_class: 'fr-input-group', row_attr: {class: 'fr-col-12 fr-col-md-5 '}, attr: {class: 'fr-input'}}) }}
                         {{ form_row(form.endTime, {group_class: 'fr-input-group', row_attr: {class: 'fr-col fr-mb-3w fr-col-md-6 fr-mt-1w'} }) }}
                     </div>

--- a/tests/Integration/Infrastructure/Controller/Regulation/DuplicateRegulationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/DuplicateRegulationControllerTest.php
@@ -28,7 +28,7 @@ final class DuplicateRegulationControllerTest extends AbstractWebTestCase
         // Measure
         $this->assertSame('Circulation interdite', $measures->eq(0)->filter('h3')->text());
         $this->assertSame('pour tous les véhicules', $measures->eq(0)->filter('.app-card__content li')->eq(0)->text());
-        $this->assertSame('à partir du 11/03/2023 à 00h00', $measures->eq(0)->filter('.app-card__content li')->eq(1)->text()); // Date comes from DateUtilsMock
+        $this->assertSame('à partir du 11/03/2023 à 00h00', $measures->eq(0)->filter('.app-card__content li')->eq(1)->text());
         $this->assertSame('Rue du Simplon à Paris 18e Arrondissement (75018)', $measures->eq(0)->filter('.app-card__content li')->eq(3)->text());
     }
 

--- a/tests/Integration/Infrastructure/Controller/Regulation/DuplicateRegulationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/DuplicateRegulationControllerTest.php
@@ -28,7 +28,7 @@ final class DuplicateRegulationControllerTest extends AbstractWebTestCase
         // Measure
         $this->assertSame('Circulation interdite', $measures->eq(0)->filter('h3')->text());
         $this->assertSame('pour tous les véhicules', $measures->eq(0)->filter('.app-card__content li')->eq(0)->text());
-        $this->assertSame('à partir du 09/06/2023 à 10h00', $measures->eq(0)->filter('.app-card__content li')->eq(1)->text()); // Date comes from DateUtilsMock
+        $this->assertSame('à partir du 09/06/2023 à 00h00', $measures->eq(0)->filter('.app-card__content li')->eq(1)->text()); // Date comes from DateUtilsMock
         $this->assertSame('Rue du Simplon à Paris 18e Arrondissement (75018)', $measures->eq(0)->filter('.app-card__content li')->eq(3)->text());
     }
 

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
@@ -140,8 +140,6 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['periods'][0]['isPermanent'] = '1';
         $values['measure_form']['periods'][0]['recurrenceType'] = 'certainDays';
         $values['measure_form']['periods'][0]['startDate'] = '2023-10-30';
-        $values['measure_form']['periods'][0]['startTime']['hour'] = '8';
-        $values['measure_form']['periods'][0]['startTime']['minute'] = '0';
         $values['measure_form']['periods'][0]['dailyRange']['applicableDays'] = ['monday'];
         $values['measure_form']['periods'][0]['timeSlots'][0]['startTime']['hour'] = '8';
         $values['measure_form']['periods'][0]['timeSlots'][0]['startTime']['minute'] = '0';
@@ -196,8 +194,6 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['locations'][0]['namedStreet']['cityLabel'] = 'La Madeleine (59110)';
         $values['measure_form']['locations'][0]['namedStreet']['roadName'] = 'Rue de NOT_HANDLED_BY_MOCK';
         $values['measure_form']['periods'][0]['startDate'] = '2023-10-30';
-        $values['measure_form']['periods'][0]['startTime']['hour'] = '8';
-        $values['measure_form']['periods'][0]['startTime']['minute'] = '0';
 
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
         $this->assertResponseStatusCodeSame(422);
@@ -229,8 +225,6 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['locations'][0]['namedStreet']['toHouseNumber'] = '';
         $values['measure_form']['locations'][0]['namedStreet']['direction'] = DirectionEnum::BOTH->value;
         $values['measure_form']['periods'][0]['startDate'] = '2023-10-30';
-        $values['measure_form']['periods'][0]['startTime']['hour'] = '0';
-        $values['measure_form']['periods'][0]['startTime']['minute'] = '0';
 
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
@@ -334,8 +328,6 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['locations'][0]['namedStreet']['toHouseNumber'] = '999'; // Mock will return no result
         $values['measure_form']['locations'][0]['namedStreet']['direction'] = DirectionEnum::BOTH->value;
         $values['measure_form']['periods'][0]['startDate'] = '2023-10-30';
-        $values['measure_form']['periods'][0]['startTime']['hour'] = '0';
-        $values['measure_form']['periods'][0]['startTime']['minute'] = '0';
 
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
@@ -366,8 +358,6 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['locations'][0]['namedStreet']['toHouseNumber'] = '44'; // Not on same section than 80
         $values['measure_form']['locations'][0]['namedStreet']['direction'] = DirectionEnum::BOTH->value;
         $values['measure_form']['periods'][0]['startDate'] = '2023-10-30';
-        $values['measure_form']['periods'][0]['startTime']['hour'] = '0';
-        $values['measure_form']['periods'][0]['startTime']['minute'] = '0';
 
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
@@ -432,8 +422,6 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['vehicleSet']['allVehicles'] = 'yes';
         $values['measure_form']['locations'][0] = $locationForm;
         $values['measure_form']['periods'][0]['startDate'] = '2023-10-30';
-        $values['measure_form']['periods'][0]['startTime']['hour'] = '0';
-        $values['measure_form']['periods'][0]['startTime']['minute'] = '0';
 
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
@@ -470,8 +458,6 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['locations'][0]['departmentalRoad']['fromAbscissa'] = 100;
         $values['measure_form']['locations'][0]['departmentalRoad']['toAbscissa'] = 650;
         $values['measure_form']['periods'][0]['startDate'] = '2023-10-30';
-        $values['measure_form']['periods'][0]['startTime']['hour'] = '0';
-        $values['measure_form']['periods'][0]['startTime']['minute'] = '0';
 
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
@@ -504,8 +490,6 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['locations'][0]['departmentalRoad']['fromAbscissa'] = 100000000;
         $values['measure_form']['locations'][0]['departmentalRoad']['toAbscissa'] = 650;
         $values['measure_form']['periods'][0]['startDate'] = '2023-10-30';
-        $values['measure_form']['periods'][0]['startTime']['hour'] = '0';
-        $values['measure_form']['periods'][0]['startTime']['minute'] = '0';
 
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
@@ -538,8 +522,6 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['locations'][0]['departmentalRoad']['fromAbscissa'] = 100;
         $values['measure_form']['locations'][0]['departmentalRoad']['toAbscissa'] = 100000000;
         $values['measure_form']['periods'][0]['startDate'] = '2023-10-30';
-        $values['measure_form']['periods'][0]['startTime']['hour'] = '0';
-        $values['measure_form']['periods'][0]['startTime']['minute'] = '0';
 
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
@@ -869,7 +851,6 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
 
         $this->assertResponseStatusCodeSame(422);
-        $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#measure_form_periods_0_startTime_error')->text());
         $this->assertSame('Cette valeur ne doit pas être vide.', $crawler->filter('#measure_form_periods_0_startDate_error')->text());
     }
 

--- a/tests/Unit/Application/Regulation/Command/Period/SavePeriodCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Period/SavePeriodCommandHandlerTest.php
@@ -132,15 +132,10 @@ final class SavePeriodCommandHandlerTest extends TestCase
     public function testCreateWithoutEndDate(): void
     {
         $startDateTime = new \DateTimeImmutable('2023-05-22');
-        $startTime = new \DateTimeImmutable('2023-05-22 10:00:00');
-
-        $mergedStartDateTime = new \DateTimeImmutable('2023-05-22 10:00:00');
 
         $this->dateUtils
-            ->expects(self::once())
-            ->method('mergeDateAndTime')
-            ->withConsecutive([$startDateTime, $startTime])
-            ->willReturnOnConsecutiveCalls($mergedStartDateTime);
+            ->expects(self::never())
+            ->method('mergeDateAndTime');
 
         $this->idFactory
             ->expects(self::once())
@@ -164,7 +159,7 @@ final class SavePeriodCommandHandlerTest extends TestCase
                     new Period(
                         uuid: '7fb74c5d-069b-4027-b994-7545bb0942d0',
                         measure: $measure,
-                        startDateTime: $mergedStartDateTime,
+                        startDateTime: $startDateTime,
                         endDateTime: null,
                         recurrenceType: PeriodRecurrenceTypeEnum::CERTAIN_DAYS->value,
                     ),
@@ -206,7 +201,7 @@ final class SavePeriodCommandHandlerTest extends TestCase
         $command->measure = $measure;
         $command->startDate = $startDateTime;
         $command->endDate = null;
-        $command->startTime = $startTime;
+        $command->startTime = null;
         $command->endTime = null;
         $command->recurrenceType = PeriodRecurrenceTypeEnum::CERTAIN_DAYS->value;
         $command->dailyRange = $dailyRangeCommand;

--- a/tests/Unit/Application/Regulation/Command/Period/SavePeriodCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Period/SavePeriodCommandHandlerTest.php
@@ -129,7 +129,7 @@ final class SavePeriodCommandHandlerTest extends TestCase
         $this->assertSame($createdPeriod, $result);
     }
 
-    public function testCreateWithoutEndDate(): void
+    public function testCreateWithoutStartTimeAndEndDate(): void
     {
         $startDateTime = new \DateTimeImmutable('2023-05-22');
 
@@ -198,6 +198,7 @@ final class SavePeriodCommandHandlerTest extends TestCase
             ->willReturnOnConsecutiveCalls($createdTimeSlot, $createdDailyRange);
 
         $command = new SavePeriodCommand();
+        $command->isPermanent = true;
         $command->measure = $measure;
         $command->startDate = $startDateTime;
         $command->endDate = null;


### PR DESCRIPTION
Traite le point 6° de #1056 : On peut enlever l'heure de début pour une réglementation permanente mais il faudrait garder le jour de début

![Capture d’écran du 2024-12-04 17-25-22](https://github.com/user-attachments/assets/ccf34a8e-d22e-48fb-9e03-a816cd14a00d)
