### PR TITLE
Corrige les caractères encodés dans la popup carte

### DIFF
--- a/src/Infrastructure/Twig/AppExtension.php
+++ b/src/Infrastructure/Twig/AppExtension.php
@@ -130,12 +130,12 @@ class AppExtension extends \Twig\Extension\AbstractExtension
         return $this->featureFlagService->isFeatureEnabled($featureName, $request);
     }
 
-    public function capFirst(string $text): string
+    public function capFirst(string $text): \Twig\Markup
     {
         if (!$text) {
-            return '';
+            return new \Twig\Markup('', 'utf-8');
         }
 
-        return strtoupper(substr($text, 0, 1)) . substr($text, 1);
+        return new \Twig\Markup(strtoupper(substr($text, 0, 1)) . substr($text, 1), 'utf-8');
     }
 }

--- a/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
+++ b/tests/Unit/Infrastructure/Twig/AppExtensionTest.php
@@ -236,9 +236,9 @@ class AppExtensionTest extends TestCase
 
     public function testCapFirst(): void
     {
-        $this->assertSame('', $this->extension->capFirst(''));
-        $this->assertSame('Test', $this->extension->capFirst('test'));
-        $this->assertSame('Test me', $this->extension->capFirst('test me'));
-        $this->assertSame('Test me First', $this->extension->capFirst('test me First'));
+        $this->assertSame('', (string) $this->extension->capFirst(''));
+        $this->assertSame('Test', (string) $this->extension->capFirst('test'));
+        $this->assertSame('Test me', (string) $this->extension->capFirst('test me'));
+        $this->assertSame('Test me First', (string) $this->extension->capFirst('test me First'));
     }
 }


### PR DESCRIPTION
* Closes #1009 

Dans la DB les apostrophes ne sont pas encodées, ce sont bien des `'`, et en local si je crée un arrêté avec un "Sauf autre" qui vaut "les véhicules de l'entreprise", j'ai le même affichage encodé dans la popup

Donc le problème venait bien de l'affichage de la popup et pas des données

En fait c'est le filtre `app_capFirst` qui n'était pas marqué comme renvoyant du "markup" et donc Twig échappait son résultat lors du rendu. https://stackoverflow.com/questions/60084156/can-i-mark-a-twig-variable-equally-as-safe-as-a-captured-chunk-of-text