### PR TITLE
Ajoute Sens concerné sur les routes départementales et nationales

### DIFF
--- a/src/Application/Regulation/Command/DuplicateMeasureCommandHandler.php
+++ b/src/Application/Regulation/Command/DuplicateMeasureCommandHandler.php
@@ -73,6 +73,7 @@ final class DuplicateMeasureCommandHandler
                 $numberedRoadCmd->toPointNumber = $numberedRoad->getToPointNumber();
                 $numberedRoadCmd->toAbscissa = $numberedRoad->getToAbscissa();
                 $numberedRoadCmd->toSide = $numberedRoad->getToSide();
+                $numberedRoadCmd->direction = $numberedRoad->getDirection();
                 $cmd->assignNumberedRoad($numberedRoadCmd);
             } elseif ($namedStreet = $location->getNamedStreet()) {
                 $cmd->namedStreet = new SaveNamedStreetCommand();

--- a/src/Application/Regulation/Command/Location/SaveNumberedRoadCommand.php
+++ b/src/Application/Regulation/Command/Location/SaveNumberedRoadCommand.php
@@ -6,6 +6,7 @@ namespace App\Application\Regulation\Command\Location;
 
 use App\Application\QueryInterface;
 use App\Application\Regulation\Query\Location\GetNumberedRoadGeometryQuery;
+use App\Domain\Regulation\Enum\DirectionEnum;
 use App\Domain\Regulation\Location\Location;
 use App\Domain\Regulation\Location\NumberedRoad;
 use App\Domain\Regulation\Measure;
@@ -21,6 +22,7 @@ final class SaveNumberedRoadCommand implements RoadCommandInterface
     public ?string $toPointNumber = null;
     public ?int $toAbscissa = null;
     public ?string $toSide = null;
+    public string $direction = DirectionEnum::BOTH->value;
     public ?string $geometry = null;
     public ?Measure $measure;
     public ?Location $location = null;
@@ -36,6 +38,7 @@ final class SaveNumberedRoadCommand implements RoadCommandInterface
         $this->toPointNumber = $numberedRoad?->getToPointNumber();
         $this->toAbscissa = $numberedRoad?->getToAbscissa();
         $this->toSide = $numberedRoad?->getToSide();
+        $this->direction = $numberedRoad?->getDirection() ?? DirectionEnum::BOTH->value;
         $this->roadType = $numberedRoad?->getLocation()?->getRoadType();
     }
 

--- a/src/Application/Regulation/Command/Location/SaveNumberedRoadCommandHandler.php
+++ b/src/Application/Regulation/Command/Location/SaveNumberedRoadCommandHandler.php
@@ -23,6 +23,7 @@ final class SaveNumberedRoadCommandHandler
                 new NumberedRoad(
                     uuid: $this->idFactory->make(),
                     location: $command->location,
+                    direction: $command->direction,
                     roadNumber: $command->roadNumber,
                     administrator: $command->administrator,
                     fromPointNumber: $command->fromPointNumber,
@@ -48,6 +49,7 @@ final class SaveNumberedRoadCommandHandler
             toPointNumber: $command->toPointNumber,
             toAbscissa: $command->toAbscissa,
             toSide: $command->toSide,
+            direction: $command->direction,
         );
 
         return $command->numberedRoad;

--- a/src/Application/Regulation/Query/Location/GetNumberedRoadGeometryQueryHandler.php
+++ b/src/Application/Regulation/Query/Location/GetNumberedRoadGeometryQueryHandler.php
@@ -46,6 +46,7 @@ final class GetNumberedRoadGeometryQueryHandler implements QueryInterface
             $command->toPointNumber,
             $command->toSide,
             $command->toAbscissa ?? 0,
+            $command->direction,
         );
     }
 

--- a/src/Application/RoadSectionMakerInterface.php
+++ b/src/Application/RoadSectionMakerInterface.php
@@ -17,5 +17,6 @@ interface RoadSectionMakerInterface
         string $toPointNumber,
         string $toSide,
         int $toAbscissa,
+        string $direction,
     ): string;
 }

--- a/src/Domain/Regulation/Location/NumberedRoad.php
+++ b/src/Domain/Regulation/Location/NumberedRoad.php
@@ -9,6 +9,7 @@ class NumberedRoad
     public function __construct(
         private string $uuid,
         private Location $location,
+        private string $direction,
         private ?string $administrator = null,
         private ?string $roadNumber = null,
         private ?string $fromPointNumber = null,
@@ -70,7 +71,13 @@ class NumberedRoad
         return $this->toSide;
     }
 
+    public function getDirection(): string
+    {
+        return $this->direction;
+    }
+
     public function update(
+        string $direction,
         ?string $administrator = null,
         ?string $roadNumber = null,
         ?string $fromPointNumber = null,
@@ -88,5 +95,6 @@ class NumberedRoad
         $this->fromAbscissa = $fromAbscissa;
         $this->toAbscissa = $toAbscissa;
         $this->toSide = $toSide;
+        $this->direction = $direction;
     }
 }

--- a/src/Infrastructure/Adapter/RoadSectionMaker.php
+++ b/src/Infrastructure/Adapter/RoadSectionMaker.php
@@ -12,6 +12,7 @@ use App\Application\Exception\StartAbscissaOutOfRangeException;
 use App\Application\LineSectionMakerInterface;
 use App\Application\RoadGeocoderInterface;
 use App\Application\RoadSectionMakerInterface;
+use App\Domain\Regulation\Enum\DirectionEnum;
 
 final class RoadSectionMaker implements RoadSectionMakerInterface
 {
@@ -32,6 +33,7 @@ final class RoadSectionMaker implements RoadSectionMakerInterface
         string $toPointNumber,
         string $toSide,
         int $toAbscissa,
+        string $direction,
     ): string {
         try {
             $fromCoords = $this->roadGeocoder
@@ -49,6 +51,11 @@ final class RoadSectionMaker implements RoadSectionMakerInterface
             throw new EndAbscissaOutOfRangeException($roadType, previous: $e);
         } catch (GeocodingFailureException $e) {
             throw new RoadGeocodingFailureException($roadType, previous: $e);
+        }
+
+        // NOTE : Rien à faire pour le cas A vers B, on mettra le fait qu'une seule direction est concernée comme métadonnée dans les exports DATEX / CIFS / etc.
+        if ($direction === DirectionEnum::B_TO_A->value) {
+            [$fromCoords, $toCoords] = [$toCoords, $fromCoords];
         }
 
         try {

--- a/src/Infrastructure/Form/Regulation/NamedStreetFormType.php
+++ b/src/Infrastructure/Form/Regulation/NamedStreetFormType.php
@@ -129,13 +129,13 @@ final class NamedStreetFormType extends AbstractType
         $choices = [];
 
         foreach (DirectionEnum::cases() as $case) {
-            $choices[\sprintf('regulation.location.named_street.direction.%s', $case->value)] = $case->value;
+            $choices[\sprintf('regulation.location.direction.%s', $case->value)] = $case->value;
         }
 
         return [
             'choices' => $choices,
-            'label' => 'regulation.location.named_street.direction',
-            'help' => 'regulation.location.named_street.direction.help',
+            'label' => 'regulation.location.direction',
+            'help' => 'regulation.location.direction.help',
         ];
     }
 

--- a/src/Infrastructure/Form/Regulation/NumberedRoadFormType.php
+++ b/src/Infrastructure/Form/Regulation/NumberedRoadFormType.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\Form\Regulation;
 
 use App\Application\Regulation\Command\Location\SaveNumberedRoadCommand;
+use App\Domain\Regulation\Enum\DirectionEnum;
 use App\Domain\Regulation\Enum\RoadSideEnum;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -78,6 +79,7 @@ final class NumberedRoadFormType extends AbstractType
                     'help' => 'regulation.location.referencePoint.abscissa.help',
                 ],
             )
+            ->add('direction', ChoiceType::class, $this->getDirectionOptions())
             ->add('roadType', HiddenType::class, ['data' => $options['roadType']])
         ;
 
@@ -85,6 +87,7 @@ final class NumberedRoadFormType extends AbstractType
         $builder->addEventListener(FormEvents::PRE_SUBMIT, function (FormEvent $event): void {
             $data = $event->getData();
             $data['roadType'] = $event->getForm()->getParent()->get('roadType')->getData();
+            $data['direction'] = $data['direction'] ?? DirectionEnum::BOTH->value;
             $event->setData($data);
         });
     }
@@ -121,6 +124,21 @@ final class NumberedRoadFormType extends AbstractType
                 ['regulation.location.administrator.placeholder' => ''],
                 $choices,
             ),
+        ];
+    }
+
+    private function getDirectionOptions(): array
+    {
+        $choices = [];
+
+        foreach (DirectionEnum::cases() as $case) {
+            $choices[\sprintf('regulation.location.direction.%s', $case->value)] = $case->value;
+        }
+
+        return [
+            'choices' => $choices,
+            'label' => 'regulation.location.direction',
+            'help' => 'regulation.location.direction.help',
         ];
     }
 

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/LocationFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/LocationFixture.php
@@ -99,6 +99,7 @@ final class LocationFixture extends Fixture implements DependentFixtureInterface
         $numberedRoadTypicalMeasureLocation4 = new NumberedRoad(
             uuid: 'fae12210-025f-4450-8912-e73861ff7792',
             location: $typicalMeasureLocation4,
+            direction: DirectionEnum::BOTH->value,
             administrator: 'Loire-Atlantique',
             roadNumber: 'D17',
             fromPointNumber: '28',
@@ -194,6 +195,7 @@ final class LocationFixture extends Fixture implements DependentFixtureInterface
         $numberedRoadPublishedLocation4DepartmentalRoad = new NumberedRoad(
             uuid: '1346b8e4-e768-4370-90c3-2c3f8985b9d8',
             location: $publishedLocation4DepartmentalRoad,
+            direction: DirectionEnum::BOTH->value,
             administrator: 'Ardennes',
             roadNumber: 'D322',
             fromPointNumber: '1',
@@ -273,6 +275,7 @@ final class LocationFixture extends Fixture implements DependentFixtureInterface
         $numberedRoadCifsLocationDepartmentalRoad = new NumberedRoad(
             uuid: 'eb1f2403-8aaf-4a02-8d50-0b0dbc66f85c',
             location: $cifsLocationDepartmentalRoad,
+            direction: DirectionEnum::BOTH->value,
             administrator: 'Ardennes',
             roadNumber: 'D324',
             fromPointNumber: '1',

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.NumberedRoad.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/Regulation.Location.NumberedRoad.orm.xml
@@ -22,6 +22,7 @@
             <option name="default">0</option>
       </options>
     </field>
+    <field name="direction" type="string" column="direction" nullable="false" length="10" />
     <one-to-one field="location" target-entity="App\Domain\Regulation\Location\Location" inversed-by="numberedRoad">
         <join-column name="location_uuid" referenced-column-name="uuid" on-delete="CASCADE"/>
     </one-to-one>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20241205151339.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20241205151339.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241205151339 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE numbered_road ADD direction VARCHAR(10) DEFAULT NULL;');
+        $this->addSql("UPDATE numbered_road SET direction = 'BOTH';");
+        $this->addSql('ALTER TABLE numbered_road ALTER direction SET NOT NULL;');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE numbered_road DROP direction');
+    }
+}

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -255,6 +255,7 @@
                     {{ form_row(form[roadType].toAbscissa, { row_attr: {class:'fr-col-12 fr-col-md-4'}, attr: {class: 'fr-input'}}) }}
                 </div>
             </fieldset>
+            {{ form_row(form[roadType].direction, { group_class: 'fr-select-group', widget_class: 'fr-select' }) }}
         </fieldset>
     </div>
 {% endmacro %}

--- a/tests/Unit/Application/Regulation/Command/DuplicateMeasureCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/DuplicateMeasureCommandHandlerTest.php
@@ -182,6 +182,10 @@ final class DuplicateMeasureCommandHandlerTest extends TestCase
             ->willReturn($numberedRoad1);
         $numberedRoad1
             ->expects(self::once())
+            ->method('getDirection')
+            ->willReturn(DirectionEnum::BOTH->value);
+        $numberedRoad1
+            ->expects(self::once())
             ->method('getAdministrator')
             ->willReturn('Ardèche');
         $numberedRoad1
@@ -263,6 +267,7 @@ final class DuplicateMeasureCommandHandlerTest extends TestCase
         $locationCommand2->roadType = RoadTypeEnum::DEPARTMENTAL_ROAD->value;
         $numberedRoad = new SaveNumberedRoadCommand();
         $numberedRoad->roadType = RoadTypeEnum::DEPARTMENTAL_ROAD->value;
+        $numberedRoad->direction = DirectionEnum::BOTH->value;
         $numberedRoad->administrator = 'Ardèche';
         $numberedRoad->roadNumber = 'D110';
         $numberedRoad->fromPointNumber = '1';

--- a/tests/Unit/Application/Regulation/Command/Location/SaveNumberedRoadCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Location/SaveNumberedRoadCommandHandlerTest.php
@@ -9,6 +9,7 @@ use App\Application\Regulation\Command\Location\SaveNumberedRoadCommand;
 use App\Application\Regulation\Command\Location\SaveNumberedRoadCommandHandler;
 use App\Domain\Geography\Coordinates;
 use App\Domain\Geography\GeoJSON;
+use App\Domain\Regulation\Enum\DirectionEnum;
 use App\Domain\Regulation\Location\Location;
 use App\Domain\Regulation\Location\NumberedRoad;
 use App\Domain\Regulation\Repository\NumberedRoadRepositoryInterface;
@@ -26,6 +27,7 @@ final class SaveNumberedRoadCommandHandlerTest extends TestCase
     private string $toPointNumber;
     private string $toSide;
     private int $toAbscissa;
+    private string $direction;
 
     private MockObject $idFactory;
     private MockObject $numberedRoadRepository;
@@ -43,6 +45,7 @@ final class SaveNumberedRoadCommandHandlerTest extends TestCase
         $this->toPointNumber = '5';
         $this->toSide = 'U';
         $this->toAbscissa = 100;
+        $this->direction = DirectionEnum::BOTH->value;
 
         $this->geometry = GeoJSON::toLineString([
             Coordinates::fromLonLat(-1.935836, 47.347024),
@@ -73,6 +76,7 @@ final class SaveNumberedRoadCommandHandlerTest extends TestCase
                     new NumberedRoad(
                         uuid: '7fb74c5d-069b-4027-b994-7545bb0942d0',
                         location: $location,
+                        direction: $this->direction,
                         administrator: $this->administrator,
                         roadNumber: $this->roadNumber,
                         fromPointNumber: $this->fromPointNumber,
@@ -93,6 +97,7 @@ final class SaveNumberedRoadCommandHandlerTest extends TestCase
 
         $command = new SaveNumberedRoadCommand();
         $command->location = $location;
+        $command->direction = $this->direction;
         $command->administrator = $this->administrator;
         $command->roadNumber = $this->roadNumber;
         $command->fromPointNumber = $this->fromPointNumber;
@@ -114,6 +119,7 @@ final class SaveNumberedRoadCommandHandlerTest extends TestCase
             ->expects(self::once())
             ->method('update')
             ->with(
+                $this->direction,
                 $this->administrator,
                 $this->roadNumber,
                 $this->fromPointNumber,
@@ -138,6 +144,7 @@ final class SaveNumberedRoadCommandHandlerTest extends TestCase
         );
 
         $command = new SaveNumberedRoadCommand($numberedRoad);
+        $command->direction = $this->direction;
         $command->administrator = $this->administrator;
         $command->roadNumber = $this->roadNumber;
         $command->fromPointNumber = $this->fromPointNumber;

--- a/tests/Unit/Domain/Regulation/Location/NumberedRoadTest.php
+++ b/tests/Unit/Domain/Regulation/Location/NumberedRoadTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Domain\Regulation\Location;
 
+use App\Domain\Regulation\Enum\DirectionEnum;
 use App\Domain\Regulation\Location\Location;
 use App\Domain\Regulation\Location\NumberedRoad;
 use PHPUnit\Framework\TestCase;
@@ -17,6 +18,7 @@ final class NumberedRoadTest extends TestCase
         $numberedRoad = new NumberedRoad(
             uuid: '8785a4c2-8f0d-423e-bd5b-641f228df23b',
             location: $location,
+            direction: DirectionEnum::BOTH->value,
             administrator: 'Ardèche',
             roadNumber: 'D110',
             fromPointNumber: '14',
@@ -29,6 +31,7 @@ final class NumberedRoadTest extends TestCase
 
         $this->assertSame('8785a4c2-8f0d-423e-bd5b-641f228df23b', $numberedRoad->getUuid());
         $this->assertSame($location, $numberedRoad->getLocation());
+        $this->assertSame(DirectionEnum::BOTH->value, $numberedRoad->getDirection());
         $this->assertSame('Ardèche', $numberedRoad->getAdministrator());
         $this->assertSame('D110', $numberedRoad->getRoadNumber());
         $this->assertSame('14', $numberedRoad->getFromPointNumber());
@@ -39,6 +42,7 @@ final class NumberedRoadTest extends TestCase
         $this->assertSame('U', $numberedRoad->getToSide());
 
         $numberedRoad->update(
+            DirectionEnum::B_TO_A->value,
             'Ain',
             'D16',
             '10',
@@ -49,6 +53,7 @@ final class NumberedRoadTest extends TestCase
             0,
         );
 
+        $this->assertSame(DirectionEnum::B_TO_A->value, $numberedRoad->getDirection());
         $this->assertSame('Ain', $numberedRoad->getAdministrator());
         $this->assertSame('D16', $numberedRoad->getRoadNumber());
         $this->assertSame('10', $numberedRoad->getFromPointNumber());

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -677,24 +677,24 @@
                 <source>regulation.location.roadName.results_label</source>
                 <target>Noms de voies suggérés</target>
             </trans-unit>
-            <trans-unit id="regulation.location.named_street.direction">
-                <source>regulation.location.named_street.direction</source>
+            <trans-unit id="regulation.location.direction">
+                <source>regulation.location.direction</source>
                 <target>Sens concerné</target>
             </trans-unit>
-            <trans-unit id="regulation.location.named_street.direction.help">
-                <source>regulation.location.named_street.direction.help</source>
+            <trans-unit id="regulation.location.direction.help">
+                <source>regulation.location.direction.help</source>
                 <target>Définissez le sens impacté par la restriction.</target>
             </trans-unit>
-            <trans-unit id="regulation.location.named_street.direction.BOTH">
-                <source>regulation.location.named_street.direction.BOTH</source>
+            <trans-unit id="regulation.location.direction.BOTH">
+                <source>regulation.location.direction.BOTH</source>
                 <target>Double sens</target>
             </trans-unit>
-            <trans-unit id="regulation.location.named_street.direction.A_TO_B">
-                <source>regulation.location.named_street.direction.A_TO_B</source>
+            <trans-unit id="regulation.location.direction.A_TO_B">
+                <source>regulation.location.direction.A_TO_B</source>
                 <target>Sens A vers B</target>
             </trans-unit>
-            <trans-unit id="regulation.location.named_street.direction.B_TO_A">
-                <source>regulation.location.named_street.direction.B_TO_A</source>
+            <trans-unit id="regulation.location.direction.B_TO_A">
+                <source>regulation.location.direction.B_TO_A</source>
                 <target>Sens B vers A</target>
             </trans-unit>
             <trans-unit id="regulation.location.named_street.section">


### PR DESCRIPTION
* Ref #528 
* Suite de #1098 

Cette PR ajoute le champ "Sens concerné" aux localisations de type RD et RN

Pour l'instant il n'y a pas d'interaction avec les champs "Côté". (Par contre s'il y a incohérence, le géocodage échouera. Par ex si on choisit "Côté = D" (sens PR croissants) sur une nationale alors qu'on a choisit le sens B vers A où $$PR_A < PR_B$$. D'où l'idée d'inférer les côtés à partir du sens concerné)