### PR TITLE
Configure le tunnel SSH pour les migrations Metabase

### DIFF
--- a/.github/workflows/metabase_migrate.yml
+++ b/.github/workflows/metabase_migrate.yml
@@ -32,9 +32,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
+      - name: Install Scalingo CLI
+        run: curl -O https://cli-dl.scalingo.com/install && bash install
+
+      - name: Install SSH key
+        # Credit: https://stackoverflow.com/a/69234389
+        run: |
+          mkdir -p ~/.ssh
+          install -m 600 -D /dev/null ~/.ssh/id_rsa
+          echo "${{ secrets.GH_SCALINGO_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+
+      - name: Add Scalingo as a known host
+        run: |
+          ssh-keyscan -H ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
+
       - name: Init environment variables
         run: |
-          echo "METABASE_DATABASE_URL=${{ secrets.METABASE_MIGRATIONS_METABASE_DATABASE_URL }}" >> .env
+          echo "METABASE_DATABASE_URL=${{ secrets.METABASE_MIGRATIONS_METABASE_DATABASE_URL }}" >> .env.local
 
       - name: CI
         run: make ci_metabase_migrate BIN_COMPOSER="composer" BIN_CONSOLE="php bin/console"

--- a/Makefile
+++ b/Makefile
@@ -289,6 +289,8 @@ ci_bdtopo_migrate: ## Run CI steps for BD TOPO Migrate workflow
 
 ci_metabase_migrate: ## Run CI steps for Metabase Migrate workflow
 	make composer CMD="install -n --prefer-dist"
+	scalingo login --ssh --ssh-identity ~/.ssh/id_rsa
+	./tools/scalingodbtunnel dialog-metabase --host-url --port 10001 & ./tools/wait-for-it.sh 127.0.0.1:10001
 	make metabase_migrate
 
 ci_metabase_export: ## Export data to Metabase


### PR DESCRIPTION
* Suite au merge de #1116

La CI qui exécute les migrations Metabase échoue

https://github.com/MTES-MCT/dialog/actions/runs/12370148568/job/34523506389#step:7:229

```
 In Driver.php line 34:
                                                                               
  SQLSTATE[08006] [7] connection to server at "127.0.0.1", port 10001 failed:  
   Connection refused                                                          
  	Is the server running on that host and accepting TCP/IP connections?  
```

En effet j'avais copié la CI des migrations BDTOPO, mais la DB Metabase est privée, donc il faut passer par un tunnel SSH vers Scalingo.

J'ai pour cela repris la config du workflow Metabase Export