### PR TITLE
RD/RN : Détecte le côté à partir du sens concerné

### DIFF
--- a/src/Application/Exception/BothDirectionsNotSupportedAtPointNumbers.php
+++ b/src/Application/Exception/BothDirectionsNotSupportedAtPointNumbers.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Exception;
+
+class BothDirectionsNotSupportedAtPointNumbers extends GeocodingFailureException
+{
+}

--- a/src/Application/PointNumberSideDetectorInterface.php
+++ b/src/Application/PointNumberSideDetectorInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application;
+
+interface PointNumberSideDetectorInterface
+{
+    public function detect(
+        string $direction,
+        string $administrator,
+        string $roadNumber,
+        string $fromPointNumber,
+        int $fromAbscissa,
+        string $toPointNumber,
+        int $toAbscissa,
+    ): array;
+}

--- a/src/Application/Regulation/Query/Location/GetNumberedRoadGeometryQueryHandler.php
+++ b/src/Application/Regulation/Query/Location/GetNumberedRoadGeometryQueryHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Application\Regulation\Query\Location;
 
+use App\Application\PointNumberSideDetectorInterface;
 use App\Application\QueryInterface;
 use App\Application\RoadGeocoderInterface;
 use App\Application\RoadSectionMakerInterface;
@@ -13,11 +14,24 @@ final class GetNumberedRoadGeometryQueryHandler implements QueryInterface
     public function __construct(
         private RoadSectionMakerInterface $roadSectionMaker,
         private RoadGeocoderInterface $roadGeocoder,
+        private PointNumberSideDetectorInterface $pointNumberSideDetector,
     ) {
     }
 
     public function __invoke(GetNumberedRoadGeometryQuery $query): string
     {
+        $command = $query->command;
+
+        [$command->fromSide, $command->toSide] = $this->pointNumberSideDetector->detect(
+            $command->direction,
+            $command->administrator,
+            $command->roadNumber,
+            $command->fromPointNumber,
+            $command->fromAbscissa ?? 0,
+            $command->toPointNumber,
+            $command->toAbscissa ?? 0,
+        );
+
         if ($query->geometry) {
             return $query->geometry;
         }

--- a/src/Application/RoadGeocoderInterface.php
+++ b/src/Application/RoadGeocoderInterface.php
@@ -30,4 +30,10 @@ interface RoadGeocoderInterface
     public function findSectionsInArea(string $areaGeometry, array $excludeTypes = [], ?bool $clipToArea = false): string;
 
     public function convertPolygonRoadToLines(string $geometry): string;
+
+    public function getAvailableSidesAtPointNumber(
+        string $administrator,
+        string $roadNumber,
+        string $pointNumber,
+    ): array;
 }

--- a/src/Domain/Regulation/Location/NumberedRoad.php
+++ b/src/Domain/Regulation/Location/NumberedRoad.php
@@ -97,4 +97,17 @@ class NumberedRoad
         $this->toSide = $toSide;
         $this->direction = $direction;
     }
+
+    /**
+     * Compare two PR+abs.
+     * Return -1 if A < B, 0 if A === B, or 1 if A > B
+     */
+    public static function comparePointNumber(
+        string $pointNumberA,
+        int $abscissaA,
+        string $pointNumberB,
+        int $abscissaB,
+    ): int {
+        return 0;
+    }
 }

--- a/src/Infrastructure/Adapter/BdTopoRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/BdTopoRoadGeocoder.php
@@ -414,4 +414,34 @@ final class BdTopoRoadGeocoder implements RoadGeocoderInterface, IntersectionGeo
 
         return $row['geom'];
     }
+
+    public function getAvailableSidesAtPointNumber(
+        string $administrator,
+        string $roadNumber,
+        string $pointNumber,
+    ): array {
+        $rows = $this->bdtopoConnection->fetchAllAssociative(
+            \sprintf(
+                'SELECT p.cote AS side
+                FROM point_de_repere AS p
+                WHERE p.gestionnaire = :administrator
+                AND p.route = :roadNumber
+                AND p.numero = :pointNumber
+                ',
+            ),
+            [
+                'administrator' => $administrator,
+                'roadNumber' => $roadNumber,
+                'pointNumber' => $pointNumber,
+            ],
+        );
+
+        $sides = [];
+
+        foreach ($rows as $row) {
+            $sides[] = $row['side'];
+        }
+
+        return $sides;
+    }
 }

--- a/src/Infrastructure/Adapter/PointNumberSideDetector.php
+++ b/src/Infrastructure/Adapter/PointNumberSideDetector.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Adapter;
+
+use App\Application\Exception\BothDirectionsNotSupportedAtPointNumbers;
+use App\Application\PointNumberSideDetectorInterface;
+use App\Application\RoadGeocoderInterface;
+use App\Domain\Regulation\Enum\DirectionEnum;
+use App\Domain\Regulation\Enum\RoadSideEnum;
+use App\Domain\Regulation\Location\NumberedRoad;
+
+final class PointNumberSideDetector implements PointNumberSideDetectorInterface
+{
+    public function __construct(
+        private readonly RoadGeocoderInterface $roadGeocoder,
+    ) {
+    }
+
+    public function detect(
+        string $direction,
+        string $administrator,
+        string $roadNumber,
+        string $fromPointNumber,
+        int $fromAbscissa,
+        string $toPointNumber,
+        int $toAbscissa,
+    ): array {
+        $sidesAtFromPoint = $this->roadGeocoder->getAvailableSidesAtPointNumber(
+            $administrator,
+            $roadNumber,
+            $fromPointNumber,
+        );
+
+        $sidesAtToPoint = $this->roadGeocoder->getAvailableSidesAtPointNumber(
+            $administrator,
+            $roadNumber,
+            $toPointNumber,
+        );
+
+        $isSingleWayAtFromPoint = \in_array(RoadSideEnum::U->value, $sidesAtFromPoint);
+        $isSingleWayAtToPoint = \in_array(RoadSideEnum::U->value, $sidesAtToPoint);
+
+        if ($isSingleWayAtFromPoint || $isSingleWayAtToPoint) {
+            // L'un des deux PR au moins est sur une chaussée unique
+            // On doit forcément utiliser des PR de type U.
+            return [RoadSideEnum::U->value, RoadSideEnum::U->value];
+        }
+
+        // Les deux PR se trouvent sur une section à chaussée séparée.
+        // A priori, les deux côtés G ou D sont possibles au niveau de chaque PR.
+        // On choisit le côté adéquat en fonction de la direction demandée et de l'ordre
+        // des PR dans le sens des PR croissants.
+        // Le "Double sens" n'est pas supporté pour l'instant, il faut saisir deux localisations,
+        // une dans chaque sens.
+
+        if ($direction === DirectionEnum::BOTH->value) {
+            // TODO: handle in controller
+            throw new BothDirectionsNotSupportedAtPointNumbers();
+        }
+
+        if (NumberedRoad::comparePointNumber($fromPointNumber, $fromAbscissa, $toPointNumber, $toAbscissa) <= 0) {
+            // Le PR A est situé avant le PR B, dans l'ordre des PR croissants.
+            // On doit choisir le côté D si le sens A -> B est demandé, et le côté G sinon.
+            $side = $direction === DirectionEnum::A_TO_B->value
+                ? RoadSideEnum::D->value
+                : RoadSideEnum::G->value;
+
+            return [$side, $side];
+        }
+
+        // Le PR A est situé après le PR B, donc on choisit le côté G si A->B est demandé, et le côté D sinon.
+        $side = $direction === DirectionEnum::A_TO_B->value
+            ? RoadSideEnum::G->value
+            : RoadSideEnum::D->value;
+
+        return [$side, $side];
+    }
+}

--- a/src/Infrastructure/Form/Regulation/NumberedRoadFormType.php
+++ b/src/Infrastructure/Form/Regulation/NumberedRoadFormType.php
@@ -6,7 +6,6 @@ namespace App\Infrastructure\Form\Regulation;
 
 use App\Application\Regulation\Command\Location\SaveNumberedRoadCommand;
 use App\Domain\Regulation\Enum\DirectionEnum;
-use App\Domain\Regulation\Enum\RoadSideEnum;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -44,22 +43,12 @@ final class NumberedRoadFormType extends AbstractType
                 ],
             )
             ->add(
-                'fromSide',
-                ChoiceType::class,
-                options: $this->getRoadSideOptions(),
-            )
-            ->add(
                 'toPointNumber',
                 TextType::class,
                 options: [
                     'label' => 'regulation.location.referencePoint.pointNumber',
                     'help' => 'regulation.location.referencePoint.pointNumber.help',
                 ],
-            )
-            ->add(
-                'toSide',
-                ChoiceType::class,
-                options: $this->getRoadSideOptions(),
             )
             ->add(
                 'fromAbscissa',
@@ -90,23 +79,6 @@ final class NumberedRoadFormType extends AbstractType
             $data['direction'] = $data['direction'] ?? DirectionEnum::BOTH->value;
             $event->setData($data);
         });
-    }
-
-    private function getRoadSideOptions(): array
-    {
-        $choices = [];
-
-        foreach (RoadSideEnum::cases() as $case) {
-            $choices[\sprintf('regulation.location.road.side.%s', $case->value)] = $case->value;
-        }
-
-        return [
-            'choices' => array_merge(
-                $choices,
-            ),
-            'label' => 'regulation.location.road.side',
-            'help' => 'regulation.location.road.side.help',
-        ];
     }
 
     private function getAdministratorOptions(array $administrators, string $roadType): array

--- a/templates/regulation/fragments/_measure_form.html.twig
+++ b/templates/regulation/fragments/_measure_form.html.twig
@@ -238,7 +238,6 @@
                 </legend>
                 <div class="fr-grid-row fr-grid-row--gutters">
                     {{ form_row(form[roadType].fromPointNumber, { row_attr: {class:'fr-col-12 fr-col-md-4'}, attr: {class: 'fr-input'}}) }}
-                    {{ form_row(form[roadType].fromSide, { row_attr: {class:'fr-col-12 fr-col-md-4'}, attr: {class: 'fr-select'}}) }}
                     {{ form_row(form[roadType].fromAbscissa, { row_attr: {class:'fr-col-12 fr-col-md-4'}, attr: {class: 'fr-input'}}) }}
                 </div>
             </fieldset>
@@ -251,7 +250,6 @@
                 </legend>
                 <div class="fr-grid-row fr-grid-row--gutters">
                     {{ form_row(form[roadType].toPointNumber, { row_attr: {class:'fr-col-12 fr-col-md-4'}, attr: {class: 'fr-input'}}) }}
-                    {{ form_row(form[roadType].toSide, { row_attr: {class:'fr-col-12 fr-col-md-4'}, attr: {class: 'fr-select'}}) }}
                     {{ form_row(form[roadType].toAbscissa, { row_attr: {class:'fr-col-12 fr-col-md-4'}, attr: {class: 'fr-input'}}) }}
                 </div>
             </fieldset>

--- a/tests/Unit/Application/Regulation/Command/Location/SaveNumberedRoadCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/Location/SaveNumberedRoadCommandHandlerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Application\Regulation\Command\Location;
 
 use App\Application\IdFactoryInterface;
+use App\Application\PointNumberSideDetectorInterface;
 use App\Application\Regulation\Command\Location\SaveNumberedRoadCommand;
 use App\Application\Regulation\Command\Location\SaveNumberedRoadCommandHandler;
 use App\Domain\Geography\Coordinates;
@@ -31,11 +32,13 @@ final class SaveNumberedRoadCommandHandlerTest extends TestCase
 
     private MockObject $idFactory;
     private MockObject $numberedRoadRepository;
+    private $pointNumberSideDetector;
 
     public function setUp(): void
     {
         $this->idFactory = $this->createMock(IdFactoryInterface::class);
         $this->numberedRoadRepository = $this->createMock(NumberedRoadRepositoryInterface::class);
+        $this->pointNumberSideDetector = $this->createMock(PointNumberSideDetectorInterface::class);
 
         $this->administrator = 'Département de Loire-Atlantique';
         $this->roadNumber = 'D12';
@@ -90,9 +93,24 @@ final class SaveNumberedRoadCommandHandlerTest extends TestCase
             )
             ->willReturn($createdNumberedRoad);
 
+        $this->pointNumberSideDetector
+            ->expects(self::once())
+            ->method('detect')
+            ->with(
+                $this->direction,
+                $this->administrator,
+                $this->roadNumber,
+                $this->fromPointNumber,
+                $this->fromAbscissa,
+                $this->toPointNumber,
+                $this->toAbscissa,
+            )
+            ->willReturn([$this->fromSide, $this->toSide]);
+
         $handler = new SaveNumberedRoadCommandHandler(
             $this->idFactory,
             $this->numberedRoadRepository,
+            $this->pointNumberSideDetector,
         );
 
         $command = new SaveNumberedRoadCommand();
@@ -101,10 +119,8 @@ final class SaveNumberedRoadCommandHandlerTest extends TestCase
         $command->administrator = $this->administrator;
         $command->roadNumber = $this->roadNumber;
         $command->fromPointNumber = $this->fromPointNumber;
-        $command->fromSide = $this->fromSide;
         $command->fromAbscissa = $this->fromAbscissa;
         $command->toPointNumber = $this->toPointNumber;
-        $command->toSide = $this->toSide;
         $command->toAbscissa = $this->toAbscissa;
 
         $result = $handler($command);
@@ -138,9 +154,24 @@ final class SaveNumberedRoadCommandHandlerTest extends TestCase
             ->expects(self::never())
             ->method('add');
 
+        $this->pointNumberSideDetector
+            ->expects(self::once())
+            ->method('detect')
+            ->with(
+                $this->direction,
+                $this->administrator,
+                $this->roadNumber,
+                $this->fromPointNumber,
+                $this->fromAbscissa,
+                $this->toPointNumber,
+                $this->toAbscissa,
+            )
+            ->willReturn([$this->fromSide, $this->toSide]);
+
         $handler = new SaveNumberedRoadCommandHandler(
             $this->idFactory,
             $this->numberedRoadRepository,
+            $this->pointNumberSideDetector,
         );
 
         $command = new SaveNumberedRoadCommand($numberedRoad);

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -553,14 +553,6 @@
                 <source>regulation.location.referencePoint.to</source>
                 <target>Point de fin</target>
             </trans-unit>
-            <trans-unit id="regulation.location.road.side">
-                <source>regulation.location.road.side</source>
-                <target>Côté</target>
-            </trans-unit>
-            <trans-unit id="regulation.location.road.side.help">
-                <source>regulation.location.road.side.help</source>
-                <target>Côté de la route où se situe le PR</target>
-            </trans-unit>
             <trans-unit id="regulation.location.referencePoint">
                 <source>regulation.location.referencePoint</source>
                 <target>Section concernée</target>
@@ -568,18 +560,6 @@
             <trans-unit id="regulation.location.referencePoint.help">
                 <source>regulation.location.referencePoint.help</source>
                 <target>Indiquez la section de route concernée par la mesure. La restriction s'applique à toutes les voies de la chaussée</target>
-            </trans-unit>
-            <trans-unit id="regulation.location.road.side.D">
-                <source>regulation.location.road.side.D</source>
-                <target>Chaussée droite (D)</target>
-            </trans-unit>
-            <trans-unit id="regulation.location.road.side.G">
-                <source>regulation.location.road.side.G</source>
-                <target>Chaussée gauche (G)</target>
-            </trans-unit>
-            <trans-unit id="regulation.location.road.side.U">
-                <source>regulation.location.road.side.U</source>
-                <target>Chaussée unique (U)</target>
             </trans-unit>
             <trans-unit id="regulation.location.referencePoint.pointNumber">
                 <source>regulation.location.referencePoint.pointNumber</source>


### PR DESCRIPTION
* Ref #1094

Cette PR retire les champs "Côté" des formulaires de routes départementales et nationales

Le côté est calculé en fonction du sens concerné et de l'ordre des PR A et B (croissant / décroissant)

TODO

* Implémenter comparePointNumber()
* Afficher une erreur si les PR sont sur une route à chaussée séparée et qu'on demande "Double sens" : pour l'instant il faut créer une localisation par sens...