### PR TITLE
Enregistre la date de création de l'organisation

### DIFF
--- a/src/Application/User/Command/ConvertAccessRequestToUserCommandHandler.php
+++ b/src/Application/User/Command/ConvertAccessRequestToUserCommandHandler.php
@@ -50,10 +50,12 @@ final class ConvertAccessRequestToUserCommandHandler
 
         $organization = $this->organizationRepository->findOneBySiret($accessRequest->getSiret());
         $organizationRole = OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value; // Default organization role
+        $now = $this->dateUtils->getNow();
 
         if (!$organization) {
             $organizationRole = OrganizationRolesEnum::ROLE_ORGA_ADMIN->value; // The first user in an organization becomes an admin
             $organization = (new Organization($this->idFactory->make()))
+                ->setCreatedAt($now)
                 ->setSiret($accessRequest->getSiret())
                 ->setName($accessRequest->getOrganization());
             $this->organizationRepository->add($organization);
@@ -64,7 +66,7 @@ final class ConvertAccessRequestToUserCommandHandler
             ->setPassword($accessRequest->getPassword())
             ->setEmail($accessRequest->getEmail())
             ->setRoles([UserRolesEnum::ROLE_USER->value])
-            ->setRegistrationDate($this->dateUtils->getNow());
+            ->setRegistrationDate($now);
 
         $organizationUser = (new OrganizationUser($this->idFactory->make()))
             ->setUser($user)

--- a/src/Application/User/Command/SaveOrganizationCommandHandler.php
+++ b/src/Application/User/Command/SaveOrganizationCommandHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Application\User\Command;
 
+use App\Application\DateUtilsInterface;
 use App\Application\IdFactoryInterface;
 use App\Domain\User\Exception\SiretAlreadyExistException;
 use App\Domain\User\Organization;
@@ -13,6 +14,7 @@ final class SaveOrganizationCommandHandler
 {
     public function __construct(
         private IdFactoryInterface $idFactory,
+        private DateUtilsInterface $dateUtils,
         private OrganizationRepositoryInterface $organizationRepository,
     ) {
     }
@@ -21,6 +23,7 @@ final class SaveOrganizationCommandHandler
     {
         if (!$command->organization) {
             $organization = (new Organization($this->idFactory->make()))
+                ->setCreatedAt($this->dateUtils->getNow())
                 ->setSiret($command->siret)
                 ->setName($command->name);
 

--- a/src/Domain/User/Organization.php
+++ b/src/Domain/User/Organization.php
@@ -6,6 +6,7 @@ namespace App\Domain\User;
 
 class Organization
 {
+    private \DateTimeInterface $createdAt;
     private string $name;
     private ?string $siret;
     private ?string $logo;
@@ -18,6 +19,18 @@ class Organization
     public function getUuid(): string
     {
         return $this->uuid;
+    }
+
+    public function getCreatedAt(): \DateTimeInterface
+    {
+        return $this->createdAt;
+    }
+
+    public function setCreatedAt(\DateTimeInterface $createdAt): self
+    {
+        $this->createdAt = $createdAt;
+
+        return $this;
     }
 
     public function getName(): string

--- a/src/Infrastructure/Controller/Admin/OrganizationCrudController.php
+++ b/src/Infrastructure/Controller/Admin/OrganizationCrudController.php
@@ -8,6 +8,7 @@ use App\Application\IdFactoryInterface;
 use App\Domain\User\Organization;
 use EasyCorp\Bundle\EasyAdminBundle\Config\Crud;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\AbstractCrudController;
+use EasyCorp\Bundle\EasyAdminBundle\Field\DateField;
 use EasyCorp\Bundle\EasyAdminBundle\Field\TextField;
 
 final class OrganizationCrudController extends AbstractCrudController
@@ -29,6 +30,9 @@ final class OrganizationCrudController extends AbstractCrudController
     {
         return [
             TextField::new('name')->setLabel('Nom de l\'organisation'),
+            DateField::new('createdAt')
+                ->setLabel('Date de création')
+                ->setDisabled($pageName === Crud::PAGE_EDIT),
             TextField::new('siret')->setLabel('Siret'),
         ];
     }

--- a/src/Infrastructure/Persistence/Doctrine/Fixtures/OrganizationFixture.php
+++ b/src/Infrastructure/Persistence/Doctrine/Fixtures/OrganizationFixture.php
@@ -23,14 +23,17 @@ final class OrganizationFixture extends Fixture implements DependentFixtureInter
     {
         $mainOrg = (new Organization(self::MAIN_ORG_ID))
             ->setName(self::MAIN_ORG_NAME)
+            ->setCreatedAt(new \DateTimeImmutable('2022-11-01'))
             ->setLogo('/path/to/logo.jpeg');
 
         $otherOrg = (new Organization(self::OTHER_ORG_ID))
             ->setName('Mairie de Savenay')
+            ->setCreatedAt(new \DateTimeImmutable('2023-02-13'))
             ->setSiret('12345678909876');
 
         $otherOrg2 = (new Organization(self::OTHER_ORG_ID_2))
             ->setName('Mairie de Saint Ouen')
+            ->setCreatedAt(new \DateTimeImmutable('2023-06-24'))
             ->setSiret('67876540989876');
 
         $organizationUser1 = new OrganizationUser('53aede0c-1ff3-4873-9e3d-132950dfb893');

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/User.Organization.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/User.Organization.orm.xml
@@ -7,6 +7,11 @@
     <field name="name" type="string" column="name" nullable="false"/>
     <field name="siret" type="string" length="14" nullable="true"/>
     <field name="logo" type="string" length="200" nullable="true"/>
+    <field name="createdAt" type="datetimetz" nullable="false">
+        <options>
+          <option name="default">CURRENT_TIMESTAMP</option>
+        </options>
+    </field>
     <unique-constraints>
         <unique-constraint columns="siret" name="organization_siret" />
     </unique-constraints>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20241219094151.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20241219094151.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version20241219094151 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add column organization.created_at';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE organization ADD created_at TIMESTAMP(0) WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE organization DROP created_at');
+    }
+}

--- a/tests/Unit/Application/User/Command/ConvertAccessRequestToUserCommandHandlerTest.php
+++ b/tests/Unit/Application/User/Command/ConvertAccessRequestToUserCommandHandlerTest.php
@@ -192,6 +192,7 @@ final class ConvertAccessRequestToUserCommandHandlerTest extends TestCase
             ->setRegistrationDate($date);
 
         $organization = (new Organization('d145a0e3-e397-412c-ba6a-90b150f7aec2'))
+            ->setCreatedAt($date)
             ->setName('Fairness')
             ->setSiret('82050375300015');
 

--- a/tests/Unit/Application/User/Command/SaveOrganizationCommandHandlerTest.php
+++ b/tests/Unit/Application/User/Command/SaveOrganizationCommandHandlerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Tests\Unit\Application\User\Command;
 
+use App\Application\DateUtilsInterface;
 use App\Application\IdFactoryInterface;
 use App\Application\User\Command\SaveOrganizationCommand;
 use App\Application\User\Command\SaveOrganizationCommandHandler;
@@ -15,22 +16,31 @@ use PHPUnit\Framework\TestCase;
 final class SaveOrganizationCommandHandlerTest extends TestCase
 {
     private $idFactory;
+    private $dateUtils;
     private $organizationRepository;
 
     public function setUp(): void
     {
         $this->idFactory = $this->createMock(IdFactoryInterface::class);
+        $this->dateUtils = $this->createMock(DateUtilsInterface::class);
         $this->organizationRepository = $this->createMock(OrganizationRepositoryInterface::class);
     }
 
     public function testCreate(): void
     {
+        $date = new \DateTimeImmutable('2024-05-07');
+        $this->dateUtils
+            ->expects(self::once())
+            ->method('getNow')
+            ->willReturn($date);
+
         $this->idFactory
             ->expects(self::once())
             ->method('make')
             ->willReturn('7fb74c5d-069b-4027-b994-7545bb0942d0');
 
         $createdOrganization = (new Organization(uuid: '7fb74c5d-069b-4027-b994-7545bb0942d0'))
+            ->setCreatedAt($date)
             ->setSiret('21930027400012')
             ->setName('Commune de La Courneuve');
 
@@ -45,6 +55,7 @@ final class SaveOrganizationCommandHandlerTest extends TestCase
 
         $handler = new SaveOrganizationCommandHandler(
             $this->idFactory,
+            $this->dateUtils,
             $this->organizationRepository,
         );
 
@@ -87,6 +98,7 @@ final class SaveOrganizationCommandHandlerTest extends TestCase
 
         $handler = new SaveOrganizationCommandHandler(
             $this->idFactory,
+            $this->dateUtils,
             $this->organizationRepository,
         );
 
@@ -131,6 +143,7 @@ final class SaveOrganizationCommandHandlerTest extends TestCase
 
         $handler = new SaveOrganizationCommandHandler(
             $this->idFactory,
+            $this->dateUtils,
             $this->organizationRepository,
         );
 
@@ -177,6 +190,7 @@ final class SaveOrganizationCommandHandlerTest extends TestCase
 
         $handler = new SaveOrganizationCommandHandler(
             $this->idFactory,
+            $this->dateUtils,
             $this->organizationRepository,
         );
 

--- a/tests/Unit/Domain/User/OrganizationTest.php
+++ b/tests/Unit/Domain/User/OrganizationTest.php
@@ -11,12 +11,16 @@ final class OrganizationTest extends TestCase
 {
     public function testGetters(): void
     {
+        $date = new \DateTimeImmutable('2024-05-07');
+
         $organization = (new Organization('6598fd41-85cb-42a6-9693-1bc45f4dd392'))
+            ->setCreatedAt($date)
             ->setName('Mairie de Savenay')
             ->setSiret('21440195200129')
             ->setLogo('/path/to/logo.jpg');
 
         $this->assertSame('6598fd41-85cb-42a6-9693-1bc45f4dd392', $organization->getUuid());
+        $this->assertEquals($date, $organization->getCreatedAt());
         $this->assertSame('Mairie de Savenay', $organization->getName());
         $this->assertSame('21440195200129', $organization->getSiret());
         $this->assertSame('Mairie de Savenay', (string) $organization);


### PR DESCRIPTION
Suite à suggestion de @MathieuFV 

L'enregistrement de la date de création des organisations permettra de suivre l'évolution du nb d'organisations, en complément de la remontée d'informations vers Metabase (nb total d'organisations remonté chaque semaine)