### PR TITLE
Corrige ci_metabase_export

### DIFF
--- a/.github/workflows/metabase_export.yml
+++ b/.github/workflows/metabase_export.yml
@@ -32,4 +32,4 @@ jobs:
           echo "METABASE_DATABASE_URL=${{ secrets.METABASE_EXPORT_METABASE_DATABASE_URL }}" >> .env
 
       - name: Run export
-        run: make ci_metabase_export
+        run: make ci_metabase_export BIN_PHP="php" BIN_CONSOLE="php bin/console" BIN_COMPOSER="composer"

--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,7 @@ ci_metabase_migrate: ## Run CI steps for Metabase Migrate workflow
 	make metabase_migrate
 
 ci_metabase_export: ## Export data to Metabase
+	make composer CMD="install -n --prefer-dist"
 	scalingo login --ssh --ssh-identity ~/.ssh/id_rsa
 	./tools/scalingodbtunnel dialog-metabase --host-url --port 10001 & ./tools/wait-for-it.sh 127.0.0.1:10001
 	make console CMD="app:metabase:export"


### PR DESCRIPTION
* Correctif pour #1116

La CI d'export des indicateurs Metabase ne passait plus https://github.com/MTES-MCT/dialog/actions/runs/12464388509/job/34788385112

J'avais oublié d'installer les dépendances PHP, vu qu'on passe maintenant par une commande Symfony, et de configurer les variables d'environnement pour lancer les commandes hors Docker, comme pour les autres CI

Conséquence de ne pas l'avoir vu tout de suite, on a un trou de 2 semaines dans les indicateurs... Je n'aurais pas dû merger avant les congés