### PR TITLE
Correction valeur tonnage dans la dropdowm

### DIFF
--- a/src/Infrastructure/Form/Regulation/VehicleSetFormType.php
+++ b/src/Infrastructure/Form/Regulation/VehicleSetFormType.php
@@ -44,12 +44,12 @@ final class VehicleSetFormType extends AbstractType
                 ChoiceType::class,
                 options : [
                     'choices' => [
-                        3.5 => 3.5,
-                        7.5 => 7.5,
-                        19 => 19,
-                        26 => 26,
-                        32 => 32,
-                        44 => 44,
+                        '3.5' => 3.5,
+                        '7.5' => 7.5,
+                        '19' => 19,
+                        '26' => 26,
+                        '32' => 32,
+                        '44' => 44,
                     ],
                     'label' => 'regulation.vehicle_set.heavyweightMaxWeight',
                     'placeholder' => 'regulation.vehicle_set.heavyweightMaxWeight.placeholder',

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/AddMeasureControllerTest.php
@@ -727,6 +727,28 @@ final class AddMeasureControllerTest extends AbstractWebTestCase
         $this->assertStringContainsString('Cette valeur ne doit pas être vide.', $crawler->filter('#measure_form_vehicleSet_critairTypes_error')->text());
     }
 
+    public function testHeavyweightMaxWeightChoices(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_PERMANENT . '/measure/add');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+
+        $choices = $crawler
+            ->filter('select[name="measure_form[vehicleSet][heavyweightMaxWeight]"] > option')
+            ->each(fn ($node) => [$node->attr('value'), $node->text()]);
+
+        $this->assertEquals([
+            ['', 'Sélectionner le poids'],
+            ['3.5', 3.5],
+            ['7.5', 7.5],
+            ['19', 19],
+            ['26', 26],
+            ['32', 32],
+            ['44', 44],
+        ], $choices);
+    }
+
     public function testInvalidCritairTypes(): void
     {
         $client = $this->login();


### PR DESCRIPTION
Suite à un retour de @aureliebaton  cette PR vient corriger le bug d'affichage de la valeur du nombre de tonne dans la dropdown.
Les valeurs non entières (3.5t et 7.5t ) ne s'affichaient pas correctement. 

