### PR TITLE
Corrige l'export Metabase : DATABASE_URL manquant, uuid d'utilisateur actif incorrect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,7 @@ ci_metabase_migrate: ## Run CI steps for Metabase Migrate workflow
 ci_metabase_export: ## Export data to Metabase
 	make composer CMD="install -n --prefer-dist"
 	scalingo login --ssh --ssh-identity ~/.ssh/id_rsa
+	./tools/scalingodbtunnel dialog --host-url --port 10000 & ./tools/wait-for-it.sh 127.0.0.1:10000
 	./tools/scalingodbtunnel dialog-metabase --host-url --port 10001 & ./tools/wait-for-it.sh 127.0.0.1:10001
 	make console CMD="app:metabase:export"
 

--- a/docs/tools/metabase.md
+++ b/docs/tools/metabase.md
@@ -37,6 +37,6 @@ La configuration de la GitHub Action passe par diverses variables d'environnemen
 | Variable d'environnement | Configuration | Description |
 |---|---|---|
 | `METABASE_MIGRATIONS_METABASE_DATABASE_URL` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | L'URL d'accès à la base de données Metabase par la CI, afin d'exécuter les migrations (`./tools/scalingodbtunnel dialog-metabase --host-url --port 10001`) |
-| `METABASE_EXPORT_DATABASE_URL` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | L'URL d'accès à la base de données applicative par la CI (`./tools/scalingodbtunnel dialog --host-url --port 10001`) |
+| `METABASE_EXPORT_DATABASE_URL` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | L'URL d'accès à la base de données applicative par la CI (`./tools/scalingodbtunnel dialog --host-url --port 10000`) |
 | `METABASE_EXPORT_METABASE_DATABASE_URL` | Secret | L'URL d'accès à la base de données Metabase par la CI (`./tools/scalingodbtunnel dialog-metabase --host-url --port 10001`) |
 | `GH_SCALINGO_SSH_PRIVATE_KEY` | Secret | Clé SSH privée permettant l'accès à Scalingo par la CI |

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Statistics/StatisticsRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Statistics/StatisticsRepository.php
@@ -65,7 +65,7 @@ final class StatisticsRepository implements StatisticsRepositoryInterface
         foreach ($userRows as $row) {
             $stmt->bindValue('id', $row['uuid']);
             $stmt->bindValue('uploadedAt', $now->format(\DateTimeInterface::ATOM));
-            $stmt->bindValue('lastActiveAt', $row['lastActiveAt']?->format(\DateTimeInterface::ATOM));
+            $stmt->bindValue('lastActiveAt', $row['last_active_at']);
             $stmt->execute();
         }
     }

--- a/src/Infrastructure/Persistence/Doctrine/Repository/User/UserRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/User/UserRepository.php
@@ -51,9 +51,11 @@ final class UserRepository extends ServiceEntityRepository implements UserReposi
 
     public function findAllForStatistics(): array
     {
-        return $this->createQueryBuilder('u')
-            ->select('u.uuid, u.lastActiveAt')
-            ->getQuery()
-            ->getResult();
+        return $this->getEntityManager()
+            ->getConnection()
+            ->fetchAllAssociative(
+                'SELECT uuid_generate_v4() AS uuid, u.last_active_at AS last_active_at
+                FROM "user" AS u',
+            );
     }
 }

--- a/tests/Integration/Infrastructure/Symfony/Command/RunMetabaseExportCommandTest.php
+++ b/tests/Integration/Infrastructure/Symfony/Command/RunMetabaseExportCommandTest.php
@@ -60,5 +60,9 @@ final class RunMetabaseExportCommandTest extends KernelTestCase
 
         $this->assertSame('2023-06-09 00:00:00', $rows[2]['uploaded_at']);
         $this->assertSame(null, $rows[2]['last_active_at']);
+
+        // Execute again to test for uuid conflicts
+        $commandTester->execute([]);
+        $commandTester->assertCommandIsSuccessful();
     }
 }


### PR DESCRIPTION
* Ref #1126 

Toujours pour corriger l'export Metabase...

La CI échoue encore : https://github.com/MTES-MCT/dialog/actions/runs/12649320616/job/35245478021#step:8:430

Car j'ai oublié de configurer le tunnel sur le port 10000 pour la DB applicative `dialog`, je n'avais que le tunnel vers metabase sur le port 10001, y compris dans les secrets, mais du coup la connexion applicative pour calculer les stats échouait, car on utilise la database URL metabase pour accéder à la DB dialog...

Bref, avec cette PR on a bien :

* Connexion SSH :heavy_check_mark: 
* Connexion dialog <-> GHA via tunnel SSH sur le port 10000. J'ai reconfiguré le secret METABASE_EXPORT_DATABASE_URL
* Connexion metabase <-> GHA via tunnel SSH sur le port 10001. J'ai reconfiguré le secret METABASE_EXPORT_METABASE_DATABASE_URL

Elle corrige aussi un problème sur l'uuid de `analytics_user_active` : j'utilisais l'UUID de l'utilisateur, mais il faut un nouvel UUID à chaque fois, comme on le faisait dans le script SQL avant de passer à PHP (voir #1116)