### PR TITLE
Affiche plus de détails dans le rapport Litteralis

### DIFF
--- a/src/Infrastructure/IntegrationReport/CommonRecordEnum.php
+++ b/src/Infrastructure/IntegrationReport/CommonRecordEnum.php
@@ -8,6 +8,7 @@ enum CommonRecordEnum: string
 {
     case ATTR_REGULATION_ID = 'regulationId';
     case ATTR_URL = 'url';
+    case ATTR_DETAILS = 'details';
 
     case FACT_INTEGRATION_NAME = 'common.integration_name';
     case FACT_ORGANIZATION = 'common.organization';

--- a/src/Infrastructure/Litteralis/LitteralisExecutor.php
+++ b/src/Infrastructure/Litteralis/LitteralisExecutor.php
@@ -69,7 +69,9 @@ final class LitteralisExecutor
                 $reporter->addError(LitteralisRecordEnum::ERROR_IMPORT_COMMAND_FAILED->value, [
                     CommonRecordEnum::ATTR_REGULATION_ID->value => $regulationFeatures[0]['properties']['arretesrcid'],
                     CommonRecordEnum::ATTR_URL->value => $regulationFeatures[0]['properties']['shorturl'],
-                    'message' => $exc->getMessage(),
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'message' => $exc->getMessage(),
+                    ],
                     'violations' => $exc instanceof ValidationFailedException ? iterator_to_array($exc->getViolations()) : null,
                     'command' => $command,
                 ]);

--- a/src/Infrastructure/Litteralis/LitteralisExtractor.php
+++ b/src/Infrastructure/Litteralis/LitteralisExtractor.php
@@ -47,7 +47,9 @@ final class LitteralisExtractor
                 $reporter->addWarning(LitteralisRecordEnum::WARNING_MISSING_GEOMETRY->value, [
                     CommonRecordEnum::ATTR_REGULATION_ID->value => $identifier,
                     CommonRecordEnum::ATTR_URL->value => $feature['properties']['shorturl'],
-                    'idemprise' => $feature['properties']['idemprise'],
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'idemprise' => $feature['properties']['idemprise'],
+                    ],
                 ]);
                 continue;
             }

--- a/src/Infrastructure/Litteralis/LitteralisPeriodParser.php
+++ b/src/Infrastructure/Litteralis/LitteralisPeriodParser.php
@@ -55,9 +55,11 @@ final class LitteralisPeriodParser
                 [
                     CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
                     CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
-                    'idemprise' => $properties['idemprise'],
-                    $startDateProperty => $properties[$startDateProperty],
-                    'format' => $dateFormat,
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'idemprise' => $properties['idemprise'],
+                        $startDateProperty => $properties[$startDateProperty],
+                        'format' => $dateFormat,
+                    ],
                 ],
             );
         }
@@ -82,9 +84,11 @@ final class LitteralisPeriodParser
                 [
                     CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
                     CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
-                    'idemprise' => $properties['idemprise'],
-                    $endDateProperty => $properties[$endDateProperty],
-                    'format' => $dateFormat,
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'idemprise' => $properties['idemprise'],
+                        $endDateProperty => $properties[$endDateProperty],
+                        'format' => $dateFormat,
+                    ],
                 ],
             );
         }
@@ -168,8 +172,10 @@ final class LitteralisPeriodParser
         $reporter->addError(LitteralisRecordEnum::ERROR_PERIOD_UNPARSABLE->value, [
             CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
             CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
-            'idemprise' => $properties['idemprise'],
-            'jours et horaires' => $value,
+            CommonRecordEnum::ATTR_DETAILS->value => [
+                'idemprise' => $properties['idemprise'],
+                'jours et horaires' => $value,
+            ],
         ]);
 
         return [];

--- a/src/Infrastructure/Litteralis/LitteralisTransformer.php
+++ b/src/Infrastructure/Litteralis/LitteralisTransformer.php
@@ -234,8 +234,10 @@ final readonly class LitteralisTransformer
             if (!\array_key_exists($name, self::MEASURE_MAP)) {
                 $reporter->addNotice(LitteralisRecordEnum::NOTICE_UNSUPPORTED_MEASURE->value, [
                     CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
-                    'name' => $name,
-                    'idemprise' => $properties['idemprise'],
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'name' => $name,
+                        'idemprise' => $properties['idemprise'],
+                    ],
                 ]);
                 continue;
             }
@@ -294,10 +296,12 @@ final readonly class LitteralisTransformer
                     $reporter->addError(LitteralisRecordEnum::ERROR_MEASURE_PARAMETER_INCONSISTENT_NUMBER->value, [
                         CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
                         CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
-                        'idemprise' => $properties['idemprise'],
-                        'measureName' => $name,
-                        'expected' => $index + 1,
-                        'actual' => $number,
+                        CommonRecordEnum::ATTR_DETAILS->value => [
+                            'idemprise' => $properties['idemprise'],
+                            'measureName' => $name,
+                            'expected' => $index + 1,
+                            'actual' => $number,
+                        ],
                     ]);
 
                     continue;
@@ -393,8 +397,10 @@ final readonly class LitteralisTransformer
             $reporter->addError(LitteralisRecordEnum::ERROR_MAX_SPEED_VALUE_MISSING->value, [
                 CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
                 CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
-                'idemprise' => $properties['idemprise'],
-                'mesures' => $properties['mesures'],
+                CommonRecordEnum::ATTR_DETAILS->value => [
+                    'idemprise' => $properties['idemprise'],
+                    'mesures' => $properties['mesures'],
+                ],
             ]);
 
             return null;
@@ -404,8 +410,10 @@ final readonly class LitteralisTransformer
             $reporter->addError(LitteralisRecordEnum::ERROR_MAX_SPEED_VALUE_INVALID->value, [
                 CommonRecordEnum::ATTR_REGULATION_ID->value => $properties['arretesrcid'],
                 CommonRecordEnum::ATTR_URL->value => $properties['shorturl'],
-                'idemprise' => $properties['idemprise'],
-                'limite de vitesse' => $value,
+                CommonRecordEnum::ATTR_DETAILS->value => [
+                    'idemprise' => $properties['idemprise'],
+                    'limite de vitesse' => $value,
+                ],
             ]);
 
             return null;

--- a/tests/Integration/Infrastructure/IntegrationReport/ReportFormatterTest.php
+++ b/tests/Integration/Infrastructure/IntegrationReport/ReportFormatterTest.php
@@ -125,4 +125,113 @@ integration.report.notice.example.no_measures_found : 1 (dans 1 arrêtés)
 
         $this->assertSame($expectedResult, $reportFormatter->format($records));
     }
+
+    public function testDetails(): void
+    {
+        $reportFormatter = new ReportFormatter($this->translator);
+
+        $records = [
+            [
+                RecordTypeEnum::FACT->value,
+                [
+                    RecordTypeEnum::FACT->value => 'example.organization',
+                    'value' => 'Ville exemple',
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => 'regulation1',
+                    CommonRecordEnum::ATTR_DETAILS->value => ['orgId' => 'abc123'],
+                ],
+            ],
+            [
+                RecordTypeEnum::COUNT->value,
+                [
+                    RecordTypeEnum::COUNT->value => 'example.numFeatures',
+                    'value' => 42,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => 'regulation1',
+                    CommonRecordEnum::ATTR_DETAILS->value => ['numRegulations' => 104],
+                ],
+            ],
+            [
+                RecordTypeEnum::ERROR->value,
+                [
+                    RecordTypeEnum::ERROR->value => 'example.importCommandFailed',
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => 'regulation1',
+                    CommonRecordEnum::ATTR_DETAILS->value => ['message' => 'oops'],
+                ],
+            ],
+            [
+                RecordTypeEnum::WARNING->value,
+                [
+                    RecordTypeEnum::WARNING->value => 'example.missingGeometry',
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => 'regulation1',
+                    CommonRecordEnum::ATTR_DETAILS->value => ['idemprise' => 'def456'],
+                ],
+            ],
+            [
+                RecordTypeEnum::WARNING->value,
+                [
+                    RecordTypeEnum::WARNING->value => 'example.warningWithoutDetails',
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => 'regulation1',
+                ],
+            ],
+            [
+                RecordTypeEnum::NOTICE->value,
+                [
+                    RecordTypeEnum::NOTICE->value => 'example.unsupportedMeasure',
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => 'regulation1',
+                    CommonRecordEnum::ATTR_DETAILS->value => ['name' => 'Stationnement interdit', 'idemprise' => 123],
+                ],
+            ],
+            [
+                RecordTypeEnum::NOTICE->value,
+                [
+                    RecordTypeEnum::NOTICE->value => 'example.unsupportedMeasure',
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => 'regulation1',
+                    CommonRecordEnum::ATTR_DETAILS->value => ['name' => 'Interdiction de dépasser', 'idemprise' => 456],
+                ],
+            ],
+        ];
+
+        $expectedResult = "Rapport d'intégration
+======================
+
+Informations d'exécution
+-------------------------
+
+integration.report.fact.example.organization : Ville exemple (orgId = 'abc123')
+
+Décomptes
+----------
+
+integration.report.count.example.numFeatures : 42 (numRegulations = 104)
+
+Erreurs
+-------
+
+integration.report.error.example.importCommandFailed : 1 (dans 1 arrêtés)
+  Arrêtés :
+    regulation1 (message = 'oops')
+
+
+Avertissements
+--------------
+
+integration.report.warning.example.missingGeometry : 1 (dans 1 arrêtés)
+  Arrêtés :
+    regulation1 (idemprise = 'def456')
+
+integration.report.warning.example.warningWithoutDetails : 1 (dans 1 arrêtés)
+  Arrêtés :
+    regulation1
+
+
+Remarques
+---------
+
+integration.report.notice.example.unsupportedMeasure : 2 (dans 1 arrêtés)
+  Arrêtés :
+    regulation1 (name = 'Stationnement interdit', idemprise = 123 ; name = 'Interdiction de dépasser', idemprise = 456)
+
+";
+
+        $this->assertSame($expectedResult, $reportFormatter->format($records));
+    }
 }

--- a/tests/Unit/Infrastructure/Litteralis/LitteralisExecutorTest.php
+++ b/tests/Unit/Infrastructure/Litteralis/LitteralisExecutorTest.php
@@ -170,9 +170,11 @@ final class LitteralisExecutorTest extends TestCase
             ->expects(self::once())
             ->method('addError')
             ->with(LitteralisRecordEnum::ERROR_IMPORT_COMMAND_FAILED->value, [
-                'message' => 'oops',
                 CommonRecordEnum::ATTR_REGULATION_ID->value => '1234',
                 CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
+                CommonRecordEnum::ATTR_DETAILS->value => [
+                    'message' => 'oops',
+                ],
                 'violations' => null,
                 'command' => $command3,
             ]);

--- a/tests/Unit/Infrastructure/Litteralis/LitteralisExtractorTest.php
+++ b/tests/Unit/Infrastructure/Litteralis/LitteralisExtractorTest.php
@@ -95,9 +95,11 @@ final class LitteralisExtractorTest extends TestCase
             ->expects(self::once())
             ->method('addWarning')
             ->with(LitteralisRecordEnum::WARNING_MISSING_GEOMETRY->value, [
-                'idemprise' => 'emprise4',
                 CommonRecordEnum::ATTR_REGULATION_ID->value => 'arrete3',
                 CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
+                CommonRecordEnum::ATTR_DETAILS->value => [
+                    'idemprise' => 'emprise4',
+                ],
             ]);
 
         $extractor = new LitteralisExtractor($this->client);

--- a/tests/Unit/Infrastructure/Litteralis/LitteralisPeriodParserTest.php
+++ b/tests/Unit/Infrastructure/Litteralis/LitteralisPeriodParserTest.php
@@ -7,6 +7,7 @@ namespace App\Tests\Unit\Infrastructure\Litteralis;
 use App\Application\Regulation\Command\Period\SavePeriodCommand;
 use App\Application\Regulation\Command\Period\SaveTimeSlotCommand;
 use App\Domain\Condition\Period\Enum\PeriodRecurrenceTypeEnum;
+use App\Infrastructure\IntegrationReport\CommonRecordEnum;
 use App\Infrastructure\IntegrationReport\Reporter;
 use App\Infrastructure\Litteralis\LitteralisPeriodParser;
 use App\Infrastructure\Litteralis\LitteralisRecordEnum;
@@ -104,7 +105,17 @@ final class LitteralisPeriodParserTest extends TestCase
         $reporter
             ->expects(self::once())
             ->method('addError')
-            ->with(LitteralisRecordEnum::ERROR_PERIOD_UNPARSABLE->value);
+            ->with(
+                LitteralisRecordEnum::ERROR_PERIOD_UNPARSABLE->value,
+                [
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => 'id2',
+                    CommonRecordEnum::ATTR_URL->value => 'url',
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'idemprise' => 'id1',
+                        'jours et horaires' => $value,
+                    ],
+                ],
+            );
 
         $this->assertEquals([], $this->parser->parseTimeSlots($value, $properties, $reporter));
     }

--- a/tests/Unit/Infrastructure/Litteralis/LitteralisTransformerTest.php
+++ b/tests/Unit/Infrastructure/Litteralis/LitteralisTransformerTest.php
@@ -287,9 +287,11 @@ final class LitteralisTransformerTest extends TestCase
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_DATE_PARSING_FAILED->value,
                     CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
                     CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
-                    'arretedebut' => 'BAD FORMAT',
-                    'idemprise' => 493136,
-                    'format' => \DateTimeInterface::ISO8601,
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'arretedebut' => 'BAD FORMAT',
+                        'idemprise' => 493136,
+                        'format' => \DateTimeInterface::ISO8601,
+                    ],
                 ],
             ],
             [
@@ -298,9 +300,11 @@ final class LitteralisTransformerTest extends TestCase
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_DATE_PARSING_FAILED->value,
                     CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
                     CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
-                    'arretefin' => 'BAD FORMAT',
-                    'idemprise' => 493136,
-                    'format' => \DateTimeInterface::ISO8601,
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'arretefin' => 'BAD FORMAT',
+                        'idemprise' => 493136,
+                        'format' => \DateTimeInterface::ISO8601,
+                    ],
                 ],
             ],
             [
@@ -309,8 +313,10 @@ final class LitteralisTransformerTest extends TestCase
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_MAX_SPEED_VALUE_MISSING->value,
                     CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
                     CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
-                    'idemprise' => 493136,
-                    'mesures' => 'Limitation de vitesse',
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'idemprise' => 493136,
+                        'mesures' => 'Limitation de vitesse',
+                    ],
                 ],
             ],
             [
@@ -319,8 +325,10 @@ final class LitteralisTransformerTest extends TestCase
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_MAX_SPEED_VALUE_INVALID->value,
                     CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
                     CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
-                    'idemprise' => 493136,
-                    'limite de vitesse' => 'foo km/h',
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'idemprise' => 493136,
+                        'limite de vitesse' => 'foo km/h',
+                    ],
                 ],
             ],
             [
@@ -329,10 +337,12 @@ final class LitteralisTransformerTest extends TestCase
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_MEASURE_PARAMETER_INCONSISTENT_NUMBER->value,
                     CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
                     CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
-                    'idemprise' => 493136,
-                    'measureName' => 'Circulation interdite 4',
-                    'expected' => 1,
-                    'actual' => 4,
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'idemprise' => 493136,
+                        'measureName' => 'Circulation interdite 4',
+                        'expected' => 1,
+                        'actual' => 4,
+                    ],
                 ],
             ],
             [
@@ -341,8 +351,10 @@ final class LitteralisTransformerTest extends TestCase
                     RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_PERIOD_UNPARSABLE->value,
                     CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
                     CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
-                    'idemprise' => 493136,
-                    'jours et horaires' => 'foo',
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'idemprise' => 493136,
+                        'jours et horaires' => 'foo',
+                    ],
                 ],
             ],
         ], $this->reporter->getRecords());
@@ -363,8 +375,10 @@ final class LitteralisTransformerTest extends TestCase
                 [
                     RecordTypeEnum::NOTICE->value => LitteralisRecordEnum::NOTICE_UNSUPPORTED_MEASURE->value,
                     CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
-                    'name' => 'unknown measure',
-                    'idemprise' => 493136,
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'name' => 'unknown measure',
+                        'idemprise' => 493136,
+                    ],
                 ],
             ],
             [


### PR DESCRIPTION
**Motivation**

Lorsqu'une erreur, un warning ou une notice est loggée dans l'intégration Litteralis, on ajoute des détails comme l'ID de l'emprise, la valeur qui a posé problème, etc

Mais jusqu'ici elles étaient seulement mises dans le log, qui est assez peu pratique à utiliser

**Description des changements**

Cette PR affiche ces infos supplémentaires directement dans le rapport d'intégration, dans un format "humain" de type clé = valeur

**Exemple**

Affichage des mesures non-supportées dans l'import Fougères

Avant :

```
Remarques
---------

Mesures de type non-supporté par DiaLog : 14 (dans 10 arrêtés)
  Arrêtés :
    24-AT-0665
    24-AT-0658
    24-AT-0660
    24-AT-0661
    24-AT-0662
    24-AT-0663
    24-AT-0678
    24-AT-0684
    24-AT-0685
    24-AT-0689
```

Après :

```
Remarques
---------

Mesures de type non-supporté par DiaLog : 14 (dans 10 arrêtés)
  Arrêtés :
    24-AT-0665 (name = 'Interdiction de stationnement', idemprise = 685939)
    24-AT-0658 (name = 'Interdiction de stationnement', idemprise = 686236)
    24-AT-0660 (name = 'Interdiction de stationnement', idemprise = 686240 ; name = 'Déviation', idemprise = 686240)
    24-AT-0661 (name = 'Interdiction de stationnement', idemprise = 686241)
    24-AT-0662 (name = 'Interdiction de stationnement', idemprise = 686242)
    24-AT-0663 (name = 'Interdiction de stationnement', idemprise = 686248)
    24-AT-0678 (name = 'Rétrécissement temporaire de largeur de voie', idemprise = 687658 ; name = 'Interruption de circulation travaux', idemprise = 687658 ; name = 'Mesure libre circulation', idemprise = 687658)
    24-AT-0684 (name = 'Interdiction de stationnement', idemprise = 687735)
    24-AT-0685 (name = 'Dérogation à une interdiction de circuler', idemprise = 687738 ; name = 'Sens interdit (ou sens unique)', idemprise = 687738)
    24-AT-0689 (name = 'Interdiction de stationnement', idemprise = 688828)
```