### PR TITLE
Désactive la navigation JS (Turbo Drive) par défaut

### DIFF
--- a/assets/bootstrap.js
+++ b/assets/bootstrap.js
@@ -11,4 +11,9 @@ export const app = startStimulusApp(require.context(
 // register any custom, 3rd party controllers here
 // app.register('some_controller_name', SomeImportedController);
 
+// Désactive Turbo Drive par défaut, pour des raisons d'accessibilité
+// On peut toujours réactiver Turbo Drive au cas par cas avec data-turbo="true"
+// https://turbo.hotwired.dev/reference/drive#turbo.session.drive
+Turbo.session.drive = false;
+
 registerTurboEventHandlers();


### PR DESCRIPTION
* Closes #780 (à vérifier)

En me baladant sur DiaLog sur mon mobile (smartphone Android / Firefox), j'ai remarqué que quand on clique sur un lien, il n'y a pas de "feedback" indiquant que la nouvelle page charge

Donc l'utilisateur attend un certain temps (dépendant de sa connexion) sans aucune indication de chargement, puis la page change tout d'un coup

C'est lié à la navigation par JS qui est orchestrée par Turbo Drive, qui convertit le site en une expérience "SPA-like"

Or un navigateur est parfaitement capable de gérer cette "UX de chargement"

De plus, les recommandations du service public anglais GOV.UK sont de ne pas faire de SPA par défaut, et surtout pas pour des sites de contenus (en gras ce qui nous concerne) :

https://www.gov.uk/service-manual/technology/using-progressive-enhancement#single-page-applications

> Single page applications
>
> Do not build your service as a single-page application (SPA). This is where the loading of pages within your service is handled by JavaScript, rather than the browser.
>
> Single page applications rarely bring benefits and can make the service inaccessible because:
>
> * **users of assistive technology would be unaware of changes in context, for example when moving to a new page**
> * **it would fail to handle focus when moving between pages**
> * the user would be unable to navigate using the back or forward buttons in their browser
> * users would be unable to recover from an error, for example if there is an interruption to their network connection

Je propose donc de désactiver Turbo Drive. 

NOTA : 

* ça n'impacte pas Turbo Frames ni Turbo Streams, toutes nos UX "interactives" réalisées avec elles ou Stimulus fonctionnent toujours
* ça n'impacte pas la performance globale lors de la navigation. Le DOM doit toujours être chargé puisque Turbo Drive remplace le `<body>`. La différence est uniquement dans le chargement des assets, or là le cache fait toujours très bien son boulot