### PR TITLE
Exporte le nombre d'incidents CIFS dans Metabase

### DIFF
--- a/.env
+++ b/.env
@@ -23,6 +23,7 @@ APP_BAC_IDF_DECREES_FILE=data/bac_idf/decrees.json
 APP_BAC_IDF_CITIES_FILE=data/bac_idf/cities.csv
 DATABASE_URL="postgresql://dialog:dialog@database:5432/dialog"
 METABASE_DATABASE_URL="postgresql://dialog:dialog@database:5432/dialog"
+APP_DIALOG_BASE_URL=http://nginx
 REDIS_URL="redis://redis:6379"
 API_ADRESSE_BASE_URL=https://api-adresse.data.gouv.fr
 APP_IGN_GEOCODER_BASE_URL=https://data.geopf.fr

--- a/.github/workflows/metabase_export.yml
+++ b/.github/workflows/metabase_export.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           echo "DATABASE_URL=${{ secrets.METABASE_EXPORT_DATABASE_URL }}" >> .env
           echo "METABASE_DATABASE_URL=${{ secrets.METABASE_EXPORT_METABASE_DATABASE_URL }}" >> .env
+          echo "APP_DIALOG_BASE_URL=${{ variables.METABASE_EXPORT_APP_DIALOG_BASE_URL }}" >> .env
 
       - name: Run export
         run: make ci_metabase_export BIN_PHP="php" BIN_CONSOLE="php bin/console" BIN_COMPOSER="composer"

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -29,6 +29,8 @@ framework:
                 base_uri: '%env(APP_LITTERALIS_WFS_BASE_URL)%'
             ign.geocoder.client:
                 base_uri: '%env(APP_IGN_GEOCODER_BASE_URL)%'
+            dialog.http.client:
+                base_uri: '%env(APP_DIALOG_BASE_URL)%'
 
 when@test:
     framework:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -151,6 +151,10 @@ when@test:
         App\Tests\Mock\IgnGeocoderMockClient:
             decorates: 'ign.geocoder.client'
             decoration_inner_name: 'App\Tests\Mock\IgnGeocoderMockClient::ign.geocoder.client'
+        App\Tests\Mock\DiaLogMockHttpClient:
+            decorates: 'dialog.http.client'
+            decoration_inner_name: 'App\Tests\Mock\DiaLogMockHttpClient::dialog.http.client'
+            arguments: ['@http_kernel']
         App\Infrastructure\Adapter\DateUtils:
             class: App\Tests\Mock\DateUtilsMock
         Psr\Log\NullLogger: ~

--- a/docs/tools/metabase.md
+++ b/docs/tools/metabase.md
@@ -39,4 +39,5 @@ La configuration de la GitHub Action passe par diverses variables d'environnemen
 | `METABASE_MIGRATIONS_METABASE_DATABASE_URL` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | L'URL d'accès à la base de données Metabase par la CI, afin d'exécuter les migrations (`./tools/scalingodbtunnel dialog-metabase --host-url --port 10001`) |
 | `METABASE_EXPORT_DATABASE_URL` | [Secret](https://docs.github.com/fr/actions/security-guides/using-secrets-in-github-actions) au sens GitHub Actions | L'URL d'accès à la base de données applicative par la CI (`./tools/scalingodbtunnel dialog --host-url --port 10000`) |
 | `METABASE_EXPORT_METABASE_DATABASE_URL` | Secret | L'URL d'accès à la base de données Metabase par la CI (`./tools/scalingodbtunnel dialog-metabase --host-url --port 10001`) |
+| `METABASE_EXPORT_APP_DIALOG_BASE_URL` | Variable | L'URL publique de DiaLog (pour la requête des exports tels que CIFS) |
 | `GH_SCALINGO_SSH_PRIVATE_KEY` | Secret | Clé SSH privée permettant l'accès à Scalingo par la CI |

--- a/src/Application/Cifs/CifsExportClientInterface.php
+++ b/src/Application/Cifs/CifsExportClientInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Cifs;
+
+interface CifsExportClientInterface
+{
+    public function getIncidentsCount(): int;
+}

--- a/src/Infrastructure/Adapter/CifsExportClient.php
+++ b/src/Infrastructure/Adapter/CifsExportClient.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Adapter;
+
+use App\Application\Cifs\CifsExportClientInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+final class CifsExportClient implements CifsExportClientInterface
+{
+    public function __construct(
+        private HttpClientInterface $dialogHttpClient,
+    ) {
+    }
+
+    public function getIncidentsCount(): int
+    {
+        $response = $this->dialogHttpClient->request('GET', '/api/regulations/cifs.xml');
+        $xml = new \DOMDocument();
+        $xml->loadXML($response->getContent(), \LIBXML_NOBLANKS);
+
+        return $xml->getElementsByTagName('incident')->count();
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Repository/Statistics/StatisticsRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Statistics/StatisticsRepository.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Persistence\Doctrine\Repository\Statistics;
 
+use App\Application\Cifs\CifsExportClientInterface;
 use App\Domain\Regulation\Repository\RegulationOrderRecordRepositoryInterface;
 use App\Domain\Statistics\Repository\StatisticsRepositoryInterface;
 use App\Domain\User\Repository\OrganizationRepositoryInterface;
@@ -17,6 +18,7 @@ final class StatisticsRepository implements StatisticsRepositoryInterface
         private OrganizationRepositoryInterface $organizationRepository,
         private RegulationOrderRecordRepositoryInterface $regulationOrderRecordRepository,
         private Connection $metabaseConnection,
+        private CifsExportClientInterface $cifsExportClient,
     ) {
     }
 
@@ -31,6 +33,7 @@ final class StatisticsRepository implements StatisticsRepositoryInterface
             'regulationOrderRecords.published' => $this->regulationOrderRecordRepository->countPublishedRegulationOrderRecords(),
             'regulationOrderRecords.permanent' => $this->regulationOrderRecordRepository->countPermanentRegulationOrderRecords(),
             'regulationOrderRecords.temporary' => $this->regulationOrderRecordRepository->countTemporaryRegulationOrderRecords(),
+            'cifs.incidents' => $this->cifsExportClient->getIncidentsCount(),
         ];
 
         $stmt = $this->metabaseConnection->prepare(
@@ -42,7 +45,7 @@ final class StatisticsRepository implements StatisticsRepositoryInterface
             $stmt->bindValue('uploadedAt', $now->format(\DateTimeInterface::ATOM));
             $stmt->bindValue('name', $name);
             $stmt->bindValue('value', $value);
-            $stmt->execute();
+            $stmt->executeStatement();
         }
     }
 
@@ -66,7 +69,7 @@ final class StatisticsRepository implements StatisticsRepositoryInterface
             $stmt->bindValue('id', $row['uuid']);
             $stmt->bindValue('uploadedAt', $now->format(\DateTimeInterface::ATOM));
             $stmt->bindValue('lastActiveAt', $row['last_active_at']);
-            $stmt->execute();
+            $stmt->executeStatement();
         }
     }
 }

--- a/tests/Integration/Infrastructure/Symfony/Command/RunMetabaseExportCommandTest.php
+++ b/tests/Integration/Infrastructure/Symfony/Command/RunMetabaseExportCommandTest.php
@@ -27,7 +27,7 @@ final class RunMetabaseExportCommandTest extends KernelTestCase
 
         // Check count statistics
         $rows = $metabaseConnection->fetchAllAssociative('SELECT * FROM analytics_count');
-        $this->assertCount(6, $rows);
+        $this->assertCount(7, $rows);
         $this->assertEquals(['id', 'uploaded_at', 'name', 'value'], array_keys($rows[0]));
 
         $counts = [];
@@ -45,6 +45,7 @@ final class RunMetabaseExportCommandTest extends KernelTestCase
             'regulationOrderRecords.published' => 1,
             'regulationOrderRecords.permanent' => 0,
             'regulationOrderRecords.temporary' => 1,
+            'cifs.incidents' => 7,
         ], $counts);
 
         // Check user active statistics

--- a/tests/Mock/DiaLogMockHttpClient.php
+++ b/tests/Mock/DiaLogMockHttpClient.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Mock;
+
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+// During tests, we want to request the test data, but there is no real test server available via HTTP
+// So this replacement client calls the HTTP kernel directly.
+final class DiaLogMockHttpClient extends MockHttpClient
+{
+    public function __construct(private HttpKernelInterface $httpKernel)
+    {
+        $callback = \Closure::fromCallable([$this, 'handleRequests']);
+        parent::__construct($callback, 'http://testserver');
+    }
+
+    private function handleRequests(string $method, string $url, array $options): MockResponse
+    {
+        $request = Request::create($url, $method);
+        $response = $this->httpKernel->handle($request);
+
+        return new MockResponse($response->getContent());
+    }
+}

--- a/tests/Unit/Infrastructure/Adapter/CifsExportClientTest.php
+++ b/tests/Unit/Infrastructure/Adapter/CifsExportClientTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure\Adapter;
+
+use App\Infrastructure\Adapter\CifsExportClient;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Response\MockResponse;
+
+final class CifsExportClientTest extends TestCase
+{
+    private $dialogHttpClient;
+    private $client;
+
+    protected function setUp(): void
+    {
+        $this->dialogHttpClient = new MockHttpClient(baseUri: 'http://testserver');
+        $this->client = new CifsExportClient($this->dialogHttpClient);
+    }
+
+    public function testGetIncidentsCountZero(): void
+    {
+        $this->dialogHttpClient->setResponseFactory(function (string $method, string $url, array $options) {
+            $this->assertSame('GET', $method);
+            $this->assertSame('http://testserver/api/regulations/cifs.xml', $url);
+
+            return new MockResponse('<incidents></incidents>');
+        });
+
+        $this->assertSame(0, $this->client->getIncidentsCount());
+    }
+
+    public function testGetIncidentsCountSome(): void
+    {
+        $this->dialogHttpClient->setResponseFactory(function (string $method, string $url, array $options) {
+            $this->assertSame('GET', $method);
+            $this->assertSame('http://testserver/api/regulations/cifs.xml', $url);
+
+            return new MockResponse('<incidents>
+                <incident>example1</incident>
+                <incident>example2</incident>
+            </incidents>');
+        });
+
+        $this->assertSame(2, $this->client->getIncidentsCount());
+    }
+}


### PR DESCRIPTION
* Closes #1110 

TODO

* [x] Configurer METABASE_EXPORT_APP_DIALOG_BASE_URL sur la CI pour l'exécution automatique de l'export Metabase