### PR TITLE
Fix Litteralis Import : "A value containing spaces must be surrounded by quotes

### DIFF
--- a/.github/workflows/litteralis_import.yml
+++ b/.github/workflows/litteralis_import.yml
@@ -54,12 +54,14 @@ jobs:
         run: |
           echo "DATABASE_URL=${{ secrets.APP_LITTERALIS_IMPORT_DATABASE_URL }}" >> .env.local
           echo "BDTOPO_DATABASE_URL=${{ secrets.BDTOPO_DATABASE_URL }}" >> .env.local
-          echo "APP_LITTERALIS_ENABLED_ORGS=${{ vars.APP_LITTERALIS_ENABLED_ORGS }}" >> .env.local
+          # Deal with JSON quotes
+          printf "APP_LITTERALIS_ENABLED_ORGS='%s'\n" '${{ vars.APP_LITTERALIS_ENABLED_ORGS }}' >> .env.local
 
       - name: Override enabled orgs if defined by input
         if: ${{ inputs.enabled_orgs }}
         run: |
-          echo "APP_LITTERALIS_ENABLED_ORGS=${{ inputs.enabled_orgs }}" >> .env.local
+          # Deal with JSON quotes
+          printf "APP_LITTERALIS_ENABLED_ORGS='%s'\n" '${{ inputs.enabled_orgs }}' >> .env.local
 
       - name: Init organization environment variables
         run: |


### PR DESCRIPTION
* Suite à #1146 
* Vu https://github.com/MTES-MCT/dialog/actions/runs/12871429850/job/35884676288#step:12:211

J'avais bien testé la CI, mais avec `enabled_orgs = []` pour éviter de mettre les données en production avant de merger. Et ce problème de décodage JSON n'était donc pas visible...

La solution est copiée collée de la CI Eudonet

La difficulté c'est qu'il faut modifier les secrets si on veut pointer vers autre chose que la prod pour "tester" un job GitHub Actions. Peut-être qu'on devrait + utiliser les `inputs` pour pouvoir "override" les secrets quand on lance un job manuellement par workflow dispatch...