### PR TITLE
Corrige le catch-all dans LitteralisImportCommand

### DIFF
--- a/src/Infrastructure/Symfony/Command/LitteralisImportCommand.php
+++ b/src/Infrastructure/Symfony/Command/LitteralisImportCommand.php
@@ -49,7 +49,7 @@ class LitteralisImportCommand extends Command
                 $report = $this->executor->execute($name, $orgId, $now, $this->reporter);
 
                 $output->write($report);
-            } catch (\RuntimeException $exc) {
+            } catch (\Exception $exc) {
                 $output->writeln($exc->getMessage());
 
                 $returnCode = Command::FAILURE;

--- a/tests/Unit/Infrastructure/Symfony/Command/LitteralisImportCommandTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Command/LitteralisImportCommandTest.php
@@ -78,7 +78,7 @@ class LitteralisImportCommandTest extends TestCase
             ->willReturnCallback(
                 fn () => match ($matcher->getInvocationCount()) {
                     1 => 'report1' . PHP_EOL,
-                    2 => throw new \RuntimeException('Failed'),
+                    2 => throw new \Exception('Failed'),
                     3 => 'report3' . PHP_EOL,
                 },
             );


### PR DESCRIPTION
Le `catch \RuntimeException` était trop précis, il faut un `catch \Exception` pour laisser l'import continuer si jamais celui d'une collectivité plante

En l'occurrence, en raison de https://github.com/MTES-MCT/dialog/issues/1155 l'import Litteralis que j'ai lancé ce matin a importé la MEL, puis a planté en important Fougères, donc Lons-le-Saunier n'avait pas été importé, j'ai dû le relancer (l'input `enabled_orgs` sur GitHub Actions fonctionne nickel)).