### PR TITLE
[Litteralis] Corrige bug si paramètre mesures mal formaté

### DIFF
--- a/src/Infrastructure/Litteralis/LitteralisRecordEnum.php
+++ b/src/Infrastructure/Litteralis/LitteralisRecordEnum.php
@@ -11,6 +11,7 @@ enum LitteralisRecordEnum: string
     case COUNT_EXTRACTED_FEATURES = 'litteralis.extracted_features';
     case COUNT_IMPORTED_FEATURES = 'litteralis.imported_features';
 
+    case ERROR_MEASURE_PARAMETER_MALFORMED = 'litteralis.measure_parameter_malformed';
     case ERROR_MEASURE_PARAMETER_INCONSISTENT_NUMBER = 'litteralis.measure_parameter_inconsistent_number';
     case ERROR_MAX_SPEED_VALUE_INVALID = 'litteralis.max_speed_value_invalid';
     case ERROR_MAX_SPEED_VALUE_MISSING = 'litteralis.max_speed_value_missing';

--- a/tests/Unit/Infrastructure/Litteralis/LitteralisTransformerTest.php
+++ b/tests/Unit/Infrastructure/Litteralis/LitteralisTransformerTest.php
@@ -250,6 +250,18 @@ final class LitteralisTransformerTest extends TestCase
             self::feature,
         );
 
+        // Trigger ERROR_MEASURE_PARAMETER_MALFORMED
+        $malformedParamFeature = str_replace(
+            '"mesures": "Limitation de vitesse"',
+            '"mesures": "Circulation interdite"',
+            self::feature,
+        );
+        $malformedParamFeature = str_replace(
+            '"parametresmesures": "Limitation de vitesse | limite de vitesse : 70 km/h"',
+            '"parametresmesures": "Circulation interdite 1"',
+            $malformedParamFeature,
+        );
+
         // Trigger ERROR_MEASURE_PARAMETER_INCONSISTENT_NUMBER
         $inconsistentIndexFeature = str_replace(
             '"mesures": "Limitation de vitesse"',
@@ -273,6 +285,7 @@ final class LitteralisTransformerTest extends TestCase
             json_decode($invalidDatesFeature, associative: true),
             json_decode($missingSpeedLimitValueFeature, associative: true),
             json_decode($invalidSpeedLimitValueFeature, associative: true),
+            json_decode($malformedParamFeature, associative: true),
             json_decode($inconsistentIndexFeature, associative: true),
             json_decode($periodUnparsableFeature, associative: true),
         ];
@@ -328,6 +341,18 @@ final class LitteralisTransformerTest extends TestCase
                     CommonRecordEnum::ATTR_DETAILS->value => [
                         'idemprise' => 493136,
                         'limite de vitesse' => 'foo km/h',
+                    ],
+                ],
+            ],
+            [
+                RecordTypeEnum::ERROR->value,
+                [
+                    RecordTypeEnum::ERROR->value => LitteralisRecordEnum::ERROR_MEASURE_PARAMETER_MALFORMED->value,
+                    CommonRecordEnum::ATTR_REGULATION_ID->value => '24-A-0126',
+                    CommonRecordEnum::ATTR_URL->value => 'https://dl.sogelink.fr/?n3omzTyS',
+                    CommonRecordEnum::ATTR_DETAILS->value => [
+                        'idemprise' => 493136,
+                        'param' => 'Circulation interdite 1',
                     ],
                 ],
             ],

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -2491,6 +2491,10 @@
                 <source>integration.report.error.litteralis.period_unparsable</source>
                 <target>Emprises avec "jours et horaires" au format non-supporté</target>
             </trans-unit>
+            <trans-unit id="integration.report.error.litteralis.measure_parameter_malformed">
+                <source>integration.report.error.litteralis.measure_parameter_malformed</source>
+                <target>Emprises avec paramètres de mesures au format inattendu</target>
+            </trans-unit>
             <trans-unit id="integration.report.error.litteralis.measure_parameter_inconsistent_number">
                 <source>integration.report.error.litteralis.measure_parameter_inconsistent_number</source>
                 <target>Emprises avec numéros de mesures incohérents</target>


### PR DESCRIPTION
* Closes #1155 

En local, après ce correctif, l'import Litteralis de Fougères est OK

Le point de donnée fautif était le suivant (s'affiche dans le rapport d'intégration)

```
25-AT-0007 (https://dl.sogelink.fr/?RDguplkf) (idemprise = 695348, param = ',riverains,véhicules de l\'entreprise exécutant les travaux')
```