### PR TITLE
Ajout du modèle de donnée Token

### DIFF
--- a/src/Domain/User/Enum/TokenTypeEnum.php
+++ b/src/Domain/User/Enum/TokenTypeEnum.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User\Enum;
+
+enum TokenTypeEnum: string
+{
+    case FORGOT_PASSWORD = 'FORGOT_PASSWORD';
+    case CONFIRM_ACCOUNT = 'CONFIRM_ACCOUNT';
+}

--- a/src/Domain/User/Token.php
+++ b/src/Domain/User/Token.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\User;
+
+class Token
+{
+    public function __construct(
+        private string $uuid,
+        private string $token,
+        private string $type,
+        private User $user,
+        private \DateTimeInterface $expirationDate,
+    ) {
+    }
+
+    public function getUuid(): string
+    {
+        return $this->uuid;
+    }
+
+    public function getToken(): string
+    {
+        return $this->token;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function getUser(): User
+    {
+        return $this->user;
+    }
+
+    public function getExpirationDate(): \DateTimeInterface
+    {
+        return $this->expirationDate;
+    }
+}

--- a/src/Infrastructure/Persistence/Doctrine/Mapping/User.Token.orm.xml
+++ b/src/Infrastructure/Persistence/Doctrine/Mapping/User.Token.orm.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<doctrine-mapping xmlns="http://doctrine-project.org/schemas/orm/doctrine-mapping" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://doctrine-project.org/schemas/orm/doctrine-mapping https://www.doctrine-project.org/schemas/orm/doctrine-mapping.xsd">
+  <entity name="App\Domain\User\Token" table="token">
+    <indexes>
+        <index columns="token"/>
+    </indexes>
+    <id name="uuid" type="guid" column="uuid"/>
+    <field name="token" type="string" length="100" nullable="false"/>
+    <field name="type" type="string" length="20" nullable="false"/>
+    <field name="expirationDate" type="datetimetz" nullable="false"/>
+    <many-to-one field="user" target-entity="App\Domain\User\User">
+        <join-column name="user_uuid" nullable="false" referenced-column-name="uuid" on-delete="CASCADE"/>
+    </many-to-one>
+  </entity>
+</doctrine-mapping>

--- a/src/Infrastructure/Persistence/Doctrine/Migrations/Version20250121142614.php
+++ b/src/Infrastructure/Persistence/Doctrine/Migrations/Version20250121142614.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Doctrine\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20250121142614 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE token (uuid UUID NOT NULL, user_uuid UUID NOT NULL, token VARCHAR(100) NOT NULL, type VARCHAR(20) NOT NULL, expiration_date TIMESTAMP(0) WITH TIME ZONE NOT NULL, PRIMARY KEY(uuid))');
+        $this->addSql('CREATE INDEX IDX_5F37A13BABFE1C6F ON token (user_uuid)');
+        $this->addSql('CREATE INDEX IDX_5F37A13B5F37A13B ON token (token)');
+        $this->addSql('ALTER TABLE token ADD CONSTRAINT FK_5F37A13BABFE1C6F FOREIGN KEY (user_uuid) REFERENCES "user" (uuid) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE token DROP CONSTRAINT FK_5F37A13BABFE1C6F');
+        $this->addSql('DROP TABLE token');
+    }
+}

--- a/tests/Unit/Domain/User/TokenTest.php
+++ b/tests/Unit/Domain/User/TokenTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Domain\User;
+
+use App\Domain\User\Enum\TokenTypeEnum;
+use App\Domain\User\Token;
+use App\Domain\User\User;
+use PHPUnit\Framework\TestCase;
+
+final class TokenTest extends TestCase
+{
+    public function testGetters(): void
+    {
+        $user = $this->createMock(User::class);
+        $expirationDate = new \DateTime('1989-09-17');
+        $token = new Token(
+            '9cebe00d-04d8-48da-89b1-059f6b7bfe44',
+            'token',
+            TokenTypeEnum::FORGOT_PASSWORD->value,
+            $user,
+            $expirationDate,
+        );
+
+        $this->assertSame('9cebe00d-04d8-48da-89b1-059f6b7bfe44', $token->getUuid());
+        $this->assertSame('token', $token->getToken());
+        $this->assertSame(TokenTypeEnum::FORGOT_PASSWORD->value, $token->getType());
+        $this->assertSame($user, $token->getUser());
+        $this->assertSame($expirationDate, $token->getExpirationDate());
+    }
+}


### PR DESCRIPTION
* Refs #1143 

Cette PR permet de rajouter le modèle de données "Token" pour pouvoir gérer les mots de passe oubliés ainsi que l'activation de compte.