### PR TITLE
Retire les method=DELETE non-standards

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -2,7 +2,7 @@
 framework:
     secret: '%env(APP_SECRET)%'
     csrf_protection: true
-    http_method_override: false
+    http_method_override: true
     trusted_proxies: '127.0.0.1,REMOTE_ADDR'
     trusted_headers: ['x-forwarded-for', 'x-forwarded-host', 'x-forwarded-proto', 'x-forwarded-port', 'x-forwarded-prefix']
 

--- a/templates/my_area/organization/logo.html.twig
+++ b/templates/my_area/organization/logo.html.twig
@@ -37,7 +37,8 @@
                             }) }}
                         {{ form_end(form) }}
                         {% if logo %}
-                            <form method="delete" action="{{ path('app_config_organization_delete_logo', { uuid: organization.uuid }) }}">
+                            <form method="POST" action="{{ path('app_config_organization_delete_logo', { uuid: organization.uuid }) }}">
+                                <input type="hidden" name="_method" value="DELETE">
                                 <button class="fr-mt-2w fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-delete-bin-line">
                                     {{ 'organization.logo.delete'|trans }}
                                 </button>

--- a/templates/my_area/organization/user/index.html.twig
+++ b/templates/my_area/organization/user/index.html.twig
@@ -57,12 +57,14 @@
                                                     {{ 'common.update'|trans }}
                                                 </a>
                                                 <form
-                                                    method="delete"
+                                                    method="POST"
                                                     action="{{ path('app_organization_users_delete', { uuid: user.uuid, organizationUuid: organization.uuid }) }}"
                                                     data-controller="form-submit"
                                                     data-action="modal-trigger:submit->form-submit#submit"
                                                     class="fr-hidden fr-unhidden-md"
                                                 >
+                                                    <input type="hidden" name="_method" value="DELETE">
+
                                                     <d-modal-trigger modal="user-delete-modal" submitValue="user-delete-{{ user.uuid }}">
                                                         <button
                                                             class="fr-btn fr-btn--tertiary-no-outline fr-icon-delete-bin-line"

--- a/templates/my_area/organization/visa_model/index.html.twig
+++ b/templates/my_area/organization/visa_model/index.html.twig
@@ -75,11 +75,13 @@
                                                 </form>
                                                 {% if visa.organizationUuid %}
                                                     <form
-                                                        method="delete"
+                                                        method="POST"
                                                         action="{{ path('app_config_visa_models_delete', { uuid: visa.uuid, organizationUuid: organization.uuid }) }}"
                                                         data-controller="form-submit"
                                                         data-action="modal-trigger:submit->form-submit#submit"
                                                     >
+                                                        <input type="hidden" name="_method" value="DELETE">
+
                                                         <d-modal-trigger modal="visa-delete-modal" submitValue="visa-delete-{{ visa.uuid }}">
                                                             <button
                                                                 class="fr-btn fr-btn--tertiary-no-outline fr-icon-delete-bin-line"

--- a/templates/my_area/profile/delete-profile.html.twig
+++ b/templates/my_area/profile/delete-profile.html.twig
@@ -27,11 +27,13 @@
                     <li>{{ 'profile.delete.third.item'|trans }}</li>
                 </ul>
                 <form
-                method="delete"
-                action="{{ path('app_profile_delete') }}"
-                data-controller="form-submit"
-                data-action="modal-trigger:submit->form-submit#submit"
+                    method="POST"
+                    action="{{ path('app_profile_delete') }}"
+                    data-controller="form-submit"
+                    data-action="modal-trigger:submit->form-submit#submit"
                 >
+                    <input type="hidden" name="_method" value="DELETE">
+
                     <d-modal-trigger modal="user-profile-delete-modal" submitValue="user-profile-delete-{{ app.user.getFullName() }}">
                         <button
                             class="fr-btn fr-x-btn-sm--icon-left fr-icon-delete-bin-line fr-mt-3w"

--- a/templates/regulation/_items.html.twig
+++ b/templates/regulation/_items.html.twig
@@ -78,12 +78,14 @@
                             {% endif %}
                             {% if belongsToOrganizationUsers %}
                                 <form
-                                    method="delete"
+                                    method="POST"
                                     action="{{ path('app_regulation_delete', { uuid: regulation.uuid }) }}"
                                     data-controller="form-submit"
                                     data-action="modal-trigger:submit->form-submit#submit"
                                     class="fr-hidden fr-unhidden-md"
                                 >
+                                    <input type="hidden" name="_method" value="DELETE">
+
                                     <d-modal-trigger modal="regulation-delete-modal" submitValue="regulation-delete-{{ regulation.uuid }}">
                                         <button
                                             class="fr-btn fr-btn--tertiary-no-outline fr-icon-delete-bin-line"

--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -82,11 +82,13 @@
                                     <li>
                                         {% set deleteCsrfToken = csrf_token('delete-regulation') %}
                                         <form
-                                            method="delete"
+                                            method="POST"
                                             action="{{ path('app_regulation_delete', { uuid: generalInfo.uuid }) }}"
                                             data-controller="form-submit"
                                             data-action="modal-trigger:submit->form-submit#submit"
                                         >
+                                            <input type="hidden" name="_method" value="DELETE">
+
                                             <d-modal-trigger modal="regulation-delete-modal" submitValue="delete">
                                                 <button
                                                     class="fr-btn fr-btn--tertiary-no-outline fr-btn--icon-left fr-icon-delete-bin-line"

--- a/templates/regulation/fragments/_measure_delete_form.html.twig
+++ b/templates/regulation/fragments/_measure_delete_form.html.twig
@@ -1,9 +1,11 @@
 <form
-    method="delete"
+    method="POST"
     action="{{ path('fragment_regulations_measure_delete', { regulationOrderRecordUuid, uuid }) }}"
     data-controller="form-submit"
     data-action="modal-trigger:submit->form-submit#submit"
 >
+    <input type="hidden" name="_method" value="DELETE">
+
     <d-modal-trigger modal="measure-delete-modal" submitValue="{{ uuid }}">
         <button
             class="fr-btn fr-btn--tertiary fr-icon-delete-line"

--- a/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/RegulationDetailControllerTest.php
@@ -68,7 +68,8 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
 
         $formDelete = $crawler->filter('aside')->selectButton('Supprimer')->form();
         $this->assertSame($formDelete->getUri(), 'http://localhost/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL);
-        $this->assertSame($formDelete->getMethod(), 'DELETE');
+        $this->assertSame($formDelete->getMethod(), 'POST');
+        $this->assertSame($formDelete->get('_method')->getValue(), 'DELETE');
 
         $publishBtn = $crawler->selectButton('Publier');
         $this->assertSame(0, $crawler->selectButton('Valider')->count()); // Location form
@@ -134,7 +135,8 @@ final class RegulationDetailControllerTest extends AbstractWebTestCase
 
         $formDelete = $crawler->filter('aside')->selectButton('Supprimer')->form();
         $this->assertSame($formDelete->getUri(), 'http://localhost/regulations/' . RegulationOrderRecordFixture::UUID_PUBLISHED);
-        $this->assertSame($formDelete->getMethod(), 'DELETE');
+        $this->assertSame($formDelete->getMethod(), 'POST');
+        $this->assertSame($formDelete->get('_method')->getValue(), 'DELETE');
     }
 
     public function testCannotAccessBecauseDifferentOrganization(): void


### PR DESCRIPTION
* Vu https://github.com/MTES-MCT/dialog/pull/1171#issuecomment-2616053260

À plusieurs endroits on utilise `<form method="DELETE">`, or dans la spec HTML seules les méthodes GET et POST sont supportées (malheureusement)

Ça fonctionne car, visiblement, Turbo interprète le DELETE et va automatiquement envoyer ce qu'il faut pour que Symfony interprète la requête comme un DELETE

Sauf que `http_method_override` (qui permettrait à Symfony d'interpréter un `<input type="hidden" name="_method">` envoyé par Turbo) était désactivé dans notre config Symfony... Donc je ne sais même pas comment ça pouvait en réalité fonctionner.

Et je n'ai trouvé aucune trace de ça dans la doc Turbo ni sur les forums : https://turbo.hotwired.dev/reference/drive

Vu que ce n'est pas documenté, je propose de ne pas se baser sur Turbo pour ça. Cette PR passe sur l'input hidden de Symfony. L'alternative serait de tout passer en POST, mais ça impliquerait de nombreux changements dans les tests (requêtes DELETE -> POST).