### PR TITLE
Gère les géométries Litteralis déjà sous forme de linéaires

### DIFF
--- a/src/Infrastructure/Adapter/BdTopoRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/BdTopoRoadGeocoder.php
@@ -398,7 +398,14 @@ final class BdTopoRoadGeocoder implements RoadGeocoderInterface, IntersectionGeo
                 // ST_ApproximateMedialAxis permet de calculer la "ligne centrale" d'un polygone
                 // https://postgis.net/docs/ST_ApproximateMedialAxis.html
                 // Ici on l'utilise pour approximer le linéaire de voie à partir d'un polygone qui définit l'enveloppe de cette voie.
-                'SELECT ST_AsGeoJSON(ST_ApproximateMedialAxis(ST_MakeValid(:geom))) AS geom',
+                // Si la géométrie n'est pas un polygône, on la renvoie telle quelle.
+                'SELECT ST_AsGeoJSON(
+                    CASE
+                    WHEN ST_GeometryType((:geom)::geometry) IN (\'ST_Polygon\', \'ST_MultiPolygon\')
+                    THEN ST_ApproximateMedialAxis(ST_MakeValid(:geom))
+                    ELSE (:geom)::geometry
+                    END
+                ) AS geom',
                 [
                     'geom' => $geometry,
                 ],

--- a/src/Infrastructure/Integration/Litteralis/LitteralisTransformer.php
+++ b/src/Infrastructure/Integration/Litteralis/LitteralisTransformer.php
@@ -175,10 +175,12 @@ final readonly class LitteralisTransformer
         $properties = $feature['properties'];
         $label = trim($properties['localisations']);
 
-        // La géométrie est un POLYGON ou un MULTIPOLYGON dessiné(s) par un agent dans Litteralis.
-        // On convertit en linéaire en s'aidant des tronçons de route de la BDTOPO.
-        $polygonGeometry = json_encode($feature['geometry']);
-        $sectionsGeometry = $this->roadGeocoder->convertPolygonRoadToLines($polygonGeometry);
+        // Selon la collectivité, la géométrie peut être de plusieurs sortes :
+        // * (Cas par défaut) Un linéaire, sous forme de LINESTRING ou MULTILINESTRING => on importe tel quel.
+        // * Un POLYGON ou un MULTIPOLYGON dessiné(s) par un agent dans Litteralis => On convertit en linéaire en s'aidant des tronçons de route de la BDTOPO.
+        $geometry = json_encode($feature['geometry']);
+
+        $sectionsGeometry = $this->roadGeocoder->convertPolygonRoadToLines($geometry);
 
         $locationCommand = new SaveLocationCommand();
         $locationCommand->roadType = RoadTypeEnum::RAW_GEOJSON->value;

--- a/tests/Integration/Infrastructure/Adapter/BdTopoRoadGeocoderTest.php
+++ b/tests/Integration/Infrastructure/Adapter/BdTopoRoadGeocoderTest.php
@@ -417,13 +417,14 @@ final class BdTopoRoadGeocoderTest extends KernelTestCase
 
     public function testConvertPolygonToRoadLines(): void
     {
-        $polygonGeometry = '{"type":"Polygon","coordinates":[[[3.0739553997,50.6424619948],[3.0739665207,50.6424529935],[3.074522087,50.6418609607],[3.0777787224,50.63850051],[3.0776585827,50.6384534293],[3.0744016773,50.6418141505],[3.0744011534,50.6418146998],[3.0738499776,50.6424020525],[3.0733516646,50.6427136294],[3.0734506159,50.6427776181],[3.0739553997,50.6424619948]]]}';
+        $polygonCoordinates = [[[3.0739553997, 50.6424619948], [3.0739665207, 50.6424529935], [3.074522087, 50.6418609607], [3.0777787224, 50.63850051], [3.0776585827, 50.6384534293], [3.0744016773, 50.6418141505], [3.0744011534, 50.6418146998], [3.0738499776, 50.6424020525], [3.0733516646, 50.6427136294], [3.0734506159, 50.6427776181], [3.0739553997, 50.6424619948]]];
+        $polygonGeometry = json_encode(['type' => 'Polygon', 'coordinates' => $polygonCoordinates]);
+        $multiPolygonGeometry = json_encode(['type' => 'MultiPolygon', 'coordinates' => [$polygonCoordinates]]);
 
-        $geometry = $this->roadGeocoder->convertPolygonRoadToLines($polygonGeometry);
+        $expectedLine = '{"type":"MultiLineString","coordinates":[[[3.073884143,50.64244362],[3.073451098,50.642714387]],[[3.073884143,50.64244362],[3.0739208,50.64241349]],[[3.0739208,50.64241349],[3.073925633,50.642408998]],[[3.077673753,50.638523301],[3.07447901,50.641819881]],[[3.07447901,50.641819881],[3.074444873,50.641855679]],[[3.074444873,50.641855679],[3.074444682,50.64185588]],[[3.074444682,50.64185588],[3.073925633,50.642408998]]]}';
 
-        $this->assertSame(
-            '{"type":"MultiLineString","coordinates":[[[3.073884143,50.64244362],[3.073451098,50.642714387]],[[3.073884143,50.64244362],[3.0739208,50.64241349]],[[3.0739208,50.64241349],[3.073925633,50.642408998]],[[3.077673753,50.638523301],[3.07447901,50.641819881]],[[3.07447901,50.641819881],[3.074444873,50.641855679]],[[3.074444873,50.641855679],[3.074444682,50.64185588]],[[3.074444682,50.64185588],[3.073925633,50.642408998]]]}',
-            $geometry,
-        );
+        $this->assertSame($expectedLine, $this->roadGeocoder->convertPolygonRoadToLines($polygonGeometry));
+        $this->assertSame($expectedLine, $this->roadGeocoder->convertPolygonRoadToLines($multiPolygonGeometry));
+        $this->assertSame($expectedLine, $this->roadGeocoder->convertPolygonRoadToLines($expectedLine)); // Test not polygon
     }
 }


### PR DESCRIPTION
* En lien avec #1142 

Signalé par @MathieuFV : actuellement pour Fougères, la carte ne montre que quelques localisations alors qu'il y a une dizaine d'arrêtés en cours ou à venir

La cause : en DB la majorité des localisations Fougères valent `{"type": "MultiLineString", "coordinates": []}`

La raison : Fougères dessine ses géométries sous forme de linéaires et pas sous forme de contours polygônes ! On passait donc les linéaires dans convertPolygonToLines(), ce qui donnait une multilinestring vide...

Cette PR corrige convertPolygonToLines() pour ne faire le calcul que si la géométrie est un POLYGON ou un MULTIPOLYGON, et renvoyer la géométrie inchangée sinon. (Ça évite de devoir faire des checks sur le type de géométrie en PHP.)

Ça devrait corriger des problèmes vus sur la MEL aussi, ainsi que potentiellement Lons le Saunier

## Avant

![Screenshot 2025-01-28 at 15-24-17 Carte - DiaLog](https://github.com/user-attachments/assets/bdfe4d61-f2a1-4060-8887-e9983ddd0c33)

## Après

![Screenshot 2025-01-28 at 15-24-11 Carte - DiaLog](https://github.com/user-attachments/assets/e4aa32d9-4d29-4c99-9396-b81b8d1ff3ff)
