### PR TITLE
Fix worker option

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/run
-worker: php bin/console messenger:consume async --time-limit=300 --limit=50  --sleep=5 --failure-limit=5 --recover-timeout=30
+worker: php bin/console messenger:consume async --time-limit=300 --memory-limit=256M --limit=50
 postdeploy: make scalingo-postdeploy


### PR DESCRIPTION
Vu sur #1165, la définition du procfile était invalide

`2025-01-29 10:36:20.122120127 +0000 UTC [worker-1] The "--recover-timeout" option does not exist.`