### PR TITLE
Empêche le redémarrage normal du prod de déclencher un crash Scalingo

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/run
-worker: php bin/console messenger:consume async --time-limit=300 --memory-limit=256M --limit=50
+worker: php bin/console messenger:consume async --memory-limit=256M
 postdeploy: make scalingo-postdeploy

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/run
-worker: php bin/console messenger:consume async --memory-limit=256M
+worker: php bin/console messenger:consume async --memory-limit=256M --limit=50
 postdeploy: make scalingo-postdeploy

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/run
-worker: php bin/console messenger:consume async --memory-limit=256M --limit=50
+worker: bash -c "while true ; do php bin/console messenger:consume async --memory-limit=256M --limit=50 ; if [ $? -ne 0 ]; then break fi ; done"
 postdeploy: make scalingo-postdeploy

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/run
-worker: bash -c "while true ; do php bin/console messenger:consume async --memory-limit=256M --limit=50 ; if [ $? -ne 0 ]; then break fi ; done"
+worker: bash -c "set -e; while true ; do php bin/console messenger:consume async --memory-limit=256M --limit=50 ; done"
 postdeploy: make scalingo-postdeploy


### PR DESCRIPTION
* Suite de #1180 

En production Scalingo gère lui-mêmes les processus, on n'a pas accès à un supervisord ou à un systemd

L'arrêt du worker est interprété comme un crash, j'ai demandé au support Scalingo si on pouvait le marquer comme "OK"

Ils m'ont fait une suggestion en utilisant bash et une boucle infinie.

Motivation initiale du redémarrage périodique en prod : [doc Symfony](https://symfony.com/doc/current/messenger.html#deploying-to-production))

> Don't Let Workers Run Forever
>    Some services (like Doctrine's EntityManager) will consume more memory over time. So, instead of allowing your worker to run forever, use a flag like messenger:consume --limit=10 to tell your worker to only handle 10 messages before exiting (then the process manager will create a new process). There are also other options like --memory-limit=128M and --time-limit=3600. 