### PR TITLE
Ajoute les aires de stockage au DATEX

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -148,6 +148,7 @@ when@test:
             arguments: ['@http_kernel']
         App\Infrastructure\Adapter\DateUtils:
             class: App\Tests\Mock\DateUtilsMock
+            arguments: ['%client_timezone%']
         App\Tests\Mock\ApiOrganizationFetcherMock:
             decorates: 'organization_fetcher.client'
             decoration_inner_name: 'App\Tests\Mock\EudonetParis\ApiOrganizationFetcherMock::organization_fetcher.client'

--- a/templates/api/regulations.xml.twig
+++ b/templates/api/regulations.xml.twig
@@ -60,6 +60,14 @@
                                     <unitOfMeasure>kilometresPerHour</unitOfMeasure>
                                 </maxValue>
                             </typeOfRegulation>
+                        {% elseif trafficRegulation.type == 'storageArea' %}
+                            <typeOfRegulation xsi:type="MandatoryRoadOrCarriagewayOrLaneUsage">
+                                <otherObligation>
+                                    <com:values>
+                                        <com:value>Aire de stockage</com:value>
+                                    </com:values>
+                                </otherObligation>
+                            </typeOfRegulation>
                         {% else %}
                             <typeOfRegulation xsi:type="AccessRestriction">
                                 <accessRestrictionType>noEntry</accessRestrictionType>
@@ -117,7 +125,7 @@
                                                     <loc:roadInformation>
                                                         <loc:roadName>{{ location.roadName }}</loc:roadName>
                                                     </loc:roadInformation>
-                                                {% elseif location.roadType == 'departmentalRoad' %}
+                                                {% elseif location.roadType == 'departmentalRoad' or location.roadType == 'nationalRoad' %}
                                                     <loc:roadInformation>
                                                         <loc:roadNumber>{{ location.roadNumber }}</loc:roadNumber>
                                                     </loc:roadInformation>

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -453,6 +453,29 @@
                             <validityByOrder>
                                 <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
                                 <com:validityTimeSpecification>
+                                    <com:overallStartTime>2023-06-01T23:00:00+00:00</com:overallStartTime>
+                                    <com:overallEndTime>2023-06-06T22:59:00+00:00</com:overallEndTime>
+
+                                    <com:validPeriod>
+                                        <com:recurringTimePeriodOfDay>
+                                            <com:startTimeOfPeriod>19:00:00+00:00</com:startTimeOfPeriod>
+                                            <com:endTimeOfPeriod>21:00:00+00:00</com:endTimeOfPeriod>
+                                        </com:recurringTimePeriodOfDay>
+                                        <com:recurringTimePeriodOfDay>
+                                            <com:startTimeOfPeriod>12:00:00+00:00</com:startTimeOfPeriod>
+                                            <com:endTimeOfPeriod>14:00:00+00:00</com:endTimeOfPeriod>
+                                        </com:recurringTimePeriodOfDay>
+                                        <com:recurringDayWeekMonthPeriod>
+                                            <com:applicableDay>tuesday</com:applicableDay>
+                                        </com:recurringDayWeekMonthPeriod>
+                                    </com:validPeriod>
+                                </com:validityTimeSpecification>
+                            </validityByOrder>
+                        </conditions>
+                        <conditions xsi:type="ValidityCondition">
+                            <validityByOrder>
+                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                                <com:validityTimeSpecification>
                                     <com:overallStartTime>2023-06-03T08:00:00+00:00</com:overallStartTime>
                                     <com:overallEndTime>2023-06-05T10:00:00+00:00</com:overallEndTime>
 
@@ -489,29 +512,6 @@
                                             <com:applicableDay>friday</com:applicableDay>
                                             <com:applicableDay>saturday</com:applicableDay>
                                             <com:applicableDay>sunday</com:applicableDay>
-                                        </com:recurringDayWeekMonthPeriod>
-                                    </com:validPeriod>
-                                </com:validityTimeSpecification>
-                            </validityByOrder>
-                        </conditions>
-                        <conditions xsi:type="ValidityCondition">
-                            <validityByOrder>
-                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
-                                <com:validityTimeSpecification>
-                                    <com:overallStartTime>2023-06-01T23:00:00+00:00</com:overallStartTime>
-                                    <com:overallEndTime>2023-06-06T22:59:00+00:00</com:overallEndTime>
-
-                                    <com:validPeriod>
-                                        <com:recurringTimePeriodOfDay>
-                                            <com:startTimeOfPeriod>12:00:00+00:00</com:startTimeOfPeriod>
-                                            <com:endTimeOfPeriod>14:00:00+00:00</com:endTimeOfPeriod>
-                                        </com:recurringTimePeriodOfDay>
-                                        <com:recurringTimePeriodOfDay>
-                                            <com:startTimeOfPeriod>19:00:00+00:00</com:startTimeOfPeriod>
-                                            <com:endTimeOfPeriod>21:00:00+00:00</com:endTimeOfPeriod>
-                                        </com:recurringTimePeriodOfDay>
-                                        <com:recurringDayWeekMonthPeriod>
-                                            <com:applicableDay>tuesday</com:applicableDay>
                                         </com:recurringDayWeekMonthPeriod>
                                     </com:validPeriod>
                                 </com:validityTimeSpecification>
@@ -819,6 +819,113 @@
                 <trafficRegulationOrderExtended>
                     <dx:source>dialog</dx:source>
                     <dx:publicUrl>http://localhost/regulations/3ede8b1a-1816-4788-8510-e08f45511cb5</dx:publicUrl>
+                </trafficRegulationOrderExtended>
+            </_trafficRegulationOrderExtension>
+        </trafficRegulationOrder>
+        <trafficRegulationOrder id="804fedae-db25-4ac8-ac95-2d6cf4df7422" version="1">
+            <description>
+                <com:values>
+                    <com:value>Arrêté de viabilité hivernale sur la N176</com:value>
+                </com:values>
+            </description>
+            <issuingAuthority>
+                <com:values>
+                    <com:value>Main Org</com:value>
+                </com:values>
+            </issuingAuthority>
+            <regulationId>F2025/HIVER1#e0d93630-acf7-4722-81e8-ff7d5fa64b66</regulationId>
+            <status>madeAndImplemented</status>
+            <validityByOrder>
+                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                <com:validityTimeSpecification>
+                    <com:overallStartTime>2025-01-14T23:00:00+00:00</com:overallStartTime>
+                    <com:overallEndTime>2025-01-30T22:59:00+00:00</com:overallEndTime>
+                </com:validityTimeSpecification>
+            </validityByOrder>
+            <trafficRegulation>
+                <status>active</status>
+                <typeOfRegulation xsi:type="AccessRestriction">
+                    <accessRestrictionType>noEntry</accessRestrictionType>
+                </typeOfRegulation>
+                <condition xsi:type="ConditionSet">
+                    <operator>and</operator>
+                    <conditions xsi:type="ConditionSet">
+                        <operator>or</operator>
+                        <conditions xsi:type="ValidityCondition">
+                            <validityByOrder>
+                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                                <com:validityTimeSpecification>
+                                    <com:overallStartTime>2025-01-14T23:00:00+00:00</com:overallStartTime>
+                                    <com:overallEndTime>2025-01-30T22:59:00+00:00</com:overallEndTime>
+                                </com:validityTimeSpecification>
+                            </validityByOrder>
+                        </conditions>
+                    </conditions>
+                    <conditions xsi:type="ConditionSet">
+                        <operator>or</operator>
+                        <conditions xsi:type="LocationCondition">
+                            <locationByOrder xsi:type="loc:LinearLocation">
+                                <loc:supplementaryPositionalDescription>
+                                    <loc:roadInformation>
+                                        <loc:roadNumber>N176</loc:roadNumber>
+                                    </loc:roadInformation>
+                                </loc:supplementaryPositionalDescription>
+                                <loc:_linearLocationExtension>
+                                    <loc:linearLocationExtended>
+                                        <dx:geoJsonGeometry>{"type":"LineString","coordinates":[[-2.201030047,48.425146243],[-2.202297854,48.425049341],[-2.203494689,48.424960714],[-2.204844298,48.424855445],[-2.20605839,48.424763329],[-2.207220768,48.424682489],[-2.208240455,48.424597091],[-2.209135407,48.424537907],[-2.209826241,48.424496709],[-2.210661899,48.424481594],[-2.211431991,48.424488292],[-2.212205395,48.424514674],[-2.212921594,48.424565207],[-2.213689115,48.424641427],[-2.214594712,48.424757547],[-2.215491296,48.424905612],[-2.215554944,48.424919039],[-2.215680624,48.424943259],[-2.215978733,48.424998656],[-2.216104502,48.425023774],[-2.21676327,48.425177793],[-2.217372772,48.425326766],[-2.218186595,48.425555094],[-2.219502576,48.425942518],[-2.219780534,48.426026744],[-2.219883914,48.426058253],[-2.219938302,48.426073889],[-2.219946751,48.426077123],[-2.220038895,48.426104619],[-2.220177245,48.42614721],[-2.220368545,48.426204599],[-2.220522179,48.426251024],[-2.221544411,48.42654498],[-2.222444316,48.426780305],[-2.223233216,48.426961914],[-2.223998672,48.427112092],[-2.224057921,48.427122102],[-2.224949811,48.427263094],[-2.225597801,48.427335494],[-2.226444504,48.427417158],[-2.227360371,48.427472322],[-2.228360141,48.427512956],[-2.229256778,48.427551823],[-2.229803018,48.427568284],[-2.229915773,48.427571421],[-2.229968645,48.427571792],[-2.23012591,48.427572964],[-2.230357627,48.427573554],[-2.231164997,48.42757307],[-2.232126589,48.427543229],[-2.23290943,48.427500539],[-2.233736158,48.427436069],[-2.234630872,48.42734695],[-2.235478477,48.427233759],[-2.236366909,48.427095315],[-2.236939988,48.426987034],[-2.237769619,48.426816015],[-2.238652671,48.426596645],[-2.238806891,48.42655376],[-2.238871456,48.426535578],[-2.238900502,48.426527982],[-2.238917587,48.426522718],[-2.239121984,48.426466794],[-2.239360552,48.426400343],[-2.239966013,48.426209468],[-2.240233538,48.426120996],[-2.240654293,48.425979763],[-2.2414583,48.425701655],[-2.242373085,48.425379869],[-2.243183904,48.425115873],[-2.243776118,48.424928268],[-2.244414991,48.424746709],[-2.245340337,48.42449025],[-2.246279517,48.424250302],[-2.247178492,48.42404188],[-2.248091483,48.423851765],[-2.249345596,48.423618576],[-2.251348303,48.42325842],[-2.25248712,48.42306457],[-2.252912128,48.42299343],[-2.252999881,48.422976915],[-2.253983604,48.422803527]]}</dx:geoJsonGeometry>
+                                    </loc:linearLocationExtended>
+                                </loc:_linearLocationExtension>
+                            </locationByOrder>
+                        </conditions>
+                    </conditions>
+                </condition>
+            </trafficRegulation>
+            <trafficRegulation>
+                <status>active</status>
+                <typeOfRegulation xsi:type="MandatoryRoadOrCarriagewayOrLaneUsage">
+                    <otherObligation>
+                        <com:values>
+                            <com:value>Aire de stockage</com:value>
+                        </com:values>
+                    </otherObligation>
+                </typeOfRegulation>
+                <condition xsi:type="ConditionSet">
+                    <operator>and</operator>
+                    <conditions xsi:type="ConditionSet">
+                        <operator>or</operator>
+                        <conditions xsi:type="ValidityCondition">
+                            <validityByOrder>
+                                <com:validityStatus>definedByValidityTimeSpec</com:validityStatus>
+                                <com:validityTimeSpecification>
+                                    <com:overallStartTime>2025-01-14T23:00:00+00:00</com:overallStartTime>
+                                    <com:overallEndTime>2025-01-30T22:59:00+00:00</com:overallEndTime>
+                                </com:validityTimeSpecification>
+                            </validityByOrder>
+                        </conditions>
+                    </conditions>
+                    <conditions xsi:type="ConditionSet">
+                        <operator>or</operator>
+                        <conditions xsi:type="LocationCondition">
+                            <locationByOrder xsi:type="loc:LinearLocation">
+                                <loc:supplementaryPositionalDescription>
+                                    <loc:roadInformation>
+                                        <loc:roadNumber>N176</loc:roadNumber>
+                                    </loc:roadInformation>
+                                </loc:supplementaryPositionalDescription>
+                                <loc:_linearLocationExtension>
+                                    <loc:linearLocationExtended>
+                                        <dx:geoJsonGeometry>{"type":"LineString","coordinates":[[-2.125866086,48.441256556],[-2.126882365,48.440993584],[-2.127692347,48.440782741],[-2.128221077,48.440647171],[-2.128688145,48.440532298],[-2.128834016,48.44049984],[-2.129624293,48.440323193],[-2.130617158,48.44012605],[-2.132545925,48.439772971],[-2.133414753,48.439610025],[-2.133783565,48.439543562],[-2.134460911,48.439417752],[-2.136098021,48.439116918],[-2.137024227,48.438945146],[-2.137813131,48.43879645],[-2.138690961,48.438615042],[-2.138750707,48.438602534],[-2.139416035,48.438451071],[-2.140190701,48.438267816],[-2.14083112,48.438111114],[-2.141526352,48.437933098],[-2.141981518,48.437807868],[-2.142308717,48.43771794],[-2.143015876,48.437509646],[-2.143791072,48.437276757],[-2.144711466,48.436977155],[-2.144932779,48.436899029],[-2.145592021,48.436672064],[-2.145648361,48.436652488],[-2.146638941,48.436281305],[-2.14764411,48.435893251],[-2.148531723,48.435549963],[-2.149395217,48.43520952],[-2.149678275,48.435098048],[-2.150589439,48.434746508],[-2.151494931,48.434392503],[-2.152007189,48.434200739],[-2.153201983,48.433743984],[-2.154472557,48.433245153],[-2.155628804,48.43279636],[-2.156793856,48.43234086],[-2.15784459,48.431935402],[-2.158929876,48.431509497],[-2.159873934,48.431149235],[-2.160717288,48.430825807],[-2.161364093,48.430583962],[-2.161579782,48.430504244],[-2.161617753,48.430490869],[-2.162177238,48.430297901],[-2.162363489,48.430235692],[-2.162409288,48.430219272],[-2.163119101,48.429984588],[-2.163654423,48.429821516],[-2.164022757,48.429709896],[-2.164864396,48.429465849],[-2.165263397,48.429349283],[-2.166032843,48.429142634],[-2.166910484,48.428920443],[-2.167692742,48.42873396],[-2.168584343,48.428543603],[-2.16945137,48.428365131],[-2.170460996,48.428190346],[-2.171520878,48.428016964],[-2.172281681,48.427901709],[-2.173173056,48.427778043],[-2.173884611,48.427699188],[-2.174568545,48.427628747],[-2.174695934,48.427615539]]}</dx:geoJsonGeometry>
+                                    </loc:linearLocationExtended>
+                                </loc:_linearLocationExtension>
+                            </locationByOrder>
+                        </conditions>
+                    </conditions>
+                </condition>
+            </trafficRegulation>
+            <_trafficRegulationOrderExtension>
+                <trafficRegulationOrderExtended>
+                    <dx:source>dialog</dx:source>
+                    <dx:publicUrl>http://localhost/regulations/6f665f38-7765-47b1-849a-06279eba3ac6</dx:publicUrl>
                 </trafficRegulationOrderExtended>
             </_trafficRegulationOrderExtension>
         </trafficRegulationOrder>

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateMeasureControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateMeasureControllerTest.php
@@ -137,7 +137,7 @@ final class UpdateMeasureControllerTest extends AbstractWebTestCase
         $this->assertRouteSame('fragment_regulations_measure', ['uuid' => MeasureFixture::UUID_CIFS]);
         $this->assertSame(
             // 09/06/2023 comes from DateUtilsMock
-            'du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le mardi (13h00-15h00 et 20h00-22h00) du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le mardi et le jeudi (09h00-11h00)',
+            'du 02/06/2023 à 00h00 au 06/06/2023 à 23h59, le mardi (13h00-15h00 et 20h00-22h00) du 03/06/2023 à 09h00 au 05/06/2023 à 11h00, le mardi et le jeudi (09h00-11h00)',
             ensureRegularSpaces($crawler->filter('li')->eq(1)->text()),
         );
     }
@@ -165,7 +165,7 @@ final class UpdateMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['periods'][0]['timeSlots'][0]['endTime']['minute'] = '0';
         $client->request($form->getMethod(), $form->getUri(), $values);
         $crawler = $client->followRedirect();
-        $this->assertSame('du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le lundi (08h00-18h00)', $crawler->filter('li')->eq(1)->text());
+        $this->assertSame('du 30/10/2023 à 08h00 au 30/10/2023 à 16h00, le lundi (08h00-18h00)', $crawler->filter('li')->eq(1)->text());
 
         // Remove added daily range
         $crawler = $client->request('GET', '/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/measure/' . MeasureFixture::UUID_TYPICAL . '/form');
@@ -177,7 +177,7 @@ final class UpdateMeasureControllerTest extends AbstractWebTestCase
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values);
         $this->assertResponseStatusCodeSame(303);
         $crawler = $client->followRedirect();
-        $this->assertSame('du 09/06/2023 à 10h00 au 09/06/2023 à 10h00 (08h00-18h00)', $crawler->filter('li')->eq(1)->text());
+        $this->assertSame('du 30/10/2023 à 08h00 au 30/10/2023 à 16h00 (08h00-18h00)', $crawler->filter('li')->eq(1)->text());
     }
 
     public function testRemoveTimeSlots(): void
@@ -205,7 +205,7 @@ final class UpdateMeasureControllerTest extends AbstractWebTestCase
         $values['measure_form']['periods'][0]['timeSlots'][0]['endTime']['minute'] = '0';
         $client->request($form->getMethod(), $form->getUri(), $values);
         $crawler = $client->followRedirect();
-        $this->assertSame('du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le lundi (08h00-18h00)', $crawler->filter('li')->eq(1)->text());
+        $this->assertSame('du 30/10/2023 à 08h00 au 30/10/2023 à 16h00, le lundi (08h00-18h00)', $crawler->filter('li')->eq(1)->text());
 
         // Remove added timeslot
         $crawler = $client->request('GET', '/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/measure/' . MeasureFixture::UUID_TYPICAL . '/form');
@@ -217,7 +217,7 @@ final class UpdateMeasureControllerTest extends AbstractWebTestCase
         $crawler = $client->request($form->getMethod(), $form->getUri(), $values);
         $this->assertResponseStatusCodeSame(303);
         $crawler = $client->followRedirect();
-        $this->assertSame('du 09/06/2023 à 10h00 au 09/06/2023 à 10h00, le lundi', $crawler->filter('li')->eq(1)->text());
+        $this->assertSame('du 30/10/2023 à 08h00 au 30/10/2023 à 16h00, le lundi', $crawler->filter('li')->eq(1)->text());
     }
 
     public function testGeocodingFailureFullRoad(): void

--- a/tests/Mock/DateUtilsMock.php
+++ b/tests/Mock/DateUtilsMock.php
@@ -5,9 +5,17 @@ declare(strict_types=1);
 namespace App\Tests\Mock;
 
 use App\Application\DateUtilsInterface;
+use App\Infrastructure\Adapter\DateUtils;
 
 final class DateUtilsMock implements DateUtilsInterface
 {
+    private $realDateUtils;
+
+    public function __construct(string $clientTimezone)
+    {
+        $this->realDateUtils = new DateUtils($clientTimezone);
+    }
+
     public function getTomorrow(): \DateTimeImmutable
     {
         return new \DateTimeImmutable('2023-05-10');
@@ -23,9 +31,11 @@ final class DateUtilsMock implements DateUtilsInterface
         return 1695218778.6387;
     }
 
-    public function mergeDateAndTime(\DateTimeInterface $date1, \DateTimeInterface $date2): \DateTimeInterface
+    public function mergeDateAndTime(\DateTimeInterface $date, \DateTimeInterface $time): \DateTimeInterface
     {
-        return new \DateTimeImmutable('2023-06-09 09:00:00');
+        // Purement un calcul, pas de valeur dépendante de la date et heure de lancement des tests, donc on utilise
+        // la vraie méthode.
+        return $this->realDateUtils->mergeDateAndTime($date, $time);
     }
 
     public function addDays(\DateTimeInterface $dateTime, int $numDays): \DateTimeInterface

--- a/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Query/GetRegulationOrdersToDatexFormatQueryHandlerTest.php
@@ -24,6 +24,8 @@ use App\Domain\Regulation\Enum\RoadTypeEnum;
 use App\Domain\Regulation\Enum\VehicleTypeEnum;
 use App\Domain\Regulation\Location\Location;
 use App\Domain\Regulation\Location\NamedStreet;
+use App\Domain\Regulation\Location\NumberedRoad;
+use App\Domain\Regulation\Location\StorageArea;
 use App\Domain\Regulation\Measure;
 use App\Domain\Regulation\RegulationOrder;
 use App\Domain\Regulation\RegulationOrderRecord;
@@ -323,18 +325,18 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
             ->method('getMeasures')
             ->willReturn([$measure1, $measure2]);
 
-        $regulationOrderRecord2 = $this->createMock(RegulationOrderRecord::class);
+        $regulationOrderRecord2WinterMaintenance = $this->createMock(RegulationOrderRecord::class);
         $regulationOrder2 = $this->createMock(RegulationOrder::class);
-        $regulationOrderRecord2
+        $regulationOrderRecord2WinterMaintenance
             ->expects(self::once())
             ->method('getSource')
             ->willReturn(RegulationOrderRecordSourceEnum::DIALOG->value);
-        $regulationOrderRecord2
+        $regulationOrderRecord2WinterMaintenance
             ->expects(self::once())
             ->method('getRegulationOrder')
             ->willReturn($regulationOrder2);
         $uuid2 = '066c603b-c507-75fd-8000-66acdc0f7ba1';
-        $regulationOrderRecord2
+        $regulationOrderRecord2WinterMaintenance
             ->expects(self::exactly(2))
             ->method('getUuid')
             ->willReturn($uuid2);
@@ -346,105 +348,158 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
             ->expects(self::once())
             ->method('getIdentifier')
             ->willReturn('F02/2024');
-        $regulationOrderRecord2
+        $regulationOrderRecord2WinterMaintenance
             ->expects(self::once())
             ->method('getOrganizationName')
             ->willReturn('Autorité 2');
-        $regulationOrderRecord2
+        $regulationOrderRecord2WinterMaintenance
             ->expects(self::once())
             ->method('getOrganizationUuid')
             ->willReturn('df1895bf-17af-4d68-adbd-02a7110d3b29');
         $regulationOrder2
             ->expects(self::once())
             ->method('getTitle')
-            ->willReturn('Description 2');
+            ->willReturn('Arrêté viabilité hivernale');
 
-        $measure3 = $this->createMock(Measure::class);
-        $measure3
+        $winterMaintenanceMeasure = $this->createMock(Measure::class);
+        $winterMaintenanceMeasure
             ->expects(self::once())
             ->method('getType')
             ->willReturn(MeasureTypeEnum::NO_ENTRY->value);
-        $measure3
+        $winterMaintenanceMeasure
             ->expects(self::once())
             ->method('getMaxSpeed')
             ->willReturn(null);
 
-        $vehicleSet3 = $this->createMock(VehicleSet::class);
-        $measure3
+        $winterMaintenanceVehicleSet = $this->createMock(VehicleSet::class);
+        $winterMaintenanceMeasure
             ->expects(self::once())
             ->method('getVehicleSet')
-            ->willReturn($vehicleSet3);
-        $vehicleSet3
+            ->willReturn($winterMaintenanceVehicleSet);
+        $winterMaintenanceVehicleSet
             ->expects(self::once())
             ->method('getRestrictedTypes')
             ->willReturn([VehicleTypeEnum::HEAVY_GOODS_VEHICLE->value, VehicleTypeEnum::DIMENSIONS->value]);
-        $vehicleSet3
+        $winterMaintenanceVehicleSet
             ->expects(self::never())
             ->method('getCritairTypes');
-        $vehicleSet3
+        $winterMaintenanceVehicleSet
             ->expects(self::once())
             ->method('getMaxHeight')
             ->willReturn(2.4);
-        $vehicleSet3
+        $winterMaintenanceVehicleSet
             ->expects(self::once())
             ->method('getMaxWidth')
             ->willReturn(2.0);
-        $vehicleSet3
+        $winterMaintenanceVehicleSet
             ->expects(self::once())
             ->method('getMaxLength')
             ->willReturn(12.0);
-        $vehicleSet3
+        $winterMaintenanceVehicleSet
             ->expects(self::once())
             ->method('getHeavyweightMaxWeight')
             ->willReturn(3.5);
-        $vehicleSet3
+        $winterMaintenanceVehicleSet
             ->expects(self::once())
             ->method('getExemptedTypes')
             ->willReturn([VehicleTypeEnum::COMMERCIAL->value, VehicleTypeEnum::OTHER->value, VehicleTypeEnum::ROAD_MAINTENANCE_OR_CONSTRUCTION->value]);
-        $vehicleSet3
+        $winterMaintenanceVehicleSet
             ->expects(self::once())
             ->method('getOtherExemptedTypeText')
             ->willReturn('Véhicules de service');
 
-        $locationView3 = new DatexLocationView(
-            roadType: RoadTypeEnum::LANE->value,
-            roadName: 'Route du Grand Brossais',
-            roadNumber: null,
+        $winterMaintenanceStorageAreaLocationView = new DatexLocationView(
+            roadType: RoadTypeEnum::NATIONAL_ROAD->value,
+            roadName: null,
+            roadNumber: 'N176',
+            rawGeoJSONLabel: null,
+            geometry: '<storageAreaGeometry>',
+        );
+        $winterMaintenanceStorageArea = $this->createMock(StorageArea::class);
+        $winterMaintenanceStorageArea
+            ->expects(self::once())
+            ->method('getRoadNumber')
+            ->willReturn('N176');
+        $winterMaintenanceStorageArea
+            ->expects(self::once())
+            ->method('getGeometry')
+            ->willReturn('<storageAreaGeometry>');
+
+        $winterMaintenanceLocationView = new DatexLocationView(
+            roadType: RoadTypeEnum::NATIONAL_ROAD->value,
+            roadName: null,
+            roadNumber: 'N176',
             rawGeoJSONLabel: null,
             geometry: GeoJSON::toLineString([
                 Coordinates::fromLonLat(-1.935836, 47.347024),
                 Coordinates::fromLonLat(-1.930973, 47.347917),
             ]),
         );
-
-        $location3 = $this->createMock(Location::class);
-        $namedStreet3 = $this->createMock(NamedStreet::class);
-        $location3
+        $winterMaintenanceLocation = $this->createMock(Location::class);
+        $winterMaintenanceNationalRoad = $this->createMock(NumberedRoad::class);
+        $winterMaintenanceLocation
             ->expects(self::once())
             ->method('getNamedStreet')
-            ->willReturn($namedStreet3);
-        $location3
+            ->willReturn(null);
+        $winterMaintenanceLocation
+            ->expects(self::once())
+            ->method('getNumberedRoad')
+            ->willReturn($winterMaintenanceNationalRoad);
+        $winterMaintenanceLocation
             ->expects(self::once())
             ->method('getRoadType')
-            ->willReturn($locationView3->roadType);
-        $namedStreet3
+            ->willReturn(RoadTypeEnum::NATIONAL_ROAD->value);
+        $winterMaintenanceNationalRoad
             ->expects(self::once())
-            ->method('getRoadName')
-            ->willReturn($locationView3->roadName);
-        $location3
+            ->method('getRoadNumber')
+            ->willReturn('N176');
+        $winterMaintenanceLocation
             ->expects(self::once())
             ->method('getGeometry')
-            ->willReturn($locationView3->geometry);
+            ->willReturn($winterMaintenanceLocationView->geometry);
+        $winterMaintenanceLocation
+            ->expects(self::once())
+            ->method('getStorageArea')
+            ->willReturn($winterMaintenanceStorageArea);
 
-        $measure3
+        $winterMaintenanceMeasure
             ->expects(self::once())
             ->method('getLocations')
-            ->willReturn([$location3]);
+            ->willReturn([$winterMaintenanceLocation]);
+
+        $winterMaintenanceValidityView = new DatexValidityConditionView(
+            new \DateTimeImmutable('2024-01-03 08:00', $this->tz),
+            new \DateTimeImmutable('2024-01-10 16:00', $this->tz),
+            [],
+        );
+
+        $winterMaintenancePeriod = $this->createMock(Period::class);
+        $winterMaintenancePeriod
+            ->expects(self::once())
+            ->method('getStartDateTime')
+            ->willReturn($winterMaintenanceValidityView->overallStartTime);
+        $winterMaintenancePeriod
+            ->expects(self::once())
+            ->method('getEndDateTime')
+            ->willReturn($winterMaintenanceValidityView->overallEndTime);
+        $winterMaintenancePeriod
+            ->expects(self::once())
+            ->method('getDailyRange')
+            ->willReturn(null);
+        $winterMaintenancePeriod
+            ->expects(self::once())
+            ->method('getTimeSlots')
+            ->willReturn([]);
+
+        $winterMaintenanceMeasure
+            ->expects(self::once())
+            ->method('getPeriods')
+            ->willReturn([$winterMaintenancePeriod]);
 
         $regulationOrder2
             ->expects(self::once())
             ->method('getMeasures')
-            ->willReturn([$measure3]);
+            ->willReturn([$winterMaintenanceMeasure]);
 
         $regulationOrderRecord3 = $this->createMock(RegulationOrderRecord::class);
         $regulationOrder3 = $this->createMock(RegulationOrder::class);
@@ -562,7 +617,7 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
         $regulationOrderRecordRepository
             ->expects(self::once())
             ->method('findRegulationOrdersForDatexFormat')
-            ->willReturn([$regulationOrderRecord1, $regulationOrderRecord2, $regulationOrderRecord3]);
+            ->willReturn([$regulationOrderRecord1, $regulationOrderRecord2WinterMaintenance, $regulationOrderRecord3]);
 
         $regulationOrderRecordRepository
             ->expects(self::once())
@@ -613,14 +668,34 @@ final class GetRegulationOrdersToDatexFormatQueryHandlerTest extends TestCase
                     regulationId: 'F02/2024#df1895bf-17af-4d68-adbd-02a7110d3b29',
                     organization: 'Autorité 2',
                     source: RegulationOrderRecordSourceEnum::DIALOG->value,
-                    title: 'Description 2',
+                    title: 'Arrêté viabilité hivernale',
                     startDate: $startDate2,
                     endDate: null,
                     trafficRegulations: [
                         new DatexTrafficRegulationView(
                             type: 'noEntry',
-                            locationConditions: [$locationView3],
-                            validityConditions: [],
+                            locationConditions: [$winterMaintenanceLocationView],
+                            validityConditions: [$winterMaintenanceValidityView],
+                            vehicleConditions: [
+                                new DatexVehicleConditionView(
+                                    'heavyGoodsVehicle',
+                                    maxWeight: 3.5,
+                                ),
+                                new DatexVehicleConditionView(
+                                    'dimensions',
+                                    maxWidth: 2,
+                                    maxLength: 12,
+                                    maxHeight: 2.4,
+                                ),
+                                new DatexVehicleConditionView(VehicleTypeEnum::COMMERCIAL->value, isExempted: true),
+                                new DatexVehicleConditionView(VehicleTypeEnum::OTHER->value, isExempted: true, otherTypeText: 'Véhicules de service'),
+                                new DatexVehicleConditionView(VehicleTypeEnum::ROAD_MAINTENANCE_OR_CONSTRUCTION->value, isExempted: true),
+                            ],
+                        ),
+                        new DatexTrafficRegulationView(
+                            type: 'storageArea',
+                            locationConditions: [$winterMaintenanceStorageAreaLocationView],
+                            validityConditions: [$winterMaintenanceValidityView],
                             vehicleConditions: [
                                 new DatexVehicleConditionView(
                                     'heavyGoodsVehicle',


### PR DESCRIPTION
* Partie 3) de #990 

Cette PR fait remonter les aires de stockage dans le DATEX, sous la forme d'une restriction supplémentaire indiquant que l'aire de stockage est une "voie obligatoire", en reprenant les véhicules concernés (ex : poids lourds) et périodes de la mesure d'interdiction de circulation

Pour permettre de tester correctement le DATEX, j'ai dû faire utiliser le vrai algo mergeDateAndTime() au DateUtilsMock. (Cette méthode est appelée dans le calcul des dates de période à afficher)