### PR TITLE
Corrige l'ouverture par défaut des Filtres carte

### DIFF
--- a/templates/map/map.html.twig
+++ b/templates/map/map.html.twig
@@ -22,9 +22,9 @@
 
                 <div class="fr-accordion">
                     <h2 class="fr-accordion__title">
-                        <button class="fr-accordion__btn" aria-expanded="true" aria-controls="accordion-1040"><span class="fr-icon-filter-line fr-icon--sm fr-mr-1w" aria-hidden="true"></span>{{ 'map.filters.title'|trans }}</button>
+                        <button class="fr-accordion__btn" aria-expanded="true" aria-controls="map-filters-accordion"><span class="fr-icon-filter-line fr-icon--sm fr-mr-1w" aria-hidden="true"></span>{{ 'map.filters.title'|trans }}</button>
                     </h2>
-                    <div class="fr-collapse" id="accordion-1040">
+                    <div class="fr-collapse fr-collapse--expanded" id="map-filters-accordion">
                         <h3 class="fr-h6 fr-my-2w">{{ 'map.filters.title.restriction'|trans }}</h3>
                         <d-map-form target="map" urlAttribute="dataUrl" class="fr-x-block fr-mb-2w">
                             {{ form_start(form, {

--- a/tests/Integration/Infrastructure/Controller/Map/MapControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Map/MapControllerTest.php
@@ -20,5 +20,8 @@ final class MapControllerTest extends AbstractWebTestCase
         // Search form is present
         $this->assertNotNull($crawler->selectButton('Rechercher'));
         $this->assertNotNull($crawler->filter('#search[name=search][autocomplete=off][spellcheck=false]')->first());
+
+        // Filters form is open by default
+        $this->assertStringContainsString('fr-collapse--expanded', $crawler->filter('#map-filters-accordion')->attr('class'));
     }
 }


### PR DESCRIPTION
* Vu en travaillant sur #1193 

Cette PR corrige un défaut qui faisait que le panneau "Filtres" de la carte s'ouvrait avec une animation lorsqu'on chargeait la page Carte, au lieu d'être ouvert d'office

Cela explique en partie le très mauvais CLS (content layout shift) observé ici https://github.com/MTES-MCT/dialog/issues/1142#issuecomment-2623958846

| CLS | Avant | Après |
|---|---|---|
| Mobile | :red_circle: 0.971 | :green_circle: 0.1 |
| Desktop | :yellow_circle: 0.156 | :green_circle: 0.007 |