### PR TITLE
Met à jour et active le code de tracking Matomo

### DIFF
--- a/assets/analytics.js
+++ b/assets/analytics.js
@@ -1,7 +1,0 @@
-import { beginMatomoTracking } from './lib';
-
-const _matomoEnabledValue = process.env.MATOMO_ENABLED || '';
-
-if (_matomoEnabledValue && _matomoEnabledValue !== 'false') {
-    beginMatomoTracking();
-}

--- a/assets/app.js
+++ b/assets/app.js
@@ -11,8 +11,5 @@ import './styles/app.scss';
 // start the Stimulus application
 import './bootstrap';
 
-// configure analytics
-import './analytics';
-
 // our custom HTML elements
 import './customElements';

--- a/assets/lib.js
+++ b/assets/lib.js
@@ -29,32 +29,6 @@ function _displayAnyDebugExceptionPage(event) {
 
 // End Turbo helpers
 
-// Matomo helpers
-
-export function beginMatomoTracking() {
-    console.debug('[Matomo] Started');
-
-    var _paq = window._paq = window._paq || [];
-
-    // Track initial page view
-    _paq.push(['setTrackerUrl', 'https://stats.beta.gouv.fr/matomo.php']);
-    _paq.push(['setSiteId', '38']);
-    _paq.push(['trackPageView']);
-    _paq.push(['enableLinkTracking']);
-
-    document.addEventListener('turbo:load', (event) => {
-        const url = new URL(event.detail.url);
-        // Track new page views
-        // See: https://developer.matomo.org/guides/spa-tracking
-        _paq.push(['setCustomUrl', url.pathname + url.search]);
-        _paq.push(['setDocumentTitle', document.title]);
-        _paq.push(['trackPageView']);
-        _paq.push(['enableLinkTracking']);
-    });
-}
-
-// End Matomo helpers
-
 /**
  * @param {HTMLElement} element 
  * @returns {void}

--- a/assets/matomo.js
+++ b/assets/matomo.js
@@ -1,0 +1,13 @@
+var _paq = window._paq = window._paq || [];
+/* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+_paq.push(["setDoNotTrack", true]);
+_paq.push(["disableCookies"]);
+_paq.push(['trackPageView']);
+_paq.push(['enableLinkTracking']);
+(function () {
+    var u = "https://stats.beta.gouv.fr/";
+    _paq.push(['setTrackerUrl', u + 'matomo.php']);
+    _paq.push(['setSiteId', '38']);
+    var d = document, g = d.createElement('script'), s = d.getElementsByTagName('script')[0];
+    g.async = true; g.src = u + 'matomo.js'; s.parentNode.insertBefore(g, s);
+})();

--- a/templates/layouts/layout.html.twig
+++ b/templates/layouts/layout.html.twig
@@ -22,6 +22,7 @@
         {{ encore_entry_script_tags('app') }}
         <script type="module" src="{{ asset('build/dsfr/dsfr.module.min.js') }}" defer></script>
         <script type="text/javascript" nomodule src="{{ asset('build/dsfr/dsfr.nomodule.min.js') }}" defer></script>
+        {{ encore_entry_script_tags('matomo') }}
     {% endblock %}
   </head>
   <body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,6 +34,8 @@ Encore
     // enables the Symfony UX Stimulus bridge (used in assets/bootstrap.js)
     .enableStimulusBridge('./assets/controllers.json')
 
+    .addEntry('matomo', './assets/matomo.js')
+
     // When enabled, Webpack "splits" your files into smaller pieces for greater optimization.
     .splitEntryChunks()
 


### PR DESCRIPTION
* Ref #1996

Cette PR ajoute le tracker Matomo dans `layout.html.twig`. Ça lui permet d'être présent sur toutes les pages du site.

Normalement, une fois cette PR en prod, on commencera à voir des stats de visite sur cette page : https://stats.beta.gouv.fr/index.php?module=CoreHome&action=index&idSite=38&period=day&date=yesterday#?period=day&date=yesterday&idSite=38&category=Dashboard_Dashboard&subcategory=1