### PR TITLE
Corrige l'erreur CSP Matomo

### DIFF
--- a/config/packages/nelmio_security.yaml
+++ b/config/packages/nelmio_security.yaml
@@ -30,7 +30,7 @@ nelmio_security:
         enabled: true
         enforce:
             default-src: ['self']
-            script-src: ['self', 'https://dialog-metabase.osc-fr1.scalingo.io']
+            script-src: ['self', 'https://dialog-metabase.osc-fr1.scalingo.io', 'https://stats.beta.gouv.fr/matomo.js']
             style-src: ['self', 'https://dialog-metabase.osc-fr1.scalingo.io']
             connect-src: ['self', 'https://data.geopf.fr']
             font-src: ['self']


### PR DESCRIPTION
* Suite à #1197 

L'intégration Matomo ne fonctionne pas en prod à cause d'une erreur CSP

> Content-Security-Policy : Les paramètres de la page ont empêché l’exécution d’un script (script-src-elem) à l’adresse https://stats.beta.gouv.fr/matomo.js car il enfreint la directive suivante : « script-src 'self' https://dialog-metabase.osc-fr1.scalingo.io/ 'unsafe-inline' 'nonce-NT/uO4Nb62hi8iljP5ZNcQ==' »

Visible aussi sur staging, je n'ai pas pensé à regarder

* [ ] L'erreur disparaît sur l'app de review