### PR TITLE
Ajoute la Mesure d'audience à la Politique de confidentialité, avec un opt-out

### DIFF
--- a/assets/customElements/index.js
+++ b/assets/customElements/index.js
@@ -4,3 +4,4 @@ import './map';
 import './map_form';
 import './map_search_form';
 import './responsive_iframe';
+import './stats_optout_form';

--- a/assets/customElements/stats_optout_form.js
+++ b/assets/customElements/stats_optout_form.js
@@ -1,0 +1,39 @@
+// @ts-check
+import { querySelectorOrError } from './util';
+
+customElements.define('d-stats-optout-form', class extends HTMLElement {
+    connectedCallback() {
+        // https://developer.matomo.org/guides/tracking-javascript-guide#optional-creating-a-custom-opt-out-form
+
+        document.addEventListener('DOMContentLoaded', () => {
+            /** @type {HTMLInputElement} */
+            const checkbox = querySelectorOrError(this, 'input[type="checkbox"]');
+
+            this._setOptOut(checkbox);
+
+            checkbox.addEventListener('click', () => this.#onCheckboxClick(checkbox));
+        });
+    }
+
+    /**
+     * @param {HTMLInputElement} checkbox 
+     */
+    #onCheckboxClick = (checkbox) => {
+        if (checkbox.checked) {
+            window['_paq'].push(['forgetUserOptOut']);
+        } else {
+            window['_paq'].push(['optUserOut']);
+        }
+
+        this._setOptOut(checkbox);
+    };
+
+    /**
+     * @param {HTMLInputElement} checkbox 
+     */
+    _setOptOut(checkbox) {
+        window['_paq'].push([function () {
+            checkbox.checked = !this.isUserOptedOut();
+        }]);
+    }
+})

--- a/templates/privacy.html.twig
+++ b/templates/privacy.html.twig
@@ -45,6 +45,19 @@
 
             Les données sont conservées pour une durée de : 22 ans ou jusqu’à l’expiration du contrat, à compter de la notification.
 
+            ## Mesure d'audience
+
+            Notre site utilise l'outil de mesure d'audience Matomo pour collecter des données d'utilisation du site de manière anonymisée et sans avoir recours aux cookies.
+
+            Vous pouvez décider de votre participation ou non à cette collecte en utilisant la case à cocher ci-dessous.
+
+            <d-stats-optout-form class="fr-x-block fr-checkbox-group fr-mb-3w">
+                <input type="checkbox" id="stats-optout">
+                <label class="fr-label" for="stats-optout">
+                    Participer à la mesure d'audience anonymisée
+                </label>
+            </d-stats-optout-form>
+
             ## Vos droits
 
             Nous nous engageons à prendre les mesures techniques et organisationnelles appropriées afin de garantir la sécurité du traitement des données à caractère personnel de chacun.


### PR DESCRIPTION
* Closes #1196 

Le tracking Matomo fonctionne

Cette PR réalise la dernière étape pour être exempté de collecter le consentement : màj la Politique de confidentialité, et permettre aux utilisateurs de sortir de la collecte de données anonymisées

L'opt-out est réalisé par Matomo en déposant un cookie d'opt-out

J'ai suivi cette doc https://developer.matomo.org/guides/tracking-javascript-guide#optional-creating-a-custom-opt-out-form

## Pour tester

* Lancer le site en local
* Aller sur http://localhost:8000/vie-privee
* Constater que la checkbox est cochée
* Ouvrir la console web, rubrique Stockage > Cookies
* Constater qu'il n'y a pas de cookie Matomo
* Cliquer sur la checkbox pour la décocher
* Constater qu'un cookie Matomo-optout est apparu
* Recharger la page
* Constater que la checkbox est tjr décochée, que le cookie d'optout est toujours là
* Cocher la checkbox à nouveau
* Le cookie d'optout disparaît, et en rechargeant la page la checkbox est toujours cochée
