### PR TITLE
Corrige l'attribution du rôle utilisateur dans l'organisation

### DIFF
--- a/src/Application/Organization/View/GetOrCreateOrganizationView.php
+++ b/src/Application/Organization/View/GetOrCreateOrganizationView.php
@@ -10,7 +10,7 @@ final readonly class GetOrCreateOrganizationView
 {
     public function __construct(
         public Organization $organization,
-        public bool $isCreated,
+        public bool $hasOrganizationUsers,
     ) {
     }
 }

--- a/src/Application/User/Command/ProConnect/CreateProConnectUserCommandHandler.php
+++ b/src/Application/User/Command/ProConnect/CreateProConnectUserCommandHandler.php
@@ -62,9 +62,9 @@ final class CreateProConnectUserCommandHandler
             $organization = $organizationView->organization;
 
             if (!$this->isUserAlreadyRegisteredInOrganization->isSatisfiedBy($user->getEmail(), $organization)) {
-                $organizationRole = $organizationView->isCreated
-                    ? OrganizationRolesEnum::ROLE_ORGA_ADMIN->value
-                    : OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value;
+                $organizationRole = $organizationView->hasOrganizationUsers
+                    ? OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value
+                    : OrganizationRolesEnum::ROLE_ORGA_ADMIN->value;
 
                 $organizationUser = (new OrganizationUser($this->idFactory->make()))
                     ->setUser($user)

--- a/src/Application/User/Command/RegisterCommandHandler.php
+++ b/src/Application/User/Command/RegisterCommandHandler.php
@@ -47,9 +47,9 @@ final class RegisterCommandHandler
         /** @var GetOrCreateOrganizationView $organizationView */
         $organizationView = $this->commandBus->handle(new GetOrCreateOrganizationBySiretCommand($command->organizationSiret));
         $organization = $organizationView->organization;
-        $organizationRole = $organizationView->isCreated
-            ? OrganizationRolesEnum::ROLE_ORGA_ADMIN->value
-            : OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value;
+        $organizationRole = $organizationView->hasOrganizationUsers
+            ? OrganizationRolesEnum::ROLE_ORGA_CONTRIBUTOR->value
+            : OrganizationRolesEnum::ROLE_ORGA_ADMIN->value;
 
         $now = $this->dateUtils->getNow();
         $user = (new User($this->idFactory->make()))

--- a/tests/Unit/Application/User/Command/RegisterCommandHandlerTest.php
+++ b/tests/Unit/Application/User/Command/RegisterCommandHandlerTest.php
@@ -85,7 +85,7 @@ final class RegisterCommandHandlerTest extends TestCase
             ->with('mathieu@fairness.coop')
             ->willReturn(null);
 
-        $orgView = new GetOrCreateOrganizationView($organization, false);
+        $orgView = new GetOrCreateOrganizationView($organization, true);
         $this->commandBus
             ->expects(self::once())
             ->method('handle')


### PR DESCRIPTION
* Signalé ici https://github.com/MTES-MCT/dialog/pull/1209#discussion_r1975097927

Cette PR corrige l'attribution des rôles utilisateur (contributeur ou administrateur) dans l'organisation. Lors de l'inscription via ProConnect ou via le formulaire standard, le système vérifie désormais si une organisation possède déjà des utilisateurs pour déterminer automatiquement le rôle à attribuer au nouvel utilisateur.