### PR TITLE
Fix: Corrige la date de début utilisée à l'affichage initial de la carte

### DIFF
--- a/src/Infrastructure/Controller/Map/Fragments/MapDataController.php
+++ b/src/Infrastructure/Controller/Map/Fragments/MapDataController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Controller\Map\Fragments;
 
+use App\Application\DateUtilsInterface;
 use App\Domain\Regulation\Repository\LocationRepositoryInterface;
 use App\Infrastructure\Controller\DTO\MapFilterDTO;
 use App\Infrastructure\Form\Map\MapFilterFormType;
@@ -19,6 +20,7 @@ final class MapDataController
         private FormFactoryInterface $formFactory,
         private RouterInterface $router,
         private LocationRepositoryInterface $locationRepository,
+        private DateUtilsInterface $dateUtils,
     ) {
     }
 
@@ -29,7 +31,7 @@ final class MapDataController
     )]
     public function __invoke(Request $request): Response
     {
-        $dto = new MapFilterDTO();
+        $dto = new MapFilterDTO($this->dateUtils->getNow());
         $form = $this->formFactory->create(
             type: MapFilterFormType::class,
             data: $dto,

--- a/tests/Integration/Infrastructure/Controller/Map/Fragment/MapDataControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Map/Fragment/MapDataControllerTest.php
@@ -11,6 +11,27 @@ use App\Tests\Integration\Infrastructure\Controller\AbstractWebTestCase;
 
 final class MapDataControllerTest extends AbstractWebTestCase
 {
+    public function testDefaultFilters(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', '/carte/data.geojson');
+
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+        $this->assertResponseHeaderSame('Content-Type', 'application/json');
+
+        $jsonData = $client->getResponse()->getContent();
+        $dataArray = json_decode($jsonData, true);
+
+        $this->assertCount(3, $dataArray['features']);
+        $locationUuids = array_map(fn ($f) => $f['properties']['location_uuid'], $dataArray['features']);
+        // Toutes les localisations des arrêtés de test publiés avec des mesures actives à la date 'now' définie par DateUtilsMock
+        // L'ordre peut varier donc on teste par présence et non en comparant la liste exacte
+        $this->assertContains(LocationFixture::UUID_CIFS_NAMED_STREET, $locationUuids);
+        $this->assertContains(LocationFixture::UUID_CIFS_DEPARTMENTAL_ROAD, $locationUuids);
+        $this->assertContains(LocationFixture::UUID_LITTERALIS, $locationUuids);
+    }
+
     public function testMeasureTypesFilter(): void
     {
         $client = static::createClient();

--- a/tests/Unit/Infrastructure/Integration/BacIdf/BacIdfTransformerTest.php
+++ b/tests/Unit/Infrastructure/Integration/BacIdf/BacIdfTransformerTest.php
@@ -864,7 +864,7 @@ final class BacIdfTransformerTest extends TestCase
         $periodCommand1->endTime = null;
         $periodCommand1->recurrenceType = PeriodRecurrenceTypeEnum::EVERY_DAY->value;
         $timeSlot = new SaveTimeSlotCommand();
-        $timeSlot->startTime = new \DateTimeImmutable('08:00', new \DateTimeZone('Europe/Paris'));
+        $timeSlot->startTime = new \DateTimeImmutable('08:00', new \DateTimeZone('Etc/GMT-1'));
         $timeSlot->endTime = new \DateTimeImmutable('22:00', new \DateTimeZone('Etc/GMT-1'));
         $periodCommand1->timeSlots = [$timeSlot];
 

--- a/tests/Unit/Infrastructure/Integration/BacIdf/BacIdfTransformerTest.php
+++ b/tests/Unit/Infrastructure/Integration/BacIdf/BacIdfTransformerTest.php
@@ -864,8 +864,8 @@ final class BacIdfTransformerTest extends TestCase
         $periodCommand1->endTime = null;
         $periodCommand1->recurrenceType = PeriodRecurrenceTypeEnum::EVERY_DAY->value;
         $timeSlot = new SaveTimeSlotCommand();
-        $timeSlot->startTime = new \DateTimeImmutable('08:00', new \DateTimeZone('Etc/GMT-1'));
-        $timeSlot->endTime = new \DateTimeImmutable('22:00', new \DateTimeZone('Etc/GMT-1'));
+        $timeSlot->startTime = new \DateTimeImmutable('08:00', new \DateTimeZone('Europe/Paris'));
+        $timeSlot->endTime = new \DateTimeImmutable('22:00', new \DateTimeZone('Europe/Paris'));
         $periodCommand1->timeSlots = [$timeSlot];
 
         $periodCommand2 = new SavePeriodCommand();
@@ -891,8 +891,8 @@ final class BacIdfTransformerTest extends TestCase
         $dailyRange->applicableDays = [ApplicableDayEnum::WEDNESDAY->value, ApplicableDayEnum::SUNDAY->value];
         $periodCommand3->dailyRange = $dailyRange;
         $timeSlot = new SaveTimeSlotCommand();
-        $timeSlot->startTime = new \DateTimeImmutable('08:00', new \DateTimeZone('Etc/GMT-1'));
-        $timeSlot->endTime = new \DateTimeImmutable('16:00', new \DateTimeZone('Etc/GMT-1'));
+        $timeSlot->startTime = new \DateTimeImmutable('08:00', new \DateTimeZone('Europe/Paris'));
+        $timeSlot->endTime = new \DateTimeImmutable('16:00', new \DateTimeZone('Europe/Paris'));
         $periodCommand3->timeSlots = [$timeSlot];
 
         yield [

--- a/tests/Unit/Infrastructure/Integration/BacIdf/BacIdfTransformerTest.php
+++ b/tests/Unit/Infrastructure/Integration/BacIdf/BacIdfTransformerTest.php
@@ -865,7 +865,7 @@ final class BacIdfTransformerTest extends TestCase
         $periodCommand1->recurrenceType = PeriodRecurrenceTypeEnum::EVERY_DAY->value;
         $timeSlot = new SaveTimeSlotCommand();
         $timeSlot->startTime = new \DateTimeImmutable('08:00', new \DateTimeZone('Europe/Paris'));
-        $timeSlot->endTime = new \DateTimeImmutable('22:00', new \DateTimeZone('Europe/Paris'));
+        $timeSlot->endTime = new \DateTimeImmutable('22:00', new \DateTimeZone('Etc/GMT-1'));
         $periodCommand1->timeSlots = [$timeSlot];
 
         $periodCommand2 = new SavePeriodCommand();
@@ -891,8 +891,8 @@ final class BacIdfTransformerTest extends TestCase
         $dailyRange->applicableDays = [ApplicableDayEnum::WEDNESDAY->value, ApplicableDayEnum::SUNDAY->value];
         $periodCommand3->dailyRange = $dailyRange;
         $timeSlot = new SaveTimeSlotCommand();
-        $timeSlot->startTime = new \DateTimeImmutable('08:00', new \DateTimeZone('Europe/Paris'));
-        $timeSlot->endTime = new \DateTimeImmutable('16:00', new \DateTimeZone('Europe/Paris'));
+        $timeSlot->startTime = new \DateTimeImmutable('08:00', new \DateTimeZone('Etc/GMT-1'));
+        $timeSlot->endTime = new \DateTimeImmutable('16:00', new \DateTimeZone('Etc/GMT-1'));
         $periodCommand3->timeSlots = [$timeSlot];
 
         yield [


### PR DESCRIPTION
Corrige un bug signalé par un utilisateur de Corrèze le 18/03

> Bonjour
>
> Juste pour vous signaler que les travaux remontés par le Conseil Départemental du Gers sont toujours affichés sur la carte.
> ![image](https://github.com/user-attachments/assets/59e9660e-179f-40bb-be15-5ce4efcc3c0b)



À l'affichage initial la carte appelle /carte/data.geojson sans aucun queryparam, et on ne testait pas ce cas-là
