### PR TITLE
Liste des arrêtés : conserve l'état des filtres après une suppression

### DIFF
--- a/src/Infrastructure/Controller/Regulation/DeleteRegulationController.php
+++ b/src/Infrastructure/Controller/Regulation/DeleteRegulationController.php
@@ -62,8 +62,12 @@ final class DeleteRegulationController
             throw new AccessDeniedHttpException();
         }
 
+        $redirectQueryParams = $request->query->get('_redirectQueryParams')
+            ? json_decode($request->query->get('_redirectQueryParams'), true)
+            : [];
+
         return new RedirectResponse(
-            url: $this->router->generate('app_regulations_list'),
+            url: $this->router->generate('app_regulations_list', $redirectQueryParams),
             status: Response::HTTP_SEE_OTHER,
         );
     }

--- a/templates/regulation/_items.html.twig
+++ b/templates/regulation/_items.html.twig
@@ -85,6 +85,7 @@
                                     class="fr-hidden fr-unhidden-md"
                                 >
                                     <input type="hidden" name="_method" value="DELETE">
+                                    <input type="hidden" name="_redirectQueryParams" value="{{ app.request.query.all()|json_encode }}">
 
                                     <d-modal-trigger modal="regulation-delete-modal" submitValue="regulation-delete-{{ regulation.uuid }}">
                                         <button

--- a/tests/Integration/Infrastructure/Controller/Regulation/DeleteRegulationControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/DeleteRegulationControllerTest.php
@@ -27,10 +27,10 @@ final class DeleteRegulationControllerTest extends AbstractWebTestCase
         $crawler = $client->request('GET', '/regulations');
         $num = $this->countRows($crawler);
 
-        $client->request('DELETE', '/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL, [
+        $client->request('DELETE', '/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '?_redirectQueryParams=' . json_encode(['page' => 1]), [
             '_token' => $this->generateCsrfToken($client, 'delete-regulation'),
         ]);
-        $this->assertResponseRedirects('/regulations', 303);
+        $this->assertResponseRedirects('/regulations?page=1', 303);
         $crawler = $client->followRedirect();
         // Doesn't appear in list of temporary regulations anymore.
         $this->assertEquals($num - 1, $this->countRows($crawler));


### PR DESCRIPTION
Petite idée d'amélioration

Actuellement lorsqu'on supprime un arrêté depuis la vue liste, on se fait renvoyer sur la vue "par défaut" de la liste (/regulations sans filtres), donc on perd les filtres qu'on avait configurés pour trouver cet arrêté. D'ailleurs ça ne permet pas de constater facilement que l'arrêté a bien été supprimé.

Cette PR propose de propager la query string à l'URL de redirection post-suppression, pour conserver la vue de la liste

TODO

* [x] Tests