### PR TITLE
Corrige erreur 500 lors suppression de 2+ localisations

### DIFF
--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
@@ -30,6 +30,21 @@ final class LocationRepository extends ServiceEntityRepository implements Locati
     public function delete(Location $location): void
     {
         $this->getEntityManager()->remove($location);
+
+        // NamedStreet etc hold a reference to the just-deleted Location object.
+        // Detach them to prevent Doctrine from re-creating the Location after the current command finishes.
+
+        if ($ns = $location->getNamedStreet()) {
+            $this->getEntityManager()->detach($ns);
+        }
+
+        if ($nr = $location->getNumberedRoad()) {
+            $this->getEntityManager()->detach($nr);
+        }
+
+        if ($rg = $location->getRawGeoJSON()) {
+            $this->getEntityManager()->detach($rg);
+        }
     }
 
     public function findOneByUuid(string $uuid): ?Location


### PR DESCRIPTION
* Closes #1285

J'ai sorti la solution un peu "boulet de canon" similaire à ce qu'on fait dans `CleanUpLitteralisRegulationsBeforeImportCommandHandler.php`

https://github.com/MTES-MCT/dialog/blob/fc32eabd50aefb57856c67d09a2641ce506fbe40/src/Application/Integration/Litteralis/Command/CleanUpLitteralisRegulationsBeforeImportCommandHandler.php#L28-L34


Mais c'est un peu frustrant car je ne comprend pas pourquoi il faut manuellement détacher les NamedStreet / NumberedRoad / RawGeoJSON. (J'ai bien vérifié que cette solution les supprimait en DB.) Dans le SaveMeasureCommandHandler, on exécute un locationRepository->delete($location), donc avec les CASCADE qui sont bien présentes au niveau des relations avec NamedStreet etc, ceux-ci devraient aussi être supprimés...

Mais bon, au moins ça résout le problème.