### PR TITLE
CI Litteralis : Corrige cas des mdp avec apostrophe

### DIFF
--- a/tools/ci_litteralis_init_org_env_vars.py
+++ b/tools/ci_litteralis_init_org_env_vars.py
@@ -31,7 +31,7 @@ def main(secrets_env: str, env_pattern: str) -> int:
 
     with open(".env.local", "a") as f:
         for name, value in org_secrets.items():
-            f.write(f"{name}={value}\n")
+            f.write(f'{name}="{value}"\n')
 
     return 0
 


### PR DESCRIPTION
La CI d'import Litteralis est KO depuis 3 semaines, lorsque j'ai ajouté les identifiants de la Corrèze dont le mdp contient une apostrophe `'`

https://github.com/MTES-MCT/dialog/actions/runs/14712996010

Le problème était l'absence de quotes dans les lignes ajoutées au .env.local, donc on avait une ligne type `APP_LITTERALIS_CORREZE_CREDENTIALS=...blabla'...` quidémarrait une string mais ne la terminait pas, d'où l'erreur

```
!!  PHP Fatal error:  Uncaught Symfony\Component\Dotenv\Exception\FormatException: Missing quote to end the value in "/home/runner/work/dialog/dialog/.env.local" at line 11.
!!  ...blabla'...\n...
!!           ^ line 11 offset 929 in /home/runner/work/dialog/dialog/vendor/symfony/dotenv/Dotenv.php:545
```