### PR TITLE
Recherche des troncon par road ban id insensible à la casse

### DIFF
--- a/src/Infrastructure/Adapter/BdTopoRoadGeocoder.php
+++ b/src/Infrastructure/Adapter/BdTopoRoadGeocoder.php
@@ -29,10 +29,11 @@ final class BdTopoRoadGeocoder implements RoadGeocoderInterface, IntersectionGeo
                 '
                     SELECT ST_AsGeoJSON(ST_Force2D(f_ST_NormalizeGeometryCollection(ST_Collect(geometrie)))) AS geometry
                     FROM troncon_de_route
-                    WHERE identifiant_voie_ban_gauche = :road_ban_id
+                    WHERE identifiant_voie_ban_gauche IN (:road_ban_id_lower, :road_ban_id_upper)
                 ',
                 [
-                    'road_ban_id' => $roadBanId,
+                    'road_ban_id_lower' => strtolower($roadBanId),
+                    'road_ban_id_upper' => strtoupper($roadBanId),
                 ],
             );
         } catch (\Exception $exc) {


### PR DESCRIPTION
Cette PR corrige la géolocalisation dans le cas ou la clé d'interopérabilité de la BDTOPO et de la BAN ne sont pas formatés de la même manière. 
Ce bug a été remontée par la commune de Moulay (53162) -> La Haye de Terre.