### PR TITLE
Corrige la validation API named street

### DIFF
--- a/src/Infrastructure/Mapper/Transformers/LocationsTransformer.php
+++ b/src/Infrastructure/Mapper/Transformers/LocationsTransformer.php
@@ -26,6 +26,7 @@ final class LocationsTransformer
 
             if ($dto->namedStreet) {
                 $ns = new SaveNamedStreetCommand();
+                $ns->roadType = $cmd->roadType;
                 $ns->cityCode = $dto->namedStreet->cityCode;
                 $ns->cityLabel = $dto->namedStreet->cityLabel;
                 $ns->roadName = $dto->namedStreet->roadName;
@@ -82,6 +83,7 @@ final class LocationsTransformer
 
             if ($dto->rawGeoJSON) {
                 $r = new SaveRawGeoJSONCommand();
+                $r->roadType = $cmd->roadType;
                 $r->label = $dto->rawGeoJSON->label;
                 $r->geometry = $dto->rawGeoJSON->geometry;
                 $cmd->rawGeoJSON = $r;


### PR DESCRIPTION
Problème remonté par Joel Gombin avec ce payload : 
```json
{
  "identifier": "TEST_20251112_095856",
  "category": "temporaryRegulation",
  "title": "Arrêté de test minimal",
  "measures": [
    {
      "type": "noEntry",
      "createdAt": "2025-11-12T09:58:56Z",
      "periods": [
        {
          "startDate": "2025-11-12T00:00:00Z",
          "startTime": "08:00",
          "endDate": "2025-11-19T23:59:59Z",
          "endTime": "18:00",
          "recurrenceType": "everyDay"
        }
      ],
      "locations": [
        {
          "roadType": "lane",
          "namedStreet": {
            "cityCode": "75104",
            "roadName": "Rue de Rivoli",
            "fromHouseNumber": "1",
            "toHouseNumber": "5",
            "direction:": "BOTH"
          }
        }
      ]
    }
  ]
}
```

Ici le champ city_label, censé est obligatoire, n'était pas présent et causait une erreur 500. Ce problème est lié au validateur qui était mal configuré 