### PR TITLE
Integration Montpellier Metropole

### DIFF
--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -42,7 +42,6 @@
                             {% endfor %}
                         </ul>
 
-
                         {% if not isReadOnly and isDraft %}
                             {% if measures|length > 0 %}
                                 {% include "regulation/fragments/_add_measure_link.html.twig" with { regulationOrderRecordUuid: generalInfo.uuid } only %}


### PR DESCRIPTION
Rapport d'intégration des données de Montpellier Métropole : 

**Source WFS** : 2 974 arrêtés (90% de 2025)
**Importables dans DiaLog: ~900 arrêtés (30%)** 
- 650 interdictions de stationnement
- 100 circulations interdites
- 130 limitations de vitesse

**Non importables : ~2 000 (70%)**
- 665 : Autorisations de travaux sur réseaux (télécom, eau, gaz, voirie...)
- 180 : Signalisation permanente (carrefours, stops, feux)
- 1 200 : Mesures non supportées (déviation, alternée, neutralisation, etc.)