### PR TITLE
Corrige la récupération d'une localisation s'il n'y a pas de périodes

### DIFF
--- a/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/Regulation/LocationRepository.php
@@ -52,7 +52,7 @@ final class LocationRepository extends ServiceEntityRepository implements Locati
         return $this->createQueryBuilder('l')
             ->addSelect('m', 'v', 'p', 'd', 't', 'sa')
             ->innerJoin('l.measure', 'm')
-            ->innerjoin('m.periods', 'p')
+            ->leftJoin('m.periods', 'p')
             ->leftJoin('m.vehicleSet', 'v')
             ->leftJoin('p.dailyRange', 'd')
             ->leftJoin('p.timeSlots', 't')


### PR DESCRIPTION
Problème remonté par Modelity lorsqu'il n'y a pas de périodes