### PR TITLE
chore(dev): remove pg-admin and update posgtres volume for docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,5 @@
 volumes:
   database: {}
-  pgadmin-data: {}
 
 services:
   database:
@@ -12,7 +11,7 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - 'database:/var/lib/postgresql@14/data:rw'
+      - 'database:/var/lib/postgresql/data:rw'
 
   php:
     build:
@@ -49,20 +48,6 @@ services:
       - ./paas/server.locations:/etc/nginx/server.locations
     depends_on:
       - php
-      - database
-
-  pgadmin:
-    image: dpage/pgadmin4
-    container_name: pgadmin4
-    restart: always
-    ports:
-      - '5050:80'
-    environment:
-      PGADMIN_DEFAULT_EMAIL: equipe@beta.gouv.fr
-      PGADMIN_DEFAULT_PASSWORD: equipe
-    volumes:
-      - pgadmin-data:/var/lib/pgadmin
-    depends_on:
       - database
 
   redis:


### PR DESCRIPTION
Attention, mise à jour de l'emplacement du volume Docker.
Le chemin décrit pour l'intérieur du container Postgres `/var/lib/postgresql@14/data` n'était pas le bon. À chaque effacement du container, les données du volume étaient perdues.