### PR TITLE
Import Litteralis : continuer en cas d'erreur applicative

### DIFF
--- a/src/Infrastructure/Integration/Litteralis/LitteralisExecutor.php
+++ b/src/Infrastructure/Integration/Litteralis/LitteralisExecutor.php
@@ -80,9 +80,7 @@ final class LitteralisExecutor
                     ]);
                     $reporter->acknowledgeNewErrors();
 
-                    // Erreur de validation : on signale et on passe à l'arrêté suivant (pas de rollback).
-                    // Erreur technique : on relance pour provoquer le rollback et arrêter l'import.
-                    if (!$exc instanceof ValidationFailedException) {
+                    if (!$this->isRecoverableException($exc)) {
                         throw $exc;
                     }
                 }
@@ -106,5 +104,11 @@ final class LitteralisExecutor
         $reporter->onReport($report);
 
         return $report;
+    }
+
+    private function isRecoverableException(\Throwable $e): bool
+    {
+        return $e instanceof ValidationFailedException
+            || str_starts_with($e::class, 'App\\');
     }
 }


### PR DESCRIPTION
Les exceptions applicatives (géocodage, périmètre d'intervention, validation…) levées lors de l'import d'un arrêté Litteralis sont désormais traitées comme des erreurs récupérables : elles sont signalées dans le rapport et l'import continue avec les arrêtés suivants au lieu de provoquer un rollback complet de l'organisation.
