### PR TITLE
fix(datex): increase availability for datex

### DIFF
--- a/src/Infrastructure/Adapter/DatexGenerator.php
+++ b/src/Infrastructure/Adapter/DatexGenerator.php
@@ -8,21 +8,18 @@ use App\Application\DateUtilsInterface;
 use App\Application\QueryBusInterface;
 use App\Application\Regulation\DatexGeneratorInterface;
 use App\Application\Regulation\Query\GetRegulationOrdersToDatexFormatQuery;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Filesystem\Path;
+use League\Flysystem\FilesystemOperator;
 
 final class DatexGenerator implements DatexGeneratorInterface
 {
-    private string $datexFilePath;
+    private const DATEX_PATH = 'datex/regulations.xml';
 
     public function __construct(
         private \Twig\Environment $twig,
         private DateUtilsInterface $dateUtils,
         private QueryBusInterface $queryBus,
-        private Filesystem $filesystem,
-        string $projectDir,
+        private FilesystemOperator $storage,
     ) {
-        $this->datexFilePath = Path::join($projectDir, '/var/datex/regulations.xml');
     }
 
     public function generate(): void
@@ -31,13 +28,7 @@ final class DatexGenerator implements DatexGeneratorInterface
             new GetRegulationOrdersToDatexFormatQuery(),
         );
 
-        $dir = Path::getDirectory($this->datexFilePath);
-
-        if (!$this->filesystem->exists($dir)) {
-            $this->filesystem->mkdir($dir, 0o755);
-        }
-
-        $tmpFile = $this->datexFilePath . '.tmp';
+        $tmpFile = tempnam(sys_get_temp_dir(), 'datex');
         $handle = fopen($tmpFile, 'w');
 
         ob_start(function (string $buffer) use ($handle): string {
@@ -53,15 +44,23 @@ final class DatexGenerator implements DatexGeneratorInterface
 
         ob_end_flush();
         fclose($handle);
-        $this->filesystem->rename($tmpFile, $this->datexFilePath, overwrite: true);
+
+        $readStream = fopen($tmpFile, 'r');
+        $this->storage->writeStream(self::DATEX_PATH, $readStream);
+
+        if (\is_resource($readStream)) {
+            fclose($readStream);
+        }
+
+        unlink($tmpFile);
     }
 
     public function getCachedDatex(): string
     {
-        if (!$this->filesystem->exists($this->datexFilePath)) {
+        if (!$this->storage->fileExists(self::DATEX_PATH)) {
             $this->generate();
         }
 
-        return $this->filesystem->readFile($this->datexFilePath);
+        return $this->storage->read(self::DATEX_PATH);
     }
 }

--- a/tests/Unit/Infrastructure/Adapter/DatexGeneratorTest.php
+++ b/tests/Unit/Infrastructure/Adapter/DatexGeneratorTest.php
@@ -8,16 +8,17 @@ use App\Application\DateUtilsInterface;
 use App\Application\QueryBusInterface;
 use App\Application\Regulation\Query\GetRegulationOrdersToDatexFormatQuery;
 use App\Infrastructure\Adapter\DatexGenerator;
+use League\Flysystem\Filesystem;
+use League\Flysystem\InMemory\InMemoryFilesystemAdapter;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Filesystem\Filesystem;
 
 final class DatexGeneratorTest extends TestCase
 {
     private \Twig\Environment&MockObject $twig;
     private DateUtilsInterface&MockObject $dateUtils;
     private QueryBusInterface&MockObject $queryBus;
-    private string $tmpDir;
+    private Filesystem $storage;
 
     protected function setUp(): void
     {
@@ -25,29 +26,10 @@ final class DatexGeneratorTest extends TestCase
         $this->dateUtils = $this->createMock(DateUtilsInterface::class);
         $this->queryBus = $this->createMock(QueryBusInterface::class);
 
-        $this->tmpDir = sys_get_temp_dir() . '/datex_generator_test_' . uniqid();
+        $this->storage = new Filesystem(new InMemoryFilesystemAdapter());
     }
 
-    protected function tearDown(): void
-    {
-        $filePath = $this->tmpDir . '/var/datex/regulations.xml';
-        $tmpFile = $filePath . '.tmp';
-
-        if (file_exists($tmpFile)) {
-            unlink($tmpFile);
-        }
-
-        if (file_exists($filePath)) {
-            unlink($filePath);
-        }
-
-        // Remove directories created during tests
-        @rmdir($this->tmpDir . '/var/datex');
-        @rmdir($this->tmpDir . '/var');
-        @rmdir($this->tmpDir);
-    }
-
-    public function testGenerateCreatesDirectoryAndFile(): void
+    public function testGenerateCreatesFile(): void
     {
         $now = new \DateTimeImmutable('2025-01-01');
         $regulationOrders = ['order1', 'order2'];
@@ -78,26 +60,20 @@ final class DatexGeneratorTest extends TestCase
             $this->twig,
             $this->dateUtils,
             $this->queryBus,
-            new Filesystem(),
-            $this->tmpDir,
+            $this->storage,
         );
 
-        $filePath = $this->tmpDir . '/var/datex/regulations.xml';
-
-        $this->assertDirectoryDoesNotExist(\dirname($filePath));
+        $this->assertFalse($this->storage->fileExists('datex/regulations.xml'));
 
         $generator->generate();
 
-        $this->assertDirectoryExists(\dirname($filePath));
-        $this->assertFileExists($filePath);
-        $this->assertSame('<xml>generated content</xml>', file_get_contents($filePath));
+        $this->assertTrue($this->storage->fileExists('datex/regulations.xml'));
+        $this->assertSame('<xml>generated content</xml>', $this->storage->read('datex/regulations.xml'));
     }
 
     public function testGenerateOverwritesExistingFile(): void
     {
-        $dir = $this->tmpDir . '/var/datex';
-        mkdir($dir, 0o755, true);
-        file_put_contents($dir . '/regulations.xml', '<xml>old content</xml>');
+        $this->storage->write('datex/regulations.xml', '<xml>old content</xml>');
 
         $now = new \DateTimeImmutable('2025-06-15');
 
@@ -122,15 +98,11 @@ final class DatexGeneratorTest extends TestCase
             $this->twig,
             $this->dateUtils,
             $this->queryBus,
-            new Filesystem(),
-            $this->tmpDir,
+            $this->storage,
         );
 
         $generator->generate();
 
-        $filePath = $this->tmpDir . '/var/datex/regulations.xml';
-        $this->assertSame('<xml>new content</xml>', file_get_contents($filePath));
-        // Ensure tmp file is cleaned up (renamed, not left behind)
-        $this->assertFileDoesNotExist($filePath . '.tmp');
+        $this->assertSame('<xml>new content</xml>', $this->storage->read('datex/regulations.xml'));
     }
 }


### PR DESCRIPTION
Au lieu de stocker le fichier Datex dans le cache du container, il est envoyé au S3 pour être disponible et mis à jour par tous les containers (prod, github Actions, ci..).

En attente de l'access_key pour l'accès au S3. A modifier dans les variables d'environnements