### PR TITLE
chore(admin): Improve user admin administration for tests env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,3 +372,5 @@ scalingo-node-postbuild: ## Scalingo postbuild hook for the Node buildpack
 scalingo-postdeploy: ## Scalingo postdeploy hook
 	@echo 'Executing migrations...'
 	php bin/console doctrine:migrations:migrate --no-interaction
+	@echo 'Syncing team admins...'
+	php bin/console app:team:sync-admins

--- a/config/team_admins.yaml
+++ b/config/team_admins.yaml
@@ -1,0 +1,56 @@
+# Liste des administrateurs internes de l'équipe DiaLog.
+#
+# Cette liste est la SOURCE DE VÉRITÉ pour les comptes ayant le rôle
+# ROLE_SUPER_ADMIN. La commande `app:team:sync-admins` synchronise cet état
+# avec la base de données à chaque déploiement (voir `make scalingo-postdeploy`).
+#
+# Les utilisateurs sont rattachés à l'organisation interne dont l'UUID est
+# défini par la variable d'environnement DIALOG_ORG_ID.
+#
+# ATTENTION : synchro stricte.
+# Tout utilisateur en base ayant ROLE_SUPER_ADMIN et absent de cette liste
+# sera SUPPRIMÉ au prochain déploiement. Si vous promouvez manuellement un
+# utilisateur en super admin, reportez-le ici.
+#
+# Champs :
+#   - email        : identifiant (unique, normalisé).
+#   - full_name    : nom complet affiché.
+#   - password_hash: (optionnel) hash bcrypt utilisé uniquement à la création
+#                    initiale de l'utilisateur. Jamais réécrit sur un compte
+#                    existant (laissez l'utilisateur gérer son mot de passe
+#                    via l'UI / la réinitialisation par email).
+#                    Pour générer un hash :
+#                      bin/console security:hash-password <password>
+
+admins:
+    - email: mathieu.marchois@beta.gouv.fr
+      full_name: "Mathieu MARCHOIS"
+      password_hash: "$2y$13$X8iaV02QuXVNAt5Pg0a75u1OoBMMef2uM2crA8UfnEYWDeviuXcwm"
+
+    - email: mathieu.fernandez@beta.gouv.fr
+      full_name: "Mathieu FERNANDEZ"
+      password_hash: "$2y$13$M/N2m6aHgQro.vQ6YyWBGOehqgZfgAlG3ZhbIfMjhlC4Nt3lLbniq"
+
+    - email: aurelie.baton@beta.gouv.fr
+      full_name: "Aurélie BATON"
+      password_hash: "$2y$13$K2XPGVl7g3D9aQktAGF4Hec/1EBt2KUHei7ABBFlWee7vnocAniGK"
+
+    - email: stephane.schultz@beta.gouv.fr
+      full_name: "Stéphane SCHULTZ"
+      password_hash: "$2y$13$5YAXUBt0RMmW1sN0rHkIMeEVVwlR1TzXxQ72Wtm/FkGOB54QjYSWm"
+
+    - email: eglantine.schmitt@developpement-durable.gouv.fr
+      full_name: "Eglantine SCHMITT"
+      password_hash: "$2y$13$Twuwt3JpdJhndtonOJyohuFq0ikYwo.iXcqBK9zM/rsTmQKLYtC2y"
+
+    - email: heloise.georgeault@developpement-durable.gouv.fr
+      full_name: "Heloise GEORGEAULT"
+      password_hash: "$2y$13$33BqPzmVm3/Q0GNPtN132e3GIgI7wqEadk5alN87t4jdGPMmE5b2."
+
+    - email: antoine.smagghe.ext@beta.gouv.fr
+      full_name: "Antoine SMAGGHE"
+      password_hash: "$2y$13$YDP63pb4dq51RnaFH7XcXeU1URJosZALl/fErMLafUio7y3ZBkluO"
+
+    - email: julien.zamor.ext@beta.gouv.fr
+      full_name: "Julien ZAMOR"
+      password_hash: "$2y$12$ExzyAkzA1KHtHmFdycsm2uaTWcwHmT45wG38pKUIYowkzs5PVoibG"

--- a/src/Domain/User/Repository/UserRepositoryInterface.php
+++ b/src/Domain/User/Repository/UserRepositoryInterface.php
@@ -21,4 +21,11 @@ interface UserRepositoryInterface
     public function findAllForExport(): array;
 
     public function findAll(): array;
+
+    /**
+     * Retourne tous les utilisateurs possédant le rôle donné (présent dans le tableau `roles`).
+     *
+     * @return User[]
+     */
+    public function findAllByRole(string $role): array;
 }

--- a/src/Infrastructure/Persistence/Doctrine/Repository/User/UserRepository.php
+++ b/src/Infrastructure/Persistence/Doctrine/Repository/User/UserRepository.php
@@ -96,4 +96,13 @@ final class UserRepository extends ServiceEntityRepository implements UserReposi
             ->getQuery()
             ->getResult();
     }
+
+    public function findAllByRole(string $role): array
+    {
+        return $this->createQueryBuilder('u')
+            ->where('u.roles LIKE :roleNeedle')
+            ->setParameter('roleNeedle', '%"' . $role . '"%')
+            ->getQuery()
+            ->getResult();
+    }
 }

--- a/src/Infrastructure/Symfony/Command/SyncTeamAdminsCommand.php
+++ b/src/Infrastructure/Symfony/Command/SyncTeamAdminsCommand.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Symfony\Command;
+
+use App\Application\DateUtilsInterface;
+use App\Application\IdFactoryInterface;
+use App\Application\StringUtilsInterface;
+use App\Domain\User\Enum\UserRolesEnum;
+use App\Domain\User\Organization;
+use App\Domain\User\OrganizationUser;
+use App\Domain\User\PasswordUser;
+use App\Domain\User\Repository\OrganizationRepositoryInterface;
+use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
+use App\Domain\User\Repository\PasswordUserRepositoryInterface;
+use App\Domain\User\Repository\UserRepositoryInterface;
+use App\Domain\User\User;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Yaml\Yaml;
+
+#[AsCommand(
+    name: 'app:team:sync-admins',
+    description: 'Synchronise les administrateurs internes de l\'équipe (config/team_admins.yaml) avec la base.',
+    hidden: false,
+)]
+final class SyncTeamAdminsCommand extends Command
+{
+    private const CONFIG_RELATIVE_PATH = 'config/team_admins.yaml';
+
+    public function __construct(
+        private UserRepositoryInterface $userRepository,
+        private PasswordUserRepositoryInterface $passwordUserRepository,
+        private OrganizationUserRepositoryInterface $organizationUserRepository,
+        private OrganizationRepositoryInterface $organizationRepository,
+        private IdFactoryInterface $idFactory,
+        private DateUtilsInterface $dateUtils,
+        private StringUtilsInterface $stringUtils,
+        private EntityManagerInterface $entityManager,
+        private string $projectDir,
+        private string $dialogOrgId,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addOption(
+            'dry-run',
+            null,
+            InputOption::VALUE_NONE,
+            'N\'applique rien, affiche uniquement le diff qui serait appliqué.',
+        );
+        $this->addOption(
+            'config',
+            null,
+            InputOption::VALUE_REQUIRED,
+            'Chemin vers un fichier YAML alternatif (défaut : config/team_admins.yaml).',
+        );
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        $configOption = $input->getOption('config');
+        $configPath = \is_string($configOption) && '' !== $configOption
+            ? $configOption
+            : $this->projectDir . '/' . self::CONFIG_RELATIVE_PATH;
+        if (!is_file($configPath)) {
+            $output->writeln(\sprintf('<error>Fichier de configuration introuvable : %s</error>', $configPath));
+
+            return Command::FAILURE;
+        }
+
+        /** @var array{admins?: array<int, array<string, string>>} $config */
+        $config = Yaml::parseFile($configPath);
+
+        $admins = $config['admins'] ?? [];
+
+        $organization = $this->organizationRepository->findOneByUuid($this->dialogOrgId);
+        if (null === $organization) {
+            $output->writeln(\sprintf('<error>Organisation équipe introuvable en base : %s</error>', $this->dialogOrgId));
+
+            return Command::FAILURE;
+        }
+
+        $desiredByEmail = [];
+        foreach ($admins as $index => $admin) {
+            if (!isset($admin['email'], $admin['full_name'])) {
+                $output->writeln(\sprintf('<error>Entrée #%d invalide : `email` et `full_name` sont requis.</error>', $index));
+
+                return Command::FAILURE;
+            }
+            $email = $this->stringUtils->normalizeEmail($admin['email']);
+            if (isset($desiredByEmail[$email])) {
+                $output->writeln(\sprintf('<error>Email dupliqué dans la config : %s</error>', $email));
+
+                return Command::FAILURE;
+            }
+            $desiredByEmail[$email] = [
+                'email' => $email,
+                'full_name' => $admin['full_name'],
+                'password_hash' => $admin['password_hash'] ?? null,
+            ];
+        }
+
+        $existingSuperAdmins = $this->userRepository->findAllByRole(UserRolesEnum::ROLE_SUPER_ADMIN->value);
+        $existingByEmail = [];
+        foreach ($existingSuperAdmins as $user) {
+            $existingByEmail[$this->stringUtils->normalizeEmail($user->getEmail())] = $user;
+        }
+
+        $created = $updated = $deleted = $skipped = 0;
+
+        foreach ($desiredByEmail as $email => $desired) {
+            if (isset($existingByEmail[$email])) {
+                $user = $existingByEmail[$email];
+                $changed = $this->updateExistingUser($user, $desired, $organization, $output, $dryRun);
+                if ($changed) {
+                    ++$updated;
+                }
+                continue;
+            }
+
+            $existing = $this->userRepository->findOneByEmail($email);
+            if ($existing instanceof User) {
+                $output->writeln(\sprintf('<info>[promote]</info> %s : ajout de ROLE_SUPER_ADMIN', $email));
+                if (!$dryRun) {
+                    $roles = $existing->getRoles();
+                    if (!\in_array(UserRolesEnum::ROLE_SUPER_ADMIN->value, $roles, true)) {
+                        $roles[] = UserRolesEnum::ROLE_SUPER_ADMIN->value;
+                        $existing->setRoles($roles);
+                    }
+                    $existing->setFullName($desired['full_name']);
+                    $existing->setIsVerified();
+                    $this->ensureOrganizationLink($existing, $organization, $dryRun);
+                }
+                ++$updated;
+                continue;
+            }
+
+            if (null === $desired['password_hash']) {
+                $output->writeln(\sprintf(
+                    '<comment>[skip]</comment> %s : utilisateur inexistant et aucun `password_hash` fourni (ignoré).',
+                    $email,
+                ));
+                ++$skipped;
+                continue;
+            }
+
+            $output->writeln(\sprintf('<info>[create]</info> %s (%s)', $email, $desired['full_name']));
+            if (!$dryRun) {
+                $user = (new User($this->idFactory->make()))
+                    ->setFullName($desired['full_name'])
+                    ->setEmail($email)
+                    ->setRoles([UserRolesEnum::ROLE_SUPER_ADMIN->value])
+                    ->setRegistrationDate($this->dateUtils->getNow())
+                    ->setIsVerified();
+
+                $passwordUser = new PasswordUser(
+                    uuid: $this->idFactory->make(),
+                    password: $desired['password_hash'],
+                    user: $user,
+                );
+                $user->setPasswordUser($passwordUser);
+
+                $this->userRepository->add($user);
+                $this->passwordUserRepository->add($passwordUser);
+
+                $organizationUser = (new OrganizationUser($this->idFactory->make()))
+                    ->setUser($user)
+                    ->setOrganization($organization)
+                    ->setIsOwner(true);
+                $this->organizationUserRepository->add($organizationUser);
+            }
+            ++$created;
+        }
+
+        foreach ($existingByEmail as $email => $user) {
+            if (isset($desiredByEmail[$email])) {
+                continue;
+            }
+            $output->writeln(\sprintf('<comment>[delete]</comment> %s (%s)', $email, $user->getFullName()));
+            if (!$dryRun) {
+                $this->userRepository->remove($user);
+            }
+            ++$deleted;
+        }
+
+        if (!$dryRun) {
+            $this->entityManager->flush();
+        }
+
+        $output->writeln(\sprintf(
+            '<info>Terminé%s — créés: %d, mis à jour: %d, supprimés: %d, ignorés: %d.</info>',
+            $dryRun ? ' (dry-run)' : '',
+            $created,
+            $updated,
+            $deleted,
+            $skipped,
+        ));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param array{email: string, full_name: string, password_hash: ?string} $desired
+     */
+    private function updateExistingUser(
+        User $user,
+        array $desired,
+        Organization $organization,
+        OutputInterface $output,
+        bool $dryRun,
+    ): bool {
+        $changes = [];
+
+        if ($user->getFullName() !== $desired['full_name']) {
+            $changes[] = \sprintf('full_name "%s" → "%s"', $user->getFullName(), $desired['full_name']);
+            if (!$dryRun) {
+                $user->setFullName($desired['full_name']);
+            }
+        }
+
+        if (!$user->isVerified()) {
+            $changes[] = 'is_verified → true';
+            if (!$dryRun) {
+                $user->setIsVerified();
+            }
+        }
+
+        $roles = $user->getRoles();
+        if (!\in_array(UserRolesEnum::ROLE_SUPER_ADMIN->value, $roles, true)) {
+            $roles[] = UserRolesEnum::ROLE_SUPER_ADMIN->value;
+            $changes[] = 'roles += ROLE_SUPER_ADMIN';
+            if (!$dryRun) {
+                $user->setRoles($roles);
+            }
+        }
+
+        $linkCreated = $this->ensureOrganizationLink($user, $organization, $dryRun);
+        if ($linkCreated) {
+            $changes[] = 'link to team organization';
+        }
+
+        if ([] === $changes) {
+            return false;
+        }
+
+        $output->writeln(\sprintf('<info>[update]</info> %s : %s', $user->getEmail(), implode(', ', $changes)));
+
+        return true;
+    }
+
+    private function ensureOrganizationLink(
+        User $user,
+        Organization $organization,
+        bool $dryRun,
+    ): bool {
+        $existing = $this->organizationUserRepository->findOrganizationUser(
+            $organization->getUuid(),
+            $user->getUuid(),
+        );
+        if (null !== $existing) {
+            return false;
+        }
+        if (!$dryRun) {
+            $organizationUser = (new OrganizationUser($this->idFactory->make()))
+                ->setUser($user)
+                ->setOrganization($organization)
+                ->setIsOwner(true);
+            $this->organizationUserRepository->add($organizationUser);
+        }
+
+        return true;
+    }
+}

--- a/tests/Integration/Infrastructure/Symfony/Command/SyncTeamAdminsCommandTest.php
+++ b/tests/Integration/Infrastructure/Symfony/Command/SyncTeamAdminsCommandTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Infrastructure\Symfony\Command;
+
+use App\Domain\User\Enum\UserRolesEnum;
+use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
+use App\Domain\User\Repository\UserRepositoryInterface;
+use App\Infrastructure\Persistence\Doctrine\Fixtures\OrganizationFixture;
+use App\Infrastructure\Persistence\Doctrine\Fixtures\UserFixture;
+use App\Infrastructure\Symfony\Command\SyncTeamAdminsCommand;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Yaml\Yaml;
+
+final class SyncTeamAdminsCommandTest extends KernelTestCase
+{
+    private string $tmpConfigPath;
+
+    protected function setUp(): void
+    {
+        $this->tmpConfigPath = tempnam(sys_get_temp_dir(), 'team_admins_') . '.yaml';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->tmpConfigPath)) {
+            unlink($this->tmpConfigPath);
+        }
+    }
+
+    private function writeConfig(array $admins): void
+    {
+        file_put_contents($this->tmpConfigPath, Yaml::dump([
+            'admins' => $admins,
+        ]));
+    }
+
+    private function runCommand(array $options = []): CommandTester
+    {
+        $container = static::getContainer();
+        $command = $container->get(SyncTeamAdminsCommand::class);
+        $tester = new CommandTester($command);
+        $tester->execute(array_merge(['--config' => $this->tmpConfigPath], $options));
+
+        return $tester;
+    }
+
+    public function testPromoteAndLinkExistingUser(): void
+    {
+        self::bootKernel();
+        $this->writeConfig([
+            [
+                'email' => UserFixture::DEPARTMENT_93_ADMIN_EMAIL,
+                'full_name' => 'Mathieu FERNANDEZ',
+            ],
+        ]);
+
+        $tester = $this->runCommand();
+        $tester->assertCommandIsSuccessful();
+
+        $container = static::getContainer();
+        $userRepo = $container->get(UserRepositoryInterface::class);
+        $orgUserRepo = $container->get(OrganizationUserRepositoryInterface::class);
+
+        $user = $userRepo->findOneByEmail(UserFixture::DEPARTMENT_93_ADMIN_EMAIL);
+        $this->assertNotNull($user);
+        $this->assertContains(UserRolesEnum::ROLE_SUPER_ADMIN->value, $user->getRoles());
+        $this->assertNotNull(
+            $orgUserRepo->findOrganizationUser(OrganizationFixture::DIALOG_ORG_ID, $user->getUuid()),
+            'L\'utilisateur doit être rattaché à l\'organisation équipe.',
+        );
+    }
+
+    public function testCreateMissingAdminWithPasswordHash(): void
+    {
+        self::bootKernel();
+        $email = 'new.team.member@beta.gouv.fr';
+        $this->writeConfig([
+            [
+                'email' => UserFixture::DEPARTMENT_93_ADMIN_EMAIL,
+                'full_name' => 'Mathieu FERNANDEZ',
+            ],
+            [
+                'email' => $email,
+                'full_name' => 'New MEMBER',
+                'password_hash' => '$2y$13$FGzLfRBW0sGZqn/eh3hlBO/nQI4XZKzrzI1svPbCYUKWlRrQELCPm',
+            ],
+        ]);
+
+        $tester = $this->runCommand();
+        $tester->assertCommandIsSuccessful();
+
+        $userRepo = static::getContainer()->get(UserRepositoryInterface::class);
+        $created = $userRepo->findOneByEmail($email);
+        $this->assertNotNull($created);
+        $this->assertSame('New MEMBER', $created->getFullName());
+        $this->assertTrue($created->isVerified());
+        $this->assertContains(UserRolesEnum::ROLE_SUPER_ADMIN->value, $created->getRoles());
+        $this->assertNotNull($created->getPasswordUser());
+    }
+
+    public function testSkipCreationWhenPasswordHashMissing(): void
+    {
+        self::bootKernel();
+        $email = 'ghost.member@beta.gouv.fr';
+        $this->writeConfig([
+            [
+                'email' => UserFixture::DEPARTMENT_93_ADMIN_EMAIL,
+                'full_name' => 'Mathieu FERNANDEZ',
+            ],
+            [
+                'email' => $email,
+                'full_name' => 'Ghost MEMBER',
+            ],
+        ]);
+
+        $tester = $this->runCommand();
+        $tester->assertCommandIsSuccessful();
+
+        $userRepo = static::getContainer()->get(UserRepositoryInterface::class);
+        $this->assertNull($userRepo->findOneByEmail($email));
+        $this->assertStringContainsString('[skip]', $tester->getDisplay());
+    }
+
+    public function testStrictSyncDeletesAdminsAbsentFromConfig(): void
+    {
+        self::bootKernel();
+        $this->writeConfig([]);
+
+        $tester = $this->runCommand();
+        $tester->assertCommandIsSuccessful();
+
+        $userRepo = static::getContainer()->get(UserRepositoryInterface::class);
+        $this->assertNull(
+            $userRepo->findOneByEmail(UserFixture::DEPARTMENT_93_ADMIN_EMAIL),
+            'Un super-admin absent du YAML doit être supprimé.',
+        );
+    }
+
+    public function testDryRunDoesNotWriteAnything(): void
+    {
+        self::bootKernel();
+        $this->writeConfig([]);
+
+        $tester = $this->runCommand(['--dry-run' => true]);
+        $tester->assertCommandIsSuccessful();
+
+        $userRepo = static::getContainer()->get(UserRepositoryInterface::class);
+        $this->assertNotNull(
+            $userRepo->findOneByEmail(UserFixture::DEPARTMENT_93_ADMIN_EMAIL),
+            'En dry-run, aucune suppression ne doit être effectuée.',
+        );
+        $this->assertStringContainsString('dry-run', $tester->getDisplay());
+    }
+
+    public function testFailsWhenConfigMissing(): void
+    {
+        self::bootKernel();
+        $container = static::getContainer();
+        $command = $container->get(SyncTeamAdminsCommand::class);
+        $tester = new CommandTester($command);
+        $tester->execute(['--config' => '/nonexistent/path.yaml']);
+
+        $this->assertSame(1, $tester->getStatusCode());
+    }
+
+    public function testUpdateUserWithoutOrganizationLink(): void
+    {
+        self::bootKernel();
+        $this->writeConfig([
+            [
+                'email' => UserFixture::DEPARTMENT_93_ADMIN_EMAIL,
+                'full_name' => 'Updated ADMIN',
+            ],
+        ]);
+
+        $container = static::getContainer();
+        $orgUserRepo = $container->get(OrganizationUserRepositoryInterface::class);
+        $userRepo = $container->get(UserRepositoryInterface::class);
+
+        $user = $userRepo->findOneByEmail(UserFixture::DEPARTMENT_93_ADMIN_EMAIL);
+        $this->assertNotNull($user);
+
+        $existingLink = $orgUserRepo->findOrganizationUser(OrganizationFixture::DIALOG_ORG_ID, $user->getUuid());
+        if ($existingLink !== null) {
+            $orgUserRepo->remove($existingLink);
+            static::getContainer()->get('doctrine.orm.default_entity_manager')->flush();
+        }
+
+        $tester = $this->runCommand();
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertNotNull(
+            $orgUserRepo->findOrganizationUser(OrganizationFixture::DIALOG_ORG_ID, $user->getUuid()),
+            'L\'utilisateur doit être rattaché à l\'organisation équipe après mise à jour.',
+        );
+        $this->assertStringContainsString('link to team organization', $tester->getDisplay());
+    }
+}

--- a/tests/Unit/Infrastructure/Symfony/Command/SyncTeamAdminsCommandTest.php
+++ b/tests/Unit/Infrastructure/Symfony/Command/SyncTeamAdminsCommandTest.php
@@ -1,0 +1,594 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Infrastructure\Symfony\Command;
+
+use App\Application\DateUtilsInterface;
+use App\Application\IdFactoryInterface;
+use App\Application\StringUtilsInterface;
+use App\Domain\User\Enum\UserRolesEnum;
+use App\Domain\User\Organization;
+use App\Domain\User\OrganizationUser;
+use App\Domain\User\Repository\OrganizationRepositoryInterface;
+use App\Domain\User\Repository\OrganizationUserRepositoryInterface;
+use App\Domain\User\Repository\PasswordUserRepositoryInterface;
+use App\Domain\User\Repository\UserRepositoryInterface;
+use App\Domain\User\User;
+use App\Infrastructure\Symfony\Command\SyncTeamAdminsCommand;
+use Doctrine\ORM\EntityManagerInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Yaml\Yaml;
+
+final class SyncTeamAdminsCommandTest extends TestCase
+{
+    private const ORG_UUID = 'e0d93630-acf7-4722-81e8-ff7d5fa64b66';
+
+    private MockObject&UserRepositoryInterface $userRepository;
+    private MockObject&PasswordUserRepositoryInterface $passwordUserRepository;
+    private MockObject&OrganizationUserRepositoryInterface $organizationUserRepository;
+    private MockObject&OrganizationRepositoryInterface $organizationRepository;
+    private MockObject&IdFactoryInterface $idFactory;
+    private MockObject&DateUtilsInterface $dateUtils;
+    private MockObject&StringUtilsInterface $stringUtils;
+    private MockObject&EntityManagerInterface $entityManager;
+
+    private string $projectDir;
+    private string $configPath;
+
+    protected function setUp(): void
+    {
+        $this->userRepository = $this->createMock(UserRepositoryInterface::class);
+        $this->passwordUserRepository = $this->createMock(PasswordUserRepositoryInterface::class);
+        $this->organizationUserRepository = $this->createMock(OrganizationUserRepositoryInterface::class);
+        $this->organizationRepository = $this->createMock(OrganizationRepositoryInterface::class);
+        $this->idFactory = $this->createMock(IdFactoryInterface::class);
+        $this->dateUtils = $this->createMock(DateUtilsInterface::class);
+        $this->stringUtils = $this->createMock(StringUtilsInterface::class);
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+
+        $this->stringUtils->method('normalizeEmail')->willReturnCallback(
+            static fn (string $email): string => strtolower(trim($email)),
+        );
+
+        $this->projectDir = sys_get_temp_dir() . '/dialog-team-admins-' . uniqid();
+        mkdir($this->projectDir . '/config', 0o777, true);
+        $this->configPath = $this->projectDir . '/config/team_admins.yaml';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_file($this->configPath)) {
+            unlink($this->configPath);
+        }
+        if (is_dir($this->projectDir . '/config')) {
+            rmdir($this->projectDir . '/config');
+        }
+        if (is_dir($this->projectDir)) {
+            rmdir($this->projectDir);
+        }
+    }
+
+    private function writeConfig(?array $admins): void
+    {
+        $payload = [];
+        if (null !== $admins) {
+            $payload['admins'] = $admins;
+        }
+        file_put_contents($this->configPath, Yaml::dump($payload));
+    }
+
+    private function createCommand(string $dialogOrgId = self::ORG_UUID): SyncTeamAdminsCommand
+    {
+        return new SyncTeamAdminsCommand(
+            $this->userRepository,
+            $this->passwordUserRepository,
+            $this->organizationUserRepository,
+            $this->organizationRepository,
+            $this->idFactory,
+            $this->dateUtils,
+            $this->stringUtils,
+            $this->entityManager,
+            $this->projectDir,
+            $dialogOrgId,
+        );
+    }
+
+    public function testHasExpectedName(): void
+    {
+        $this->assertSame('app:team:sync-admins', $this->createCommand()->getName());
+    }
+
+    public function testFailsWhenConfigFileMissing(): void
+    {
+        $this->organizationRepository->expects(self::never())->method('findOneByUuid');
+        $this->entityManager->expects(self::never())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $statusCode = $tester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $statusCode);
+        $this->assertStringContainsString('Fichier de configuration introuvable', $tester->getDisplay());
+    }
+
+    public function testFailsWhenOrganizationNotFoundInDatabase(): void
+    {
+        $this->writeConfig([]);
+        $this->organizationRepository
+            ->expects(self::once())
+            ->method('findOneByUuid')
+            ->with(self::ORG_UUID)
+            ->willReturn(null);
+        $this->entityManager->expects(self::never())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $statusCode = $tester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $statusCode);
+        $this->assertStringContainsString('Organisation équipe introuvable', $tester->getDisplay());
+    }
+
+    public function testFailsWhenAdminEntryIsInvalid(): void
+    {
+        $this->writeConfig([['email' => 'no-name@beta.gouv.fr']]);
+        $this->organizationRepository->method('findOneByUuid')->willReturn($this->makeOrganization());
+        $this->entityManager->expects(self::never())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $statusCode = $tester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $statusCode);
+        $this->assertStringContainsString('`email` et `full_name` sont requis', $tester->getDisplay());
+    }
+
+    public function testFailsOnDuplicateEmail(): void
+    {
+        $this->writeConfig([
+            ['email' => 'dup@beta.gouv.fr', 'full_name' => 'A'],
+            ['email' => 'DUP@beta.gouv.fr', 'full_name' => 'B'],
+        ]);
+        $this->organizationRepository->method('findOneByUuid')->willReturn($this->makeOrganization());
+        $this->entityManager->expects(self::never())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $statusCode = $tester->execute([]);
+
+        $this->assertSame(Command::FAILURE, $statusCode);
+        $this->assertStringContainsString('Email dupliqué', $tester->getDisplay());
+    }
+
+    public function testCreatesNewAdminWhenPasswordHashProvided(): void
+    {
+        $this->writeConfig([
+            [
+                'email' => 'new@beta.gouv.fr',
+                'full_name' => 'New ADMIN',
+                'password_hash' => '$2y$13$hash',
+            ],
+        ]);
+
+        $organization = $this->makeOrganization();
+        $now = new \DateTimeImmutable('2026-01-01T00:00:00');
+
+        $this->organizationRepository->method('findOneByUuid')->willReturn($organization);
+        $this->userRepository
+            ->expects(self::once())
+            ->method('findAllByRole')
+            ->with(UserRolesEnum::ROLE_SUPER_ADMIN->value)
+            ->willReturn([]);
+        $this->userRepository
+            ->expects(self::once())
+            ->method('findOneByEmail')
+            ->with('new@beta.gouv.fr')
+            ->willReturn(null);
+        $this->dateUtils->method('getNow')->willReturn($now);
+        $this->idFactory
+            ->expects(self::exactly(3))
+            ->method('make')
+            ->willReturnOnConsecutiveCalls('uuid-user', 'uuid-password', 'uuid-orgu');
+
+        $createdUser = null;
+        $this->userRepository
+            ->expects(self::once())
+            ->method('add')
+            ->willReturnCallback(function (User $user) use (&$createdUser) {
+                $createdUser = $user;
+
+                return $user;
+            });
+
+        $this->passwordUserRepository->expects(self::once())->method('add');
+        $this->organizationUserRepository->expects(self::once())->method('add');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertNotNull($createdUser);
+        $this->assertSame('new@beta.gouv.fr', $createdUser?->getEmail());
+        $this->assertSame('New ADMIN', $createdUser?->getFullName());
+        $this->assertSame([UserRolesEnum::ROLE_SUPER_ADMIN->value], $createdUser?->getRoles());
+        $this->assertTrue($createdUser?->isVerified());
+        $this->assertSame($now, $createdUser?->getRegistrationDate());
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('[create]', $output);
+        $this->assertStringContainsString('créés: 1', $output);
+    }
+
+    public function testSkipsCreationWhenPasswordHashMissing(): void
+    {
+        $this->writeConfig([
+            ['email' => 'ghost@beta.gouv.fr', 'full_name' => 'Ghost'],
+        ]);
+        $this->organizationRepository->method('findOneByUuid')->willReturn($this->makeOrganization());
+        $this->userRepository->method('findAllByRole')->willReturn([]);
+        $this->userRepository->method('findOneByEmail')->willReturn(null);
+
+        $this->userRepository->expects(self::never())->method('add');
+        $this->passwordUserRepository->expects(self::never())->method('add');
+        $this->organizationUserRepository->expects(self::never())->method('add');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('[skip]', $output);
+        $this->assertStringContainsString('ignorés: 1', $output);
+    }
+
+    public function testPromotesExistingNonAdminUser(): void
+    {
+        $this->writeConfig([
+            ['email' => 'existing@beta.gouv.fr', 'full_name' => 'Existing USER'],
+        ]);
+
+        $organization = $this->makeOrganization();
+        $existing = $this->makeUser('user-uuid', 'existing@beta.gouv.fr', 'Old Name', [UserRolesEnum::ROLE_USER->value], isVerified: false);
+
+        $this->organizationRepository->method('findOneByUuid')->willReturn($organization);
+        $this->userRepository->method('findAllByRole')->willReturn([]);
+        $this->userRepository->method('findOneByEmail')->with('existing@beta.gouv.fr')->willReturn($existing);
+
+        $this->organizationUserRepository->method('findOrganizationUser')->willReturn(null);
+        $this->idFactory->expects(self::once())->method('make')->willReturn('uuid-orgu');
+
+        $this->userRepository->expects(self::never())->method('add');
+        $this->passwordUserRepository->expects(self::never())->method('add');
+        $this->organizationUserRepository->expects(self::once())->method('add');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertContains(UserRolesEnum::ROLE_SUPER_ADMIN->value, $existing->getRoles());
+        $this->assertSame('Existing USER', $existing->getFullName());
+        $this->assertTrue($existing->isVerified());
+        $this->assertStringContainsString('[promote]', $tester->getDisplay());
+    }
+
+    public function testUpdatesExistingSuperAdminFullNameAndDoesNotTouchPassword(): void
+    {
+        $this->writeConfig([
+            ['email' => 'admin@beta.gouv.fr', 'full_name' => 'Renamed ADMIN'],
+        ]);
+
+        $organization = $this->makeOrganization();
+        $existing = $this->makeUser(
+            'user-uuid',
+            'admin@beta.gouv.fr',
+            'Old Name',
+            [UserRolesEnum::ROLE_SUPER_ADMIN->value],
+            isVerified: true,
+        );
+
+        $this->organizationRepository->method('findOneByUuid')->willReturn($organization);
+        $this->userRepository->method('findAllByRole')->willReturn([$existing]);
+
+        $this->organizationUserRepository
+            ->method('findOrganizationUser')
+            ->with(self::ORG_UUID, 'user-uuid')
+            ->willReturn(new OrganizationUser('orgu-existing'));
+
+        $this->userRepository->expects(self::never())->method('add');
+        $this->userRepository->expects(self::never())->method('remove');
+        $this->passwordUserRepository->expects(self::never())->method('add');
+        $this->organizationUserRepository->expects(self::never())->method('add');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertSame('Renamed ADMIN', $existing->getFullName());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('[update]', $output);
+        $this->assertStringContainsString('mis à jour: 1', $output);
+    }
+
+    public function testNoopWhenSuperAdminMatchesConfigExactly(): void
+    {
+        $this->writeConfig([
+            ['email' => 'admin@beta.gouv.fr', 'full_name' => 'Same NAME'],
+        ]);
+
+        $organization = $this->makeOrganization();
+        $existing = $this->makeUser(
+            'user-uuid',
+            'admin@beta.gouv.fr',
+            'Same NAME',
+            [UserRolesEnum::ROLE_SUPER_ADMIN->value],
+            isVerified: true,
+        );
+
+        $this->organizationRepository->method('findOneByUuid')->willReturn($organization);
+        $this->userRepository->method('findAllByRole')->willReturn([$existing]);
+        $this->organizationUserRepository
+            ->method('findOrganizationUser')
+            ->willReturn(new OrganizationUser('orgu-existing'));
+
+        $this->userRepository->expects(self::never())->method('add');
+        $this->userRepository->expects(self::never())->method('remove');
+        $this->organizationUserRepository->expects(self::never())->method('add');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('créés: 0, mis à jour: 0, supprimés: 0, ignorés: 0', $output);
+        $this->assertStringNotContainsString('[update]', $output);
+    }
+
+    public function testStrictSyncDeletesSuperAdminAbsentFromConfig(): void
+    {
+        $this->writeConfig([]);
+        $organization = $this->makeOrganization();
+        $obsolete = $this->makeUser(
+            'user-uuid',
+            'gone@beta.gouv.fr',
+            'Gone PERSON',
+            [UserRolesEnum::ROLE_SUPER_ADMIN->value],
+            isVerified: true,
+        );
+
+        $this->organizationRepository->method('findOneByUuid')->willReturn($organization);
+        $this->userRepository->method('findAllByRole')->willReturn([$obsolete]);
+
+        $this->userRepository
+            ->expects(self::once())
+            ->method('remove')
+            ->with($obsolete);
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('[delete]', $output);
+        $this->assertStringContainsString('supprimés: 1', $output);
+    }
+
+    public function testDryRunPerformsNoWritesAndDoesNotFlush(): void
+    {
+        $this->writeConfig([
+            ['email' => 'new@beta.gouv.fr', 'full_name' => 'New', 'password_hash' => '$2y$13$h'],
+        ]);
+        $organization = $this->makeOrganization();
+        $obsolete = $this->makeUser(
+            'old-uuid',
+            'old@beta.gouv.fr',
+            'Old',
+            [UserRolesEnum::ROLE_SUPER_ADMIN->value],
+            isVerified: true,
+        );
+
+        $this->organizationRepository->method('findOneByUuid')->willReturn($organization);
+        $this->userRepository->method('findAllByRole')->willReturn([$obsolete]);
+        $this->userRepository->method('findOneByEmail')->willReturn(null);
+
+        $this->userRepository->expects(self::never())->method('add');
+        $this->userRepository->expects(self::never())->method('remove');
+        $this->passwordUserRepository->expects(self::never())->method('add');
+        $this->organizationUserRepository->expects(self::never())->method('add');
+        $this->entityManager->expects(self::never())->method('flush');
+        $this->idFactory->expects(self::never())->method('make');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute(['--dry-run' => true]);
+        $tester->assertCommandIsSuccessful();
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('[create]', $output);
+        $this->assertStringContainsString('[delete]', $output);
+        $this->assertStringContainsString('(dry-run)', $output);
+    }
+
+    public function testCustomConfigOptionOverridesDefaultPath(): void
+    {
+        $custom = sys_get_temp_dir() . '/team_admins_custom_' . uniqid() . '.yaml';
+        file_put_contents($custom, Yaml::dump([
+            'admins' => [],
+        ]));
+
+        try {
+            $this->organizationRepository->method('findOneByUuid')->willReturn($this->makeOrganization());
+            $this->userRepository->method('findAllByRole')->willReturn([]);
+
+            $tester = new CommandTester($this->createCommand());
+            $statusCode = $tester->execute(['--config' => $custom]);
+            $this->assertSame(Command::SUCCESS, $statusCode);
+        } finally {
+            unlink($custom);
+        }
+    }
+
+    public function testPromoteWithDryRunDoesNotModifyUser(): void
+    {
+        $this->writeConfig([
+            ['email' => 'user@beta.gouv.fr', 'full_name' => 'Updated Name'],
+        ]);
+
+        $organization = $this->makeOrganization();
+        $existing = $this->makeUser('user-uuid', 'user@beta.gouv.fr', 'Old Name', [UserRolesEnum::ROLE_USER->value], isVerified: false);
+
+        $this->organizationRepository->method('findOneByUuid')->willReturn($organization);
+        $this->userRepository->method('findAllByRole')->willReturn([]);
+        $this->userRepository->method('findOneByEmail')->with('user@beta.gouv.fr')->willReturn($existing);
+
+        $this->organizationUserRepository->expects(self::never())->method('add');
+        $this->organizationUserRepository->expects(self::never())->method('findOrganizationUser');
+        $this->entityManager->expects(self::never())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute(['--dry-run' => true]);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertNotContains(UserRolesEnum::ROLE_SUPER_ADMIN->value, $existing->getRoles());
+        $this->assertSame('Old Name', $existing->getFullName());
+        $this->assertFalse($existing->isVerified());
+        $this->assertStringContainsString('[promote]', $tester->getDisplay());
+        $this->assertStringContainsString('(dry-run)', $tester->getDisplay());
+    }
+
+    public function testUpdateNonVerifiedUserToVerified(): void
+    {
+        $this->writeConfig([
+            ['email' => 'admin@beta.gouv.fr', 'full_name' => 'Admin'],
+        ]);
+
+        $organization = $this->makeOrganization();
+        $existing = $this->makeUser(
+            'user-uuid',
+            'admin@beta.gouv.fr',
+            'Admin',
+            [UserRolesEnum::ROLE_SUPER_ADMIN->value],
+            isVerified: false,
+        );
+
+        $this->organizationRepository->method('findOneByUuid')->willReturn($organization);
+        $this->userRepository->method('findAllByRole')->willReturn([$existing]);
+        $this->organizationUserRepository
+            ->method('findOrganizationUser')
+            ->willReturn(new OrganizationUser('orgu-existing'));
+
+        $this->userRepository->expects(self::never())->method('add');
+        $this->userRepository->expects(self::never())->method('remove');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertTrue($existing->isVerified());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('[update]', $output);
+        $this->assertStringContainsString('is_verified → true', $output);
+    }
+
+    public function testUpdateUserWithoutRoleToHaveRole(): void
+    {
+        $this->writeConfig([
+            ['email' => 'admin@beta.gouv.fr', 'full_name' => 'Admin'],
+        ]);
+
+        $organization = $this->makeOrganization();
+        $existing = $this->makeUser(
+            'user-uuid',
+            'admin@beta.gouv.fr',
+            'Admin',
+            [UserRolesEnum::ROLE_USER->value],
+            isVerified: true,
+        );
+
+        $this->organizationRepository->method('findOneByUuid')->willReturn($organization);
+        $this->userRepository->method('findAllByRole')->willReturn([$existing]);
+        $this->organizationUserRepository
+            ->method('findOrganizationUser')
+            ->willReturn(new OrganizationUser('orgu-existing'));
+
+        $this->userRepository->expects(self::never())->method('add');
+        $this->userRepository->expects(self::never())->method('remove');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $this->assertContains(UserRolesEnum::ROLE_SUPER_ADMIN->value, $existing->getRoles());
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('[update]', $output);
+        $this->assertStringContainsString('ROLE_SUPER_ADMIN', $output);
+    }
+
+    public function testUpdateWithoutOrgLinkCreatesLink(): void
+    {
+        $this->writeConfig([
+            ['email' => 'admin@beta.gouv.fr', 'full_name' => 'Admin'],
+        ]);
+
+        $organization = $this->makeOrganization();
+        $existing = $this->makeUser(
+            'user-uuid',
+            'admin@beta.gouv.fr',
+            'Admin',
+            [UserRolesEnum::ROLE_SUPER_ADMIN->value],
+            isVerified: true,
+        );
+
+        $this->organizationRepository->method('findOneByUuid')->willReturn($organization);
+        $this->userRepository->method('findAllByRole')->willReturn([$existing]);
+        $this->organizationUserRepository
+            ->method('findOrganizationUser')
+            ->willReturn(null);
+
+        $this->idFactory->expects(self::once())->method('make')->willReturn('uuid-orgu');
+        $this->organizationUserRepository->expects(self::once())->method('add');
+        $this->userRepository->expects(self::never())->method('add');
+        $this->userRepository->expects(self::never())->method('remove');
+        $this->entityManager->expects(self::once())->method('flush');
+
+        $tester = new CommandTester($this->createCommand());
+        $tester->execute([]);
+        $tester->assertCommandIsSuccessful();
+
+        $output = $tester->getDisplay();
+        $this->assertStringContainsString('[update]', $output);
+        $this->assertStringContainsString('link to team organization', $output);
+    }
+
+    private function makeOrganization(): Organization
+    {
+        $organization = new Organization(self::ORG_UUID);
+        $organization->setName('DiaLog');
+
+        return $organization;
+    }
+
+    private function makeUser(
+        string $uuid,
+        string $email,
+        string $fullName,
+        array $roles,
+        bool $isVerified,
+    ): User {
+        $user = (new User($uuid))
+            ->setEmail($email)
+            ->setFullName($fullName)
+            ->setRoles($roles)
+            ->setRegistrationDate(new \DateTimeImmutable('2024-01-01'));
+        if ($isVerified) {
+            $user->setIsVerified();
+        }
+
+        return $user;
+    }
+}


### PR DESCRIPTION
Amélioration qui permet d'avoir les mêmes comptes super admin en prod / staging. Et de mieux les administrer (ajout, modification, suppression) qu'avec la méthode actuelle (migrations doctrine).