### PR TITLE
Gestion de l'interdiction de dépasser sur Literalis

### DIFF
--- a/assets/maps/measure_type_styles.test.js
+++ b/assets/maps/measure_type_styles.test.js
@@ -16,6 +16,7 @@ describe('getMeasureTypeStyle', () => {
         expect(getMeasureTypeStyle('speedLimitation')).toBe(MEASURE_TYPE_STYLES.speedLimitation);
         expect(getMeasureTypeStyle('parkingProhibited')).toBe(MEASURE_TYPE_STYLES.parkingProhibited);
         expect(getMeasureTypeStyle('alternateRoad')).toBe(MEASURE_TYPE_STYLES.alternateRoad);
+        expect(getMeasureTypeStyle('noOvertaking')).toBe(MEASURE_TYPE_STYLES.noOvertaking);
     });
 
     it('returns the default style for an unknown measure type', () => {

--- a/src/Infrastructure/Form/Regulation/Measure/MeasureFormType.php
+++ b/src/Infrastructure/Form/Regulation/Measure/MeasureFormType.php
@@ -80,9 +80,16 @@ final class MeasureFormType extends AbstractType
 
     private function getTypeOptions(): array
     {
-        $choices = [];
+        $displayOrder = [
+            MeasureTypeEnum::NO_ENTRY,
+            MeasureTypeEnum::SPEED_LIMITATION,
+            MeasureTypeEnum::PARKING_PROHIBITED,
+            MeasureTypeEnum::ALTERNATE_ROAD,
+            MeasureTypeEnum::NO_OVERTAKING,
+        ];
 
-        foreach (MeasureTypeEnum::cases() as $case) {
+        $choices = [];
+        foreach ($displayOrder as $case) {
             $choices[\sprintf('regulation.measure.type.%s', $case->value)] = $case->value;
         }
 

--- a/src/Infrastructure/Integration/Litteralis/LitteralisCommunicationExtractor.php
+++ b/src/Infrastructure/Integration/Litteralis/LitteralisCommunicationExtractor.php
@@ -26,6 +26,7 @@ final class LitteralisCommunicationExtractor
         '%limitation de vitesse%',
         '%interruption de circulation%',
         '%interdiction de stationnement%',
+        '%interdiction de dépasser%',
     ];
 
     public function __construct(

--- a/src/Infrastructure/Integration/Litteralis/LitteralisExtractor.php
+++ b/src/Infrastructure/Integration/Litteralis/LitteralisExtractor.php
@@ -17,6 +17,7 @@ final class LitteralisExtractor
         '%limitation de vitesse%',
         '%interruption de circulation%',
         '%interdiction de stationnement%',
+        '%interdiction de dépasser%',
     ];
 
     public function __construct(

--- a/src/Infrastructure/Integration/Litteralis/LitteralisTransformer.php
+++ b/src/Infrastructure/Integration/Litteralis/LitteralisTransformer.php
@@ -30,6 +30,7 @@ final readonly class LitteralisTransformer
         'Limitation de vitesse' => MeasureTypeEnum::SPEED_LIMITATION->value,
         'Limitation de vitesse (Arrêté Permanent)' => MeasureTypeEnum::SPEED_LIMITATION->value,
         'Interdiction de stationnement' => MeasureTypeEnum::PARKING_PROHIBITED->value,
+        'Interdiction de dépasser' => MeasureTypeEnum::NO_OVERTAKING->value,
 
         // Montpellier - Mesures avec préfixes dynamiques (gérés par normalizeMeasureName)
         // Les préfixes "YYYY - " (ex: "2021 - ", "2022 - ") et "AP - " sont retirés automatiquement

--- a/tests/Unit/Infrastructure/Integration/Litteralis/LitteralisCommunicationExtractorTest.php
+++ b/tests/Unit/Infrastructure/Integration/Litteralis/LitteralisCommunicationExtractorTest.php
@@ -107,7 +107,7 @@ final class LitteralisCommunicationExtractorTest extends TestCase
             ->willReturn($this->client);
 
         $expectedDate = $laterThan->format(\DateTimeInterface::ISO8601);
-        $cqlFilter = "(mesure ILIKE '%circulation interdite%' OR mesure ILIKE '%limitation de vitesse%' OR mesure ILIKE '%interruption de circulation%' OR mesure ILIKE '%interdiction de stationnement%') AND (arretefin IS NULL OR arretefin >= '" . $expectedDate . "')";
+        $cqlFilter = "(mesure ILIKE '%circulation interdite%' OR mesure ILIKE '%limitation de vitesse%' OR mesure ILIKE '%interruption de circulation%' OR mesure ILIKE '%interdiction de stationnement%' OR mesure ILIKE '%interdiction de dépasser%') AND (arretefin IS NULL OR arretefin >= '" . $expectedDate . "')";
 
         $this->client
             ->expects(self::exactly(2))
@@ -241,7 +241,7 @@ final class LitteralisCommunicationExtractorTest extends TestCase
             ->willReturn($this->client);
 
         $expectedDate = $laterThan->format(\DateTimeInterface::ISO8601);
-        $cqlFilter = "(mesure ILIKE '%circulation interdite%' OR mesure ILIKE '%limitation de vitesse%' OR mesure ILIKE '%interruption de circulation%' OR mesure ILIKE '%interdiction de stationnement%') AND (arretefin IS NULL OR arretefin >= '" . $expectedDate . "')";
+        $cqlFilter = "(mesure ILIKE '%circulation interdite%' OR mesure ILIKE '%limitation de vitesse%' OR mesure ILIKE '%interruption de circulation%' OR mesure ILIKE '%interdiction de stationnement%' OR mesure ILIKE '%interdiction de dépasser%') AND (arretefin IS NULL OR arretefin >= '" . $expectedDate . "')";
 
         $this->client
             ->expects(self::exactly(2))

--- a/tests/Unit/Infrastructure/Integration/Litteralis/LitteralisExtractorTest.php
+++ b/tests/Unit/Infrastructure/Integration/Litteralis/LitteralisExtractorTest.php
@@ -81,7 +81,7 @@ final class LitteralisExtractorTest extends TestCase
             ->with('testpassword')
             ->willReturn($this->client);
 
-        $cqlFilter = "(mesures ILIKE '%circulation interdite%' OR mesures ILIKE '%limitation de vitesse%' OR mesures ILIKE '%interruption de circulation%' OR mesures ILIKE '%interdiction de stationnement%') AND (arretefin IS NULL OR arretefin >= '2024-08-01T00:00:00+0000')";
+        $cqlFilter = "(mesures ILIKE '%circulation interdite%' OR mesures ILIKE '%limitation de vitesse%' OR mesures ILIKE '%interruption de circulation%' OR mesures ILIKE '%interdiction de stationnement%' OR mesures ILIKE '%interdiction de dépasser%') AND (arretefin IS NULL OR arretefin >= '2024-08-01T00:00:00+0000')";
 
         $this->client
             ->expects(self::exactly(2))

--- a/tests/Unit/Infrastructure/Integration/Litteralis/LitteralisTransformerTest.php
+++ b/tests/Unit/Infrastructure/Integration/Litteralis/LitteralisTransformerTest.php
@@ -355,8 +355,10 @@ final class LitteralisTransformerTest extends TestCase
         $this->assertSame([VehicleTypeEnum::OTHER->value], $command->measureCommands[0]->vehicleSet->exemptedTypes);
         $this->assertSame("véhicules de l'entreprise exécutant les travaux", $command->measureCommands[0]->vehicleSet->otherExemptedTypeText);
 
-        $this->assertSame(MeasureTypeEnum::SPEED_LIMITATION->value, $command->measureCommands[1]->type);
-        $this->assertSame(30, $command->measureCommands[1]->maxSpeed);
+        $this->assertSame(MeasureTypeEnum::NO_OVERTAKING->value, $command->measureCommands[1]->type);
+
+        $this->assertSame(MeasureTypeEnum::SPEED_LIMITATION->value, $command->measureCommands[2]->type);
+        $this->assertSame(30, $command->measureCommands[2]->maxSpeed);
 
         foreach ($command->measureCommands as $measureCommand) {
             $this->assertCount(1, $measureCommand->periods);


### PR DESCRIPTION
Cette PR rajoute la gestion des interdictions de dépasser dans Literalis et corrige l'ordre d'affichage des restrictions dans le formulaire de création d'arrêté.