### PR TITLE
Affichage des légendes en fonctions des tracés

### DIFF
--- a/src/Application/Regulation/Command/MapImage/WarmRegulationMapImageCacheCommandHandler.php
+++ b/src/Application/Regulation/Command/MapImage/WarmRegulationMapImageCacheCommandHandler.php
@@ -15,7 +15,7 @@ final readonly class WarmRegulationMapImageCacheCommandHandler
 
     public function __invoke(WarmRegulationMapImageCacheCommand $command): void
     {
-        // makeBase64Jpeg renders + caches when the storage entry is missing, and is a no-op when already cached.
-        $this->regulationMapImageMaker->makeBase64Jpeg($command->regulationOrderRecordUuid);
+        // Renders + caches when the storage entry is missing, and is a no-op when already cached.
+        $this->regulationMapImageMaker->make($command->regulationOrderRecordUuid);
     }
 }

--- a/src/Domain/Regulation/RegulationMapImage.php
+++ b/src/Domain/Regulation/RegulationMapImage.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Regulation;
+
+final readonly class RegulationMapImage
+{
+    public function __construct(
+        public string $base64Jpeg,
+        public array $measureTypes,
+    ) {
+    }
+}

--- a/src/Domain/Regulation/RegulationMapImageMakerInterface.php
+++ b/src/Domain/Regulation/RegulationMapImageMakerInterface.php
@@ -6,5 +6,5 @@ namespace App\Domain\Regulation;
 
 interface RegulationMapImageMakerInterface
 {
-    public function makeBase64Jpeg(string $regulationOrderRecordUuid): ?string;
+    public function make(string $regulationOrderRecordUuid): ?RegulationMapImage;
 }

--- a/src/Infrastructure/Adapter/RegulationMapImageMaker.php
+++ b/src/Infrastructure/Adapter/RegulationMapImageMaker.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\Adapter;
 
 use App\Application\StorageInterface;
+use App\Domain\Regulation\RegulationMapImage;
 use App\Domain\Regulation\RegulationMapImageMakerInterface;
 use App\Domain\Regulation\Repository\LocationRepositoryInterface;
 use Psr\Log\LoggerInterface;
@@ -18,7 +19,7 @@ final class RegulationMapImageMaker implements RegulationMapImageMakerInterface
     private const RENDER_TIMEOUT_SECONDS = 30;
     private const PAGE_TIMEOUT_MS = 15000;
     private const JPEG_SIGNATURE = "\xFF\xD8\xFF";
-    private const CACHE_PREFIX = 'regulation-maps/';
+    private const CACHE_PREFIX = 'regulation-maps/v2/';
 
     public function __construct(
         private readonly LocationRepositoryInterface $locationRepository,
@@ -29,7 +30,7 @@ final class RegulationMapImageMaker implements RegulationMapImageMakerInterface
     ) {
     }
 
-    public function makeBase64Jpeg(string $regulationOrderRecordUuid): ?string
+    public function make(string $regulationOrderRecordUuid): ?RegulationMapImage
     {
         $rows = $this->locationRepository->findGeometriesForRegulationOrderRecord($regulationOrderRecordUuid);
 
@@ -43,11 +44,12 @@ final class RegulationMapImageMaker implements RegulationMapImageMakerInterface
             return null;
         }
 
+        $measureTypes = array_values(array_unique(array_column($rows, 'measure_type')));
         $cachePath = $this->getCachePath($regulationOrderRecordUuid, $rows);
         $cached = $this->storage->read($cachePath);
 
         if ($cached !== null) {
-            return base64_encode($cached);
+            return new RegulationMapImage(base64_encode($cached), $measureTypes);
         }
 
         $jpeg = $this->renderViaPlaywright($regulationOrderRecordUuid, $bounds);
@@ -58,7 +60,7 @@ final class RegulationMapImageMaker implements RegulationMapImageMakerInterface
 
         $this->storage->writeContent($cachePath, $jpeg, 'image/jpeg');
 
-        return base64_encode($jpeg);
+        return new RegulationMapImage(base64_encode($jpeg), $measureTypes);
     }
 
     private function computeBounds(array $rows): ?array

--- a/src/Infrastructure/Controller/Regulation/ExportRegulationController.php
+++ b/src/Infrastructure/Controller/Regulation/ExportRegulationController.php
@@ -59,8 +59,10 @@ final class ExportRegulationController extends AbstractRegulationController
         $measures = $this->queryBus->handle(new GetMeasuresQuery($uuid));
         $regulationOrderTransformed = $this->regulationOrderTemplateTransformer->transform($regulationOrderTemplate, $generalInfo, $signingAuthority);
 
-        $mapImageBase64 = $this->regulationMapImageMaker->makeBase64Jpeg($uuid);
-        $legendSwatches = $this->regulationMeasureLegendBuilder->buildSwatches();
+        $mapImage = $this->regulationMapImageMaker->make($uuid);
+        $legendSwatches = $mapImage
+            ? array_intersect_key($this->regulationMeasureLegendBuilder->buildSwatches(), array_flip($mapImage->measureTypes))
+            : [];
 
         $content = $this->twig->render(
             name: 'regulation/export.html.twig',
@@ -69,7 +71,7 @@ final class ExportRegulationController extends AbstractRegulationController
                 'generalInfo' => $generalInfo,
                 'measures' => $measures,
                 'signingAuthority' => $signingAuthority,
-                'mapImageBase64' => $mapImageBase64,
+                'mapImageBase64' => $mapImage?->base64Jpeg,
                 'legendSwatches' => $legendSwatches,
             ],
         );

--- a/templates/regulation/_internal_map_preview.html.twig
+++ b/templates/regulation/_internal_map_preview.html.twig
@@ -6,6 +6,7 @@
     <style>
         html, body { margin: 0; padding: 0; height: 100%; width: 100%; background: #fff; }
         d-map { display: block; width: 100%; height: 100%; }
+        .maplibregl-ctrl { display: none !important; }
     </style>
     {{ encore_entry_link_tags('app') }}
 </head>

--- a/templates/regulation/export.html.twig
+++ b/templates/regulation/export.html.twig
@@ -56,23 +56,15 @@
     <div custom-style="Dialog_TitrePrincipal">Annexe — Carte de l'arrêté</div><br/>
     <p><img src="data:image/jpeg;base64,{{ mapImageBase64 }}" width="600px" /></p>
 
-    <p><b>Légende</b></p>
-    <table>
-        <tr>
-            <td>{{ 'regulation.measure.type.noEntry'|trans }}&nbsp;&nbsp;</td>
-            <td><img src="{{ legendSwatches.noEntry }}" /></td>
-        </tr>
-        <tr>
-            <td>{{ 'regulation.measure.type.speedLimitation'|trans }}&nbsp;&nbsp;</td>
-            <td><img src="{{ legendSwatches.speedLimitation }}" /></td>
-        </tr>
-        <tr>
-            <td>{{ 'regulation.measure.type.parkingProhibited'|trans }}&nbsp;&nbsp;</td>
-            <td><img src="{{ legendSwatches.parkingProhibited }}" /></td>
-        </tr>
-        <tr>
-            <td>{{ 'regulation.measure.type.alternateRoad'|trans }}&nbsp;&nbsp;</td>
-            <td><img src="{{ legendSwatches.alternateRoad }}" /></td>
-        </tr>
-    </table>
+    {% if legendSwatches is not empty %}
+        <p><b>Légende</b></p>
+        <table>
+            {% for type, swatch in legendSwatches %}
+                <tr>
+                    <td>{{ ('regulation.measure.type.' ~ type)|trans }}&nbsp;&nbsp;</td>
+                    <td><img src="{{ swatch }}" /></td>
+                </tr>
+            {% endfor %}
+        </table>
+    {% endif %}
 {% endif %}

--- a/tests/Mock/NullRegulationMapImageMaker.php
+++ b/tests/Mock/NullRegulationMapImageMaker.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace App\Tests\Mock;
 
+use App\Domain\Regulation\RegulationMapImage;
 use App\Domain\Regulation\RegulationMapImageMakerInterface;
 
 final class NullRegulationMapImageMaker implements RegulationMapImageMakerInterface
 {
-    public function makeBase64Jpeg(string $regulationOrderRecordUuid): ?string
+    public function make(string $regulationOrderRecordUuid): ?RegulationMapImage
     {
         return null;
     }

--- a/tests/Unit/Application/Regulation/Command/MapImage/WarmRegulationMapImageCacheCommandHandlerTest.php
+++ b/tests/Unit/Application/Regulation/Command/MapImage/WarmRegulationMapImageCacheCommandHandlerTest.php
@@ -16,7 +16,7 @@ final class WarmRegulationMapImageCacheCommandHandlerTest extends TestCase
         $imageMaker = $this->createMock(RegulationMapImageMakerInterface::class);
         $imageMaker
             ->expects(self::once())
-            ->method('makeBase64Jpeg')
+            ->method('make')
             ->with('record-uuid');
 
         $handler = new WarmRegulationMapImageCacheCommandHandler($imageMaker);

--- a/tests/Unit/Infrastructure/Adapter/RegulationMapImageMakerTest.php
+++ b/tests/Unit/Infrastructure/Adapter/RegulationMapImageMakerTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Unit\Infrastructure\Adapter;
 
 use App\Application\StorageInterface;
+use App\Domain\Regulation\RegulationMapImage;
 use App\Domain\Regulation\Repository\LocationRepositoryInterface;
 use App\Infrastructure\Adapter\RegulationMapImageMaker;
 use PHPUnit\Framework\TestCase;
@@ -33,7 +34,7 @@ final class RegulationMapImageMakerTest extends TestCase
             'http://internal',
         );
 
-        $this->assertNull($maker->makeBase64Jpeg('record-uuid'));
+        $this->assertNull($maker->make('record-uuid'));
     }
 
     public function testReturnsCachedJpegWithoutInvokingPlaywright(): void
@@ -67,6 +68,10 @@ final class RegulationMapImageMakerTest extends TestCase
             'http://internal',
         );
 
-        $this->assertSame(base64_encode($jpegBytes), $maker->makeBase64Jpeg('record-uuid'));
+        $result = $maker->make('record-uuid');
+
+        $this->assertInstanceOf(RegulationMapImage::class, $result);
+        $this->assertSame(base64_encode($jpegBytes), $result->base64Jpeg);
+        $this->assertSame(['noEntry'], $result->measureTypes);
     }
 }


### PR DESCRIPTION
Cette PR permet d'afficher, sur l'export word, les légendes en fonction des tracés présents sur la carte.