### PR TITLE
chore(datex): Add file size and HEAD response to increase availability

### DIFF
--- a/src/Application/Regulation/DatexGeneratorInterface.php
+++ b/src/Application/Regulation/DatexGeneratorInterface.php
@@ -9,4 +9,6 @@ interface DatexGeneratorInterface
     public function generate(): void;
 
     public function getCachedDatex(): string;
+
+    public function getCachedDatexSize(): int;
 }

--- a/src/Infrastructure/Adapter/DatexGenerator.php
+++ b/src/Infrastructure/Adapter/DatexGenerator.php
@@ -63,4 +63,13 @@ final class DatexGenerator implements DatexGeneratorInterface
 
         return $this->storage->read(self::DATEX_PATH);
     }
+
+    public function getCachedDatexSize(): int
+    {
+        if (!$this->storage->fileExists(self::DATEX_PATH)) {
+            $this->generate();
+        }
+
+        return $this->storage->fileSize(self::DATEX_PATH);
+    }
 }

--- a/src/Infrastructure/Controller/Api/Regulations/GetRegulationsController.php
+++ b/src/Infrastructure/Controller/Api/Regulations/GetRegulationsController.php
@@ -9,6 +9,7 @@ use App\Application\QueryBusInterface;
 use App\Application\Regulation\DatexGeneratorInterface;
 use App\Application\Regulation\Query\GetRegulationOrdersToDatexFormatQuery;
 use OpenApi\Attributes as OA;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Attribute\MapQueryParameter;
@@ -26,12 +27,13 @@ final class GetRegulationsController
 
     #[Route(
         '/api/regulations.{_format}',
-        methods: 'GET',
+        methods: ['GET', 'HEAD'],
         name: 'api_regulations_list',
         defaults: ['_format' => 'xml'],
     )]
     #[OA\Tag(name: 'Public')]
     public function __invoke(
+        Request $request,
         #[MapQueryParameter]
         bool $includePermanent = true,
         #[MapQueryParameter]
@@ -39,15 +41,27 @@ final class GetRegulationsController
         #[MapQueryParameter]
         bool $includeExpired = false,
     ): Response {
+        if ($request->isMethod('HEAD')) {
+            return new Response(
+                '',
+                Response::HTTP_OK,
+                [
+                    'Content-Type' => 'text/xml; charset=UTF-8',
+                    'Content-Length' => (string) $this->datexGenerator->getCachedDatexSize(),
+                ],
+            );
+        }
+
         $isDefaultParams = $includePermanent && $includeTemporary && !$includeExpired;
 
         if ($isDefaultParams) {
-            $regulationOrders = $this->datexGenerator->getCachedDatex();
-
             return new Response(
-                $regulationOrders,
+                $this->datexGenerator->getCachedDatex(),
                 Response::HTTP_OK,
-                ['Content-Type' => 'text/xml; charset=UTF-8'],
+                [
+                    'Content-Type' => 'text/xml; charset=UTF-8',
+                    'Content-Length' => (string) $this->datexGenerator->getCachedDatexSize(),
+                ],
             );
         }
 

--- a/tests/Unit/Infrastructure/Controller/Api/Regulations/GetRegulationsControllerTest.php
+++ b/tests/Unit/Infrastructure/Controller/Api/Regulations/GetRegulationsControllerTest.php
@@ -11,6 +11,7 @@ use App\Application\Regulation\Query\GetRegulationOrdersToDatexFormatQuery;
 use App\Infrastructure\Controller\Api\Regulations\GetRegulationsController;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
@@ -44,16 +45,22 @@ final class GetRegulationsControllerTest extends TestCase
             ->method('getCachedDatex')
             ->willReturn('<xml>cached</xml>');
 
+        $this->datexGenerator
+            ->expects(self::once())
+            ->method('getCachedDatexSize')
+            ->willReturn(17);
+
         $this->queryBus
             ->expects(self::never())
             ->method('handle');
 
-        $response = ($this->controller)();
+        $response = ($this->controller)(Request::create('/api/regulations.xml'));
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertNotInstanceOf(StreamedResponse::class, $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('text/xml; charset=UTF-8', $response->headers->get('Content-Type'));
+        $this->assertSame('17', $response->headers->get('Content-Length'));
         $this->assertSame('<xml>cached</xml>', $response->getContent());
     }
 
@@ -64,15 +71,45 @@ final class GetRegulationsControllerTest extends TestCase
             ->method('getCachedDatex')
             ->willReturn('<xml>generated</xml>');
 
+        $this->datexGenerator
+            ->expects(self::once())
+            ->method('getCachedDatexSize')
+            ->willReturn(19);
+
         $this->queryBus
             ->expects(self::never())
             ->method('handle');
 
-        $response = ($this->controller)();
+        $response = ($this->controller)(Request::create('/api/regulations.xml'));
 
         $this->assertInstanceOf(Response::class, $response);
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('<xml>generated</xml>', $response->getContent());
+    }
+
+    public function testHeadRequestReturnsSizeOnly(): void
+    {
+        $this->datexGenerator
+            ->expects(self::once())
+            ->method('getCachedDatexSize')
+            ->willReturn(1234);
+
+        $this->datexGenerator
+            ->expects(self::never())
+            ->method('getCachedDatex');
+
+        $this->queryBus
+            ->expects(self::never())
+            ->method('handle');
+
+        $response = ($this->controller)(Request::create('/api/regulations.xml', 'HEAD'));
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertNotInstanceOf(StreamedResponse::class, $response);
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/xml; charset=UTF-8', $response->headers->get('Content-Type'));
+        $this->assertSame('1234', $response->headers->get('Content-Length'));
+        $this->assertSame('', $response->getContent());
     }
 
     public function testCustomFiltersReturnStreamedResponse(): void
@@ -112,6 +149,11 @@ final class GetRegulationsControllerTest extends TestCase
             ->method('generate');
 
         $response = ($this->controller)(
+            Request::create('/api/regulations.xml', 'GET', [
+                'includePermanent' => false,
+                'includeTemporary' => true,
+                'includeExpired' => true,
+            ]),
             includePermanent: false,
             includeTemporary: true,
             includeExpired: true,


### PR DESCRIPTION
Cela permet à eux qui requête le fichier d'avoir sa taille en amont.