### PR TITLE
Amélioration des validations limites de vitesse et gabarit

### DIFF
--- a/config/validator/Application/Regulation/Command/SaveMeasureCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveMeasureCommand.xml
@@ -25,6 +25,9 @@
                 </option>
             </constraint>
             <constraint name="Positive"></constraint>
+            <constraint name="LessThanOrEqual">
+                <option name="value">130</option>
+            </constraint>
         </property>
        <property name="vehicleSet">
             <constraint name="Valid"/>

--- a/config/validator/Application/Regulation/Command/SaveVehicleSetCommand.xml
+++ b/config/validator/Application/Regulation/Command/SaveVehicleSetCommand.xml
@@ -121,17 +121,26 @@
             </constraint>
             <constraint name="PositiveOrZero"></constraint>
             <constraint name="LessThanOrEqual">
-                <option name="value">100</option>
+                <option name="value">44</option>
             </constraint>
         </property>
         <property name="maxWidth">
             <constraint name="PositiveOrZero"></constraint>
+            <constraint name="LessThanOrEqual">
+                <option name="value">10</option>
+            </constraint>
         </property>
         <property name="maxLength">
             <constraint name="PositiveOrZero"></constraint>
+            <constraint name="LessThanOrEqual">
+                <option name="value">50</option>
+            </constraint>
         </property>
         <property name="maxHeight">
             <constraint name="PositiveOrZero"></constraint>
+            <constraint name="LessThanOrEqual">
+                <option name="value">10</option>
+            </constraint>
         </property>
     </class>
 </constraint-mapping>

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateMeasureControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/UpdateMeasureControllerTest.php
@@ -49,6 +49,23 @@ final class UpdateMeasureControllerTest extends AbstractWebTestCase
         $this->assertSame('Cette valeur doit être strictement positive.', $crawler->filter('#measure_form_maxSpeed_error')->text());
     }
 
+    public function testWithMaxSpeedTooHigh(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/_fragment/regulations/' . RegulationOrderRecordFixture::UUID_TYPICAL . '/measure/' . MeasureFixture::UUID_TYPICAL . '/form');
+        $this->assertResponseStatusCodeSame(200);
+        $this->assertSecurityHeaders();
+
+        $saveButton = $crawler->selectButton('Valider');
+        $form = $saveButton->form();
+        $form['measure_form[type]'] = 'speedLimitation';
+        $form['measure_form[maxSpeed]'] = '150';
+
+        $crawler = $client->submit($form);
+        $this->assertResponseStatusCodeSame(422);
+        $this->assertSame('Cette valeur doit être inférieure ou égale à 130.', $crawler->filter('#measure_form_maxSpeed_error')->text());
+    }
+
     public function testWithoutMaxSpeed(): void
     {
         $client = $this->login();


### PR DESCRIPTION
* Closes #1861

Contraintes ajoutées (validators XML) :

- maxSpeed ≤ 130 km/h
- heavyweightMaxWeight ≤ 44 t (au lieu de 100 t, aligné sur la limite réglementaire FR)
- maxWidth ≤ 10 m, maxLength ≤ 50 m, maxHeight ≤ 10 m
