### PR TITLE
Ajout du séparateur ":" pour les périodes dans le parseur Litteralis

### DIFF
--- a/src/Infrastructure/Integration/Litteralis/LitteralisPeriodParser.php
+++ b/src/Infrastructure/Integration/Litteralis/LitteralisPeriodParser.php
@@ -20,7 +20,7 @@ final class LitteralisPeriodParser
     // * '19h à 7h'
     // * 'de 21h à 6h.'
     // * 'de 8 heures à 15 heures 30'
-    private const HOURS_REGEX = '/^(?:la nuit |de nuit )?(?:de )?(?P<startHour>\d{1,2}) ?(?:h|heures?) ?(?P<startMinute>\d{1,2})? (?:à|À|0|[aA]) ?(?P<endHour>\d{1,2}) ?(?:h|heures?) ?(?P<endMinute>\d{1,2})?\.?$/i';
+    private const HOURS_REGEX = '/^(?:la nuit |de nuit )?(?:de )?(?P<startHour>\d{1,2}) ?(?:h|heures?|:)? ?(?P<startMinute>\d{1,2})? (?:à|À|0|[aA]) ?(?P<endHour>\d{1,2}) ?(?:h|heures?|:)? ?(?P<endMinute>\d{1,2})?\.?$/i';
     private const ALL_HOURS_VALUES = [
         'jour et nuit',
         // <<< Litteralis Corrèze (aka CD19)

--- a/tests/Unit/Infrastructure/Integration/Litteralis/LitteralisPeriodParserTest.php
+++ b/tests/Unit/Infrastructure/Integration/Litteralis/LitteralisPeriodParserTest.php
@@ -70,6 +70,10 @@ final class LitteralisPeriodParserTest extends TestCase
                 'value' => 'de 7 heures 30 à 17 heures 30',
                 'timeSlots' => [$timeSlot2],
             ],
+            'hours-colon' => [
+                'value' => '08:00 à 18:00',
+                'timeSlots' => [$timeSlot1],
+            ],
         ];
     }
 


### PR DESCRIPTION
Lié à #1964