### PR TITLE
fix(datex): generate publicUrl from BASE_URL instead of localhost (#1…

### DIFF
--- a/templates/api/regulations.xml.twig
+++ b/templates/api/regulations.xml.twig
@@ -255,7 +255,7 @@
                 <_trafficRegulationOrderExtension>
                     <trafficRegulationOrderExtended>
                         <dx:source>{{ regulationOrder.source }}</dx:source>
-                        <dx:publicUrl>{{ url('app_regulation_detail', { uuid: regulationOrder.regulationOrderRecordUuid }) }}</dx:publicUrl>
+                        <dx:publicUrl>{{ baseUrl ~ path('app_regulation_detail', { uuid: regulationOrder.regulationOrderRecordUuid }) }}</dx:publicUrl>
                     </trafficRegulationOrderExtended>
                 </_trafficRegulationOrderExtension>
             </trafficRegulationOrder>

--- a/tests/Integration/Infrastructure/Controller/Api/GetRegulationsControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Api/GetRegulationsControllerTest.php
@@ -49,6 +49,13 @@ final class GetRegulationsControllerTest extends AbstractWebTestCase
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
 
+        $content = $response->getContent();
+        $this->assertStringNotContainsString('<dx:publicUrl>http://localhost/', $content);
+        $this->assertMatchesRegularExpression(
+            '#<dx:publicUrl>https://dialog\.beta\.gouv\.fr/regulations/[0-9a-f-]{36}</dx:publicUrl>#',
+            $content,
+        );
+
         // Je commente le temps de trouver une solution concernant l'execution random
         /*$xml = new \DOMDocument();
         $xml->loadXML($response->getContent(), \LIBXML_NOBLANKS);
@@ -74,5 +81,12 @@ final class GetRegulationsControllerTest extends AbstractWebTestCase
         $this->assertSame('text/xml; charset=UTF-8', $response->headers->get('content-type'));
         $this->assertResponseStatusCodeSame(200);
         $this->assertSecurityHeaders();
+
+        $content = $response->getContent();
+        $this->assertStringNotContainsString('<dx:publicUrl>http://localhost/', $content);
+        $this->assertMatchesRegularExpression(
+            '#<dx:publicUrl>https://dialog\.beta\.gouv\.fr/regulations/[0-9a-f-]{36}</dx:publicUrl>#',
+            $content,
+        );
     }
 }

--- a/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
+++ b/tests/Integration/Infrastructure/Controller/Api/get-regulations-expected-result.xml
@@ -158,7 +158,7 @@
                 <trafficRegulationOrderExtended>
 
                     <dx:source>dialog</dx:source>
-                    <dx:publicUrl>http://localhost/regulations/0654905d-6771-75d8-8000-d523184d0b55</dx:publicUrl>
+                    <dx:publicUrl>https://dialog.beta.gouv.fr/regulations/0654905d-6771-75d8-8000-d523184d0b55</dx:publicUrl>
                 </trafficRegulationOrderExtended>
 
             </_trafficRegulationOrderExtension>
@@ -243,7 +243,7 @@
                 <trafficRegulationOrderExtended>
 
                     <dx:source>litteralis</dx:source>
-                    <dx:publicUrl>http://localhost/regulations/066e9849-1457-7a1e-8000-3142ece4a7de</dx:publicUrl>
+                    <dx:publicUrl>https://dialog.beta.gouv.fr/regulations/066e9849-1457-7a1e-8000-3142ece4a7de</dx:publicUrl>
                 </trafficRegulationOrderExtended>
 
             </_trafficRegulationOrderExtension>
@@ -477,7 +477,7 @@
                 <trafficRegulationOrderExtended>
                     <dx:source>dialog</dx:source>
 
-                    <dx:publicUrl>http://localhost/regulations/3ede8b1a-1816-4788-8510-e08f45511cb5</dx:publicUrl>
+                    <dx:publicUrl>https://dialog.beta.gouv.fr/regulations/3ede8b1a-1816-4788-8510-e08f45511cb5</dx:publicUrl>
                 </trafficRegulationOrderExtended>
 
             </_trafficRegulationOrderExtension>
@@ -622,7 +622,7 @@
                 <trafficRegulationOrderExtended>
 
                     <dx:source>dialog</dx:source>
-                    <dx:publicUrl>http://localhost/regulations/6f665f38-7765-47b1-849a-06279eba3ac6</dx:publicUrl>
+                    <dx:publicUrl>https://dialog.beta.gouv.fr/regulations/6f665f38-7765-47b1-849a-06279eba3ac6</dx:publicUrl>
                 </trafficRegulationOrderExtended>
 
             </_trafficRegulationOrderExtension>
@@ -706,7 +706,7 @@
                 <trafficRegulationOrderExtended>
 
                     <dx:source>dialog</dx:source>
-                    <dx:publicUrl>http://localhost/regulations/9995801a-0a5c-4a93-8562-f84df8484315</dx:publicUrl>
+                    <dx:publicUrl>https://dialog.beta.gouv.fr/regulations/9995801a-0a5c-4a93-8562-f84df8484315</dx:publicUrl>
                 </trafficRegulationOrderExtended>
 
             </_trafficRegulationOrderExtension>
@@ -799,7 +799,7 @@
                 <trafficRegulationOrderExtended>
 
                     <dx:source>dialog</dx:source>
-                    <dx:publicUrl>http://localhost/regulations/9d408332-d30f-4530-be66-dfb2d98ebae5</dx:publicUrl>
+                    <dx:publicUrl>https://dialog.beta.gouv.fr/regulations/9d408332-d30f-4530-be66-dfb2d98ebae5</dx:publicUrl>
                 </trafficRegulationOrderExtended>
 
             </_trafficRegulationOrderExtension>


### PR DESCRIPTION
…883)

The DATEX feed is generated asynchronously, so url() fell back to http://localhost.