### PR TITLE
fix(regulation): refresh what depends on the type after a category change

### DIFF
--- a/src/Application/Regulation/View/GeneralInfoView.php
+++ b/src/Application/Regulation/View/GeneralInfoView.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Application\Regulation\View;
 
+use App\Domain\Regulation\Enum\RegulationOrderCategoryEnum;
 use App\Domain\Regulation\Enum\RegulationOrderRecordSourceEnum;
 use App\Domain\Regulation\Enum\RegulationOrderRecordStatusEnum;
 use App\Domain\User\OrganizationRegulationAccessInterface;
@@ -38,6 +39,11 @@ readonly class GeneralInfoView implements OrganizationRegulationAccessInterface
     public function isDraft(): bool
     {
         return $this->status === RegulationOrderRecordStatusEnum::DRAFT->value;
+    }
+
+    public function isPermanent(): bool
+    {
+        return $this->category === RegulationOrderCategoryEnum::PERMANENT_REGULATION->value;
     }
 
     public function isSourceDialog(): bool

--- a/src/Infrastructure/Controller/Regulation/Fragments/SaveGeneralInfoController.php
+++ b/src/Infrastructure/Controller/Regulation/Fragments/SaveGeneralInfoController.php
@@ -73,10 +73,22 @@ final class SaveGeneralInfoController extends AbstractRegulationController
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
+            $regulationOrder = $regulationOrderRecord->getRegulationOrder();
+            $wasPermanent = $regulationOrder->isPermanent();
+
             $this->commandBus->handle($command);
 
             $generalInfo = $this->queryBus->handle(new GetGeneralInfoQuery($uuid));
             $request->setRequestFormat(TurboBundle::STREAM_FORMAT);
+
+            $permanenceHasChanged = $wasPermanent !== $generalInfo->isPermanent();
+            $measureUuids = [];
+
+            if ($permanenceHasChanged) {
+                foreach ($regulationOrder->getMeasures() as $measure) {
+                    $measureUuids[] = $measure->getUuid();
+                }
+            }
 
             return new Response(
                 $this->twig->render(
@@ -85,6 +97,8 @@ final class SaveGeneralInfoController extends AbstractRegulationController
                         'generalInfo' => $generalInfo,
                         'canEdit' => $generalInfo->isSourceDialog(),
                         'regulationOrderRecord' => $regulationOrderRecord,
+                        'permanenceHasChanged' => $permanenceHasChanged,
+                        'measureUuids' => $measureUuids,
                     ],
                 ),
             );

--- a/templates/regulation/_detail_heading.html.twig
+++ b/templates/regulation/_detail_heading.html.twig
@@ -1,0 +1,1 @@
+{{- (isPermanent ? 'regulation.permanent' : 'regulation.temporary')|trans }} {{ identifier -}}

--- a/templates/regulation/detail.html.twig
+++ b/templates/regulation/detail.html.twig
@@ -1,6 +1,6 @@
 {% extends 'layouts/layout.html.twig' %}
 
-{% set title = (isPermanent ? 'regulation.permanent' : 'regulation.temporary')|trans ~ ' ' ~ generalInfo.identifier  %}
+{% set title = include('regulation/_detail_heading.html.twig', { isPermanent, identifier: generalInfo.identifier }) %}
 
 {% block title %}
     {{ title }}

--- a/templates/regulation/fragments/_general_info.updated.stream.html.twig
+++ b/templates/regulation/fragments/_general_info.updated.stream.html.twig
@@ -9,3 +9,17 @@
         {% include 'regulation/fragments/_publication_button.html.twig' with { canPublish: true, uuid: generalInfo.uuid, regulationOrderRecord, publishLabel: 'regulation.publish_changes'|trans } only %}
     </template>
 </turbo-stream>
+
+{% if permanenceHasChanged %}
+    <turbo-stream action="update" target="regulation-detail">
+        <template>{% include 'regulation/_detail_heading.html.twig' with { isPermanent: generalInfo.isPermanent, identifier: generalInfo.identifier } only %}</template>
+    </turbo-stream>
+
+    {% for measureUuid in measureUuids %}
+        <turbo-stream action="replace" target="block_measure_{{ measureUuid }}">
+            <template>
+                <turbo-frame id="block_measure_{{ measureUuid }}" src="{{ path('fragment_regulations_measure', { regulationOrderRecordUuid: generalInfo.uuid, uuid: measureUuid }) }}" loading="eager"></turbo-frame>
+            </template>
+        </turbo-stream>
+    {% endfor %}
+{% endif %}

--- a/tests/Integration/Infrastructure/Controller/Regulation/Fragments/SaveRegulationGeneralInfoControllerTest.php
+++ b/tests/Integration/Infrastructure/Controller/Regulation/Fragments/SaveRegulationGeneralInfoControllerTest.php
@@ -6,6 +6,7 @@ namespace App\Tests\Integration\Infrastructure\Controller\Regulation\Fragments;
 
 use App\Domain\Regulation\Enum\RegulationOrderCategoryEnum;
 use App\Domain\Regulation\Enum\RegulationSubjectEnum;
+use App\Infrastructure\Persistence\Doctrine\Fixtures\MeasureFixture;
 use App\Infrastructure\Persistence\Doctrine\Fixtures\OrganizationFixture;
 use App\Infrastructure\Persistence\Doctrine\Fixtures\RegulationOrderFixture;
 use App\Infrastructure\Persistence\Doctrine\Fixtures\RegulationOrderRecordFixture;
@@ -34,6 +35,49 @@ final class SaveRegulationGeneralInfoControllerTest extends AbstractWebTestCase
 
         $crawler = $client->request('GET', '/regulations/' . RegulationOrderRecordFixture::UUID_PERMANENT);
         $this->assertSame('Modifié le 09/06/2023 à 01h00 par Mathieu MARCHOIS', $crawler->filter('[data-testid="history"]')->text());
+    }
+
+    public function testEditChangingTheCategoryRefreshesWhatDependsOnIt(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/_fragment/regulations/general_info/form/' . RegulationOrderRecordFixture::UUID_TYPICAL);
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $saveButton = $crawler->selectButton('Valider');
+        $form = $saveButton->form();
+
+        $values = $form->getPhpValues();
+        $values['general_info_form']['category'] = RegulationOrderCategoryEnum::PERMANENT_REGULATION->value;
+        $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $content = $client->getResponse()->getContent();
+        $this->assertStringContainsString('<turbo-stream action="update" target="regulation-detail">', $content);
+        $this->assertStringContainsString('Arrêté permanent', $content);
+        $this->assertStringContainsString('<turbo-stream action="replace" target="block_measure_' . MeasureFixture::UUID_TYPICAL . '">', $content);
+    }
+
+    public function testEditKeepingTheCategoryLeavesTheMeasuresAlone(): void
+    {
+        $client = $this->login();
+        $crawler = $client->request('GET', '/_fragment/regulations/general_info/form/' . RegulationOrderRecordFixture::UUID_TYPICAL);
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $saveButton = $crawler->selectButton('Valider');
+        $form = $saveButton->form();
+
+        $values = $form->getPhpValues();
+        $values['general_info_form']['title'] = 'Nouveau titre';
+        $client->request($form->getMethod(), $form->getUri(), $values, $form->getPhpFiles());
+
+        $this->assertResponseStatusCodeSame(200);
+
+        $content = $client->getResponse()->getContent();
+        $this->assertStringNotContainsString('target="regulation-detail"', $content);
+        $this->assertStringNotContainsString('target="block_measure_', $content);
     }
 
     public function testEditWithAnAlreadyExistingIdentifier(): void

--- a/tests/Unit/Application/Regulation/View/GeneralInfoViewTest.php
+++ b/tests/Unit/Application/Regulation/View/GeneralInfoViewTest.php
@@ -45,6 +45,7 @@ final class GeneralInfoViewTest extends TestCase
 
         $this->assertTrue($generalInfo->isDraft());
         $this->assertTrue($generalInfo->isSourceDialog());
+        $this->assertFalse($generalInfo->isPermanent());
 
         $generalInformation2 = new GeneralInfoView(
             uuid: '3d1c6ec7-28f5-4b6b-be71-b0920e85b4bf',
@@ -63,7 +64,7 @@ final class GeneralInfoViewTest extends TestCase
             source: RegulationOrderRecordSourceEnum::LITTERALIS,
             regulationOrderUuid: '8a32e881-a683-4caa-976f-6882296bc29b',
             regulationOrderTemplateUuid: '92fc487a-b795-4583-88e6-0b83d23910cc',
-            category: RegulationOrderCategoryEnum::TEMPORARY_REGULATION->value,
+            category: RegulationOrderCategoryEnum::PERMANENT_REGULATION->value,
             subject: RegulationSubjectEnum::OTHER->value,
             otherCategoryText: 'Other category 1',
             title: 'title 1',
@@ -73,5 +74,6 @@ final class GeneralInfoViewTest extends TestCase
 
         $this->assertFalse($generalInformation2->isDraft());
         $this->assertFalse($generalInformation2->isSourceDialog());
+        $this->assertTrue($generalInformation2->isPermanent());
     }
 }


### PR DESCRIPTION
Corrige #1980, reposé en #2092.

## Le défaut

`RegulationOrder::isPermanent()` dérive de la catégorie, qui se modifie depuis le formulaire d'informations générales. Après l'enregistrement, `SaveGeneralInfoController` ne renvoie que deux actions : `block_general_info` et `block_publication`.

Or deux autres endroits de la page sont construits à partir de ce type :

- le titre de la page, `detail.html.twig` ligne 3 ;
- les formulaires de mesure, `_measure_form.html.twig` ligne 6, qui passent `isPermanent` à `PeriodFormType` : ce dernier retire `endDate` et `endTime` quand l'arrêté est permanent.

Les deux gardent l'ancienne valeur jusqu'au rechargement. C'est la réponse que @eglantine a donnée dans #2092 : « Faut sans doute recharger la page une fois que tu as fait la modification ».

Mesuré sur `FO1/2023` (temporaire, brouillon, deux mesures), formulaire de mesure ouvert, en lisant le prototype de période dans le DOM :

| étape | titre affiché | prototype de période |
|---|---|---|
| 1. arrêté temporaire | Arrêté temporaire | `startDate` + `endDate`, `isPermanent=0` |
| 2. passage en permanent | **Arrêté temporaire** | **`startDate` + `endDate`, `isPermanent=0`** |
| 3. rechargement | Arrêté permanent | `startDate` seul, `isPermanent=1` |

À l'étape 2, une période ajoutée depuis ce formulaire propose donc une date de fin sur un arrêté permanent, et poste `isPermanent=0`. Dans l'autre sens, même symptôme en miroir.

## Le correctif

Quand la permanence a changé, le flux Turbo porte deux actions de plus :

- `update` sur `regulation-detail`, le titre visible, rendu par un nouveau `_detail_heading.html.twig` que `detail.html.twig` utilise aussi, pour que les deux ne divergent pas ;
- `replace` sur chaque `block_measure_<uuid>`, par un cadre qui porte son `src`, ce qui fait redemander la mesure au serveur.

Le second point ferme un formulaire de mesure en cours d'édition, comme le ferait le rechargement conseillé aujourd'hui. C'est ce qui garantit que les champs proposés correspondent au nouveau type, plutôt que de corriger le formulaire déjà rendu.

Quand la catégorie ne change pas, la réponse est exactement celle d'avant.

`GeneralInfoView` gagne `isPermanent()`, à côté de `isDraft()` et `isSourceDialog()`, pour éviter de comparer la catégorie à une chaîne dans un gabarit.

## Vérification

Le scénario rejoué au navigateur après correctif, sans aucun rechargement :

| étape | titre affiché | prototype de période |
|---|---|---|
| 1. arrêté temporaire, mesure ouverte | Arrêté temporaire | `startDate` + `endDate`, `isPermanent=0` |
| 2. passage en permanent | Arrêté permanent | le formulaire périmé a laissé place à la mesure |
| 3. mesure rouverte | Arrêté permanent | `startDate` seul, `isPermanent=1` |

Et l'inverse, permanent vers temporaire, donne le symétrique.

Tests ajoutés : un test d'intégration qui vérifie les deux actions supplémentaires quand la catégorie change, un autre qui vérifie qu'elles sont absentes sinon, et les deux branches de `isPermanent()` en unitaire. Le premier échoue avant le correctif.

`phpstan -l 5`, `php-cs-fixer --dry-run` et `lint:twig` sont propres.

Suite complète : 1588 tests. Les 61 échecs restants sont tous dans les classes qui interrogent la base BD TOPO, que le README indique de demander à l'équipe et dont je ne dispose pas. Vérifié en rejouant ces mêmes classes sur l'arbre sans le correctif : chiffres identiques des deux côtés.

## Un point laissé de côté

Le titre de l'onglet du navigateur reste sur l'ancien libellé jusqu'à la navigation suivante. Turbo 7 ne met à jour `document.title` que lors d'une visite, et le viser depuis un flux demanderait de poser un identifiant sur la balise `title` du gabarit commun. Les deux tickets portent sur le contenu de la page, donc je m'en suis tenu là ; dites-moi si vous le voulez aussi.
